### PR TITLE
Replace `--prefix` instruction with `cwd`

### DIFF
--- a/packages/generator-langium/src/index.ts
+++ b/packages/generator-langium/src/index.ts
@@ -1,5 +1,5 @@
 import Generator from 'yeoman-generator';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import * as path from 'path';
 
 const TEMPLATE_DIR = '../langium-template';
@@ -141,9 +141,10 @@ class LangiumGenerator extends Generator {
             this.answers.extensionName
         );
 
-        this.spawnCommandSync('npm', ['install', '--prefix', extensionPath]);
-        this.spawnCommandSync('npm', ['run', '--prefix', extensionPath, 'langium:generate']);
-        this.spawnCommandSync('npm', ['run', '--prefix', extensionPath, 'build']);
+        const opts = { cwd: extensionPath };
+        this.spawnCommandSync('npm', ['install'], opts);
+        this.spawnCommandSync('npm', ['run', 'langium:generate'], opts);
+        this.spawnCommandSync('npm', ['run', 'build'], opts);
     }
 }
 


### PR DESCRIPTION
Closes #92 

The `--prefix` argument of `npm` does not work on Windows currently. This seems to be a [known issue](https://github.com/npm/cli/issues/1290).

This change removes the `--prefix` argument and instead starts the yeoman generator with the specified working directory.

It now works on Windows and Ubuntu (Gitpod). Can you check whether it still works on MacOS?