### PR TITLE
Fix missing quote for generated types of datatype rules

### DIFF
--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -10,7 +10,7 @@ import { AstNode, AstReflection, Reference, isAstNode } from 'langium';
 export interface AbstractElement extends AstNode {
     readonly $container: Domainmodel | AbstractElement;
     elements: Array<AbstractElement>
-    name: string
+    name: QualifiedName
 }
 
 export const AbstractElement = 'AbstractElement';

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -41,7 +41,7 @@ export function generateAst(grammar: Grammar, config: LangiumConfig): string {
 
 function buildDatatype(rule: ParserRule): GeneratorNode {
     if (isAlternatives(rule.alternatives) && rule.alternatives.elements.every(e => isKeyword(e))) {
-        return `export type ${rule.name} = ${stream(rule.alternatives.elements).filterType(isKeyword).map(e => e.value).join(' | ')}`;
+        return `export type ${rule.name} = ${stream(rule.alternatives.elements).filterType(isKeyword).map(e => `'${e.value}'`).join(' | ')}`;
     } else {
         return `export type ${rule.name} = ${rule.type ?? 'string'}`;
     }

--- a/packages/langium-cli/src/generator/type-collector.ts
+++ b/packages/langium-cli/src/generator/type-collector.ts
@@ -6,7 +6,7 @@
 
 import _ from 'lodash';
 import * as langium from 'langium';
-import { getRuleType, getTypeName, isDataTypeRule } from 'langium';
+import { getRuleType, getTypeName, isDataTypeRule, isParserRule } from 'langium';
 import { CompositeGeneratorNode, IndentNode, NL } from 'langium';
 import { processGeneratorNode } from 'langium';
 import { Cardinality, isOptional } from 'langium';
@@ -245,7 +245,11 @@ function findTypes(terminal: langium.AbstractElement, types: TypeCollection): vo
     } else if (langium.isKeyword(terminal)) {
         types.types.push(`'${terminal.value}'`);
     } else if (langium.isRuleCall(terminal)) {
-        types.types.push(getRuleType(terminal.rule.ref));
+        if (isParserRule(terminal.rule.ref) && isDataTypeRule(terminal.rule.ref)) {
+            types.types.push(terminal.rule.ref.name);
+        } else {
+            types.types.push(getRuleType(terminal.rule.ref));
+        }
     } else if (langium.isCrossReference(terminal)) {
         types.types.push(getRuleType(terminal.type.ref));
         types.reference = true;


### PR DESCRIPTION
Closes #165

Also, types generated from data type rules are now actually used as property types.