### PR TITLE
Generate `never` as AST reference type for missing cross references

### DIFF
--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -71,7 +71,7 @@ function generateAstReflection(grammar: Grammar, interfaces: Interface[]): Gener
     );
     reflectionNode.children.push(
         'export type ', grammar.name, 'AstReference = ',
-        crossReferenceTypes.map(e => `'${e.type}:${e.feature}'`).join(' | '),
+        crossReferenceTypes.map(e => `'${e.type}:${e.feature}'`).join(' | ') || 'never',
         ';', NL, NL
     );
     reflectionNode.children.push('export class ', grammar.name, 'AstReflection implements AstReflection {', NL, NL);


### PR DESCRIPTION
Closes #130 

Assuming the user grammar contains no cross references, the problem in the mentioned issue occurs. This change instead adds `never` as the type alias for `AstReference`, keeping it in line with the generated `getReferenceType` method that always throws without any cross references.