### PR TITLE
Changes TypeScript config target to ES6

### DIFF
--- a/packages/generator-langium/tsconfig.json
+++ b/packages/generator-langium/tsconfig.json
@@ -2,8 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 	  "rootDir": "src",
-	  "outDir": "app",
-	  "target": "es6"
+	  "outDir": "app"
 	},
 	"include": [
 	  "src/**/*"

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -109,7 +109,7 @@ function buildIsSubtypeMethod(interfaces: Interface[]): GeneratorNode {
     const switchNode = new IndentNode();
     const groups = groupBySupertypes(interfaces.filter(e => e.superTypes.length > 0));
 
-    for (const [superTypes, typeGroup] of Array.from(groups.entries())) {
+    for (const [superTypes, typeGroup] of groups.entries()) {
         for (const typeItem of typeGroup) {
             switchNode.children.push(`case ${typeItem.name}:`, NL);
         }

--- a/packages/langium-cli/src/generator/grammar-access-generator.ts
+++ b/packages/langium-cli/src/generator/grammar-access-generator.ts
@@ -50,7 +50,7 @@ function generateBootstrapRuleAccess(rule: langium.ParserRule): GeneratorNode {
     node.children.push(': ', rule.name, 'RuleAccess = <', rule.name, 'RuleAccess><unknown>{', NL);
     const indent = new IndentNode();
     node.children.push(indent);
-    for (const [name, feature] of Array.from(byName.entries())) {
+    for (const [name, feature] of byName.entries()) {
         indent.children.push(name, ': ', generateFeature(feature.feature), NL);
     }
 
@@ -109,7 +109,7 @@ function generateRuleAccess(rule: langium.ParserRule): CompositeGeneratorNode {
     node.children.push('export type ', rule.name + 'RuleAccess = {', NL);
 
     const indent = new IndentNode();
-    for (const [name, {kind}] of Array.from(byName.entries())) {
+    for (const [name, {kind}] of byName.entries()) {
         indent.children.push(name, ': ', kind, ';', NL);
     }
 

--- a/packages/langium-cli/src/generator/type-collector.ts
+++ b/packages/langium-cli/src/generator/type-collector.ts
@@ -199,7 +199,7 @@ export class TypeCollector {
         const names = new Set<string>(alternatives.map(e => e.name));
         const types: TypeAlternative[] = [];
 
-        for (const name of Array.from(names)) {
+        for (const name of names) {
             const fields: Field[] = [];
             const ruleCalls = new Set<string>();
             const type = { name, fields, ruleCalls: <string[]>[], super: <string[]>[], hasAction: false };

--- a/packages/langium/src/grammar/grammar-access.ts
+++ b/packages/langium/src/grammar/grammar-access.ts
@@ -29,7 +29,7 @@ export abstract class GrammarAccess {
         const { byName } = findAllFeatures(rule);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const access: any = {};
-        for (const [name, value] of Array.from(byName.entries())) {
+        for (const [name, value] of byName.entries()) {
             access[name] = value.feature;
         }
         return <T>access;

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -47,11 +47,11 @@ export function findAllFeatures(rule: ast.ParserRule): { byName: Map<string, Fea
     const featureMap = new Map<ast.AbstractElement, string>();
     putFeature(rule.alternatives, undefined, map, featureMap);
     const newMap = new Map<string, FeatureValue>();
-    for (const [key, value] of Array.from(map.entries())) {
+    for (const [key, value] of map.entries()) {
         newMap.set(key.replace(/\^/g, ''), value);
     }
     const newFeatureMap = new Map<ast.AbstractElement, string>();
-    for (const [key, value] of Array.from(featureMap.entries())) {
+    for (const [key, value] of featureMap.entries()) {
         newFeatureMap.set(key, value.replace(/\^/g, ''));
     }
     return { byName: newMap, byFeature: newFeatureMap };

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -67,7 +67,7 @@ export class LangiumGrammarValidator {
                 ruleMap.set(lowerCaseName, [rule]);
             }
         }
-        for (const rules of Array.from(ruleMap.values())) {
+        for (const rules of ruleMap.values()) {
             if (rules.length > 1) {
                 rules.forEach(e => {
                     accept('error', message, { node: e, property: 'name' });

--- a/packages/langium/src/service/symbols/document-symbol-provider.ts
+++ b/packages/langium/src/service/symbols/document-symbol-provider.ts
@@ -56,7 +56,7 @@ export class DefaultDocumentSymbolProvider implements DocumentSymbolProvider {
     protected getChildSymbols(document: LangiumDocument, astNode: AstNode): DocumentSymbol[] {
         const children: DocumentSymbol[] = [];
 
-        for (const child of Array.from(streamContents(astNode))) {
+        for (const child of streamContents(astNode)) {
             const result = this.getSymbol(document, child.node);
             children.push(...result);
         }

--- a/packages/langium/test/dependency-injection.test.ts
+++ b/packages/langium/test/dependency-injection.test.ts
@@ -304,13 +304,13 @@ describe('The inject result', () => {
         expect(res).toEqual(['a', 'b']);
     });
 
-    test('should have no effect when used with for..of', () => {
+    test('should throw error when used with for..of', () => {
         const obj = inject([() => 1, () => 'a']);
-        const res = [];
-        for (const elem of obj) {
-            res.push(elem);
-        }
-        expect(res).toEqual([]);
+        expect(() => {
+            for (const _ of obj) {
+                // We expect an error here
+            }
+        }).toThrowError();
     });
 
     test('should work with ..in.. for array', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["ESNext"],                        /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Closes #40 
Closes #74 

Changes the target version to ES6. Also removed some unnecessary calls to `Array.from` that were needed for `for-of` loops. Everything seems to be working fine (bootstrapping, vscode-extension). I had to fix a test that wasn't valid anymore, since `for-of` loops over objects throw an error in ES6.