### PR TITLE
Language specific unit tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '15'
+        node-version: '16'
     - name: Build
       shell: bash
       run: |
         npm install
-        npm test --workspace=langium --workspace=langium-cli
-        npm run lint --workspaces
+        npm test
+        npm run lint

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -88,6 +88,35 @@
 				"--extensionDevelopmentPath=${workspaceFolder}/packages/langium-vscode",
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
 			]
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Jest Langium: Run All",
+			"program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+			"args": [
+				"--config=${workspaceFolder}/packages/langium/jest.config.json",
+				"--verbose",
+				"-i",
+				"--no-cache",
+			],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Jest Langium: Run Selected File",
+			"program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+			"args": [
+				"${fileBasename}",
+				"--config=${workspaceFolder}/packages/langium/jest.config.json",
+				"--verbose",
+				"-i",
+				"--no-cache",
+			],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
 		}
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9724,7 +9724,7 @@
         "eslint": "^7.20.0",
         "eslint-plugin-header": "^3.1.1",
         "jest": "^26.6.3",
-        "langium-cli": "^0.1.0",
+        "langium-cli": "0.1.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
         "typescript": "^4.2.2"
@@ -14439,7 +14439,7 @@
         "eslint": "^7.20.0",
         "eslint-plugin-header": "^3.1.1",
         "jest": "^26.6.3",
-        "langium-cli": "^0.1.0",
+        "langium-cli": "0.1.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
         "typescript": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "tsc -b tsconfig.build.json",
     "watch": "tsc -b tsconfig.build.json -w",
     "lint": "npm run lint --workspaces",
+    "test": "npm run test --workspace=langium",
     "langium:generate": "npm run langium:generate --workspace=langium --workspace=domainmodel --workspace=arithmetics --workspace=statemachine",
     "prepare": "npm run clean && npm run build"
   },

--- a/packages/langium-cli/schema.json
+++ b/packages/langium-cli/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
+    "$defs": {
         "config": {
             "type": "object",
             "description": "A langium cli configuration",
@@ -54,13 +54,13 @@
     },
     "anyOf": [
         {
-            "$ref": "#/definitions/config"
+            "$ref": "#/$defs/config"
         },
         {
             "type": "array",
             "description": "An array of langium configurations.",
             "items": {
-                "$ref": "#/definitions/config"
+                "$ref": "#/$defs/config"
             }
         }
     ]

--- a/packages/langium/jest.config.json
+++ b/packages/langium/jest.config.json
@@ -1,0 +1,8 @@
+{
+    "preset": "ts-jest",
+    "roots": [
+        "<rootDir>/test"
+    ],
+    "collectCoverageFrom": ["src/**/{!(generated),}/*"],
+    "testEnvironment": "node"
+}

--- a/packages/langium/src/lsp/document-symbol-provider.ts
+++ b/packages/langium/src/lsp/document-symbol-provider.ts
@@ -50,18 +50,21 @@ export class DefaultDocumentSymbolProvider implements DocumentSymbolProvider {
                 children: this.getChildSymbols(document, astNode)
             }];
         } else {
-            return this.getChildSymbols(document, astNode);
+            return this.getChildSymbols(document, astNode) || [];
         }
     }
 
-    protected getChildSymbols(document: LangiumDocument, astNode: AstNode): DocumentSymbol[] {
+    protected getChildSymbols(document: LangiumDocument, astNode: AstNode): DocumentSymbol[] | undefined {
         const children: DocumentSymbol[] = [];
 
         for (const child of streamContents(astNode)) {
             const result = this.getSymbol(document, child.node);
             children.push(...result);
         }
-        return children;
+        if (children.length > 0) {
+            return children;
+        }
+        return undefined;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/langium/src/test/index.ts
+++ b/packages/langium/src/test/index.ts
@@ -1,0 +1,7 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+export * from './langium-test';

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -1,0 +1,158 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { CompletionItem, DocumentSymbol, Range } from 'vscode-languageserver';
+import { LangiumDocument, LangiumDocumentConfiguration } from '../documents/document';
+import { BuildResult } from '../documents/document-builder';
+import { LangiumServices } from '../services';
+import { getDocument } from '../utils/ast-util';
+
+export function parseHelper(services: LangiumServices): (input: string) => BuildResult {
+    const metaData = services.LanguageMetaData;
+    const documentBuilder = services.documents.DocumentBuilder;
+    return input => {
+        const randomNumber = Math.floor(Math.random() * 10000000) + 1000000;
+        const document = LangiumDocumentConfiguration.create(`file:/${randomNumber}${metaData.fileExtensions[0]}`, metaData.languageId, 0, input);
+        const buildResult = documentBuilder.build(document);
+        return buildResult;
+    };
+}
+
+export type ExpectFunction = (actual: unknown, expected: unknown) => void;
+
+interface ExpectedBase {
+    text: string
+    indexMarker?: string
+    rangeStartMarker?: string
+    rangeEndMarker?: string
+}
+
+export interface ExpectedSymbols extends ExpectedBase {
+    expectedSymbols: DocumentSymbol[]
+}
+
+export function expectSymbols(services: LangiumServices, cb: ExpectFunction): (input: ExpectedSymbols) => void {
+    return (input) => {
+        const document = parseDocument(services, input.text);
+        if (!document.parseResult) {
+            throw new Error('Could not parse document');
+        }
+        const symbolProvider = services.lsp.DocumentSymbolProvider;
+        const symbols = symbolProvider.getSymbols(document);
+        cb(symbols.length, input.expectedSymbols.length);
+        for (let i = 0; i < input.expectedSymbols.length; i++) {
+            const expected = input.expectedSymbols[i];
+            const item = symbols[i];
+            if (typeof expected === 'string') {
+                cb(item.name, expected);
+            } else {
+                cb(item, expected);
+            }
+        }
+    };
+}
+
+export interface ExpectedCompletion extends ExpectedBase {
+    index: number
+    expectedItems: Array<string | CompletionItem>
+}
+
+export function expectCompletion(services: LangiumServices, cb: ExpectFunction): (completion: ExpectedCompletion) => void {
+    return (expectedCompletion) => {
+        const { output, indices } = replaceIndices(expectedCompletion);
+        const document = parseDocument(services, output);
+        if (!document.parseResult) {
+            throw new Error('Could not parse document');
+        }
+        const completionProvider = services.lsp.completion.CompletionProvider;
+        const completions = completionProvider.getCompletion(document.parseResult.value, indices[expectedCompletion.index]);
+        const items = completions.items.sort((a, b) => a.sortText?.localeCompare(b.sortText || '0') || 0);
+        cb(items.length, expectedCompletion.expectedItems.length);
+        for (let i = 0; i < expectedCompletion.expectedItems.length; i++) {
+            const expected = expectedCompletion.expectedItems[i];
+            const completion = items[i];
+            if (typeof expected === 'string') {
+                cb(completion.label, expected);
+            } else {
+                cb(completion, expected);
+            }
+        }
+    };
+}
+
+export interface ExpectedGoToDefinition extends ExpectedBase {
+    index: number,
+    rangeIndex: number
+}
+
+export function expectGoToDefinition(services: LangiumServices, cb: ExpectFunction): (expectedGoToDefinition: ExpectedGoToDefinition) => void {
+    return (expectedGoToDefinition) => {
+        const { output, indices, ranges } = replaceIndices(expectedGoToDefinition);
+        const document = parseDocument(services, output);
+        const goToResolver = services.lsp.GoToResolver;
+        const position = document.positionAt(indices[expectedGoToDefinition.index]);
+        const textPos = {
+            textDocument: {
+                uri: document.uri
+            },
+            position: position
+        };
+        const locationLink = goToResolver.goToDefinition(document, textPos);
+        const expectedRange: Range = {
+            start: document.positionAt(ranges[expectedGoToDefinition.rangeIndex][0]),
+            end: document.positionAt(ranges[expectedGoToDefinition.rangeIndex][1])
+        };
+        cb(locationLink.length, 1);
+        cb(locationLink[0].targetSelectionRange, expectedRange);
+    };
+}
+
+function parseDocument(services: LangiumServices, input: string): LangiumDocument {
+    const buildResult = parseHelper(services)(input);
+    return getDocument(buildResult.parseResult.value);
+}
+
+function replaceIndices(base: ExpectedBase): { output: string, indices: number[], ranges: Array<[number, number]> } {
+    const indices: number[] = [];
+    const ranges: Array<[number, number]> = [];
+    const rangeStack: number[] = [];
+    const indexMarker = base.indexMarker || '<|>';
+    const rangeStartMarker = base.rangeStartMarker || '<|';
+    const rangeEndMarker = base.rangeEndMarker || '|>';
+    const regex =  new RegExp(`${escapeRegExp(indexMarker)}|${escapeRegExp(rangeStartMarker)}|${escapeRegExp(rangeEndMarker)}`);
+
+    let matched = true;
+    let input = base.text;
+
+    while (matched) {
+        const regexMatch = regex.exec(input);
+        if (regexMatch) {
+            const matchedString = regexMatch[0];
+            switch (matchedString) {
+                case indexMarker:
+                    indices.push(regexMatch.index);
+                    break;
+                case rangeStartMarker:
+                    rangeStack.push(regexMatch.index);
+                    break;
+                case rangeEndMarker: {
+                    const rangeStart = rangeStack.pop() || 0;
+                    ranges.push([rangeStart, regexMatch.index]);
+                    break;
+                }
+            }
+            input = input.substring(0, regexMatch.index) + input.substring(regexMatch.index + matchedString.length);
+        } else {
+            matched = false;
+        }
+    }
+
+    return {output: input, indices, ranges: ranges.sort((a, b) => a[0] - b[0]) };
+}
+
+function escapeRegExp(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -147,7 +147,7 @@ export function findLeafNodeAtOffset(node: CstNode, offset: number): LeafCstNode
     if (node instanceof LeafCstNodeImpl) {
         return node;
     } else if (node instanceof CompositeCstNodeImpl) {
-        const children = node.children.filter(e => e.offset < offset).reverse();
+        const children = node.children.filter(e => e.offset <= offset).reverse();
         for (const child of children) {
             const result = findLeafNodeAtOffset(child, offset);
             if (result) {

--- a/packages/langium/test/fixture.ts
+++ b/packages/langium/test/fixture.ts
@@ -4,11 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-module.exports = {
-    preset: 'ts-jest',
-    roots: [
-        '<rootDir>/test'
-    ],
-    collectCoverageFrom: ['src/**/*'],
-    testEnvironment: 'node'
-}
+import { ExpectFunction } from '../src/test';
+
+/**
+ * Expectation function for jest. Accepts any primitive/objects and does a deep recursive comparison.
+ * @param a Actual element
+ * @param e Expected element
+ */
+export const expectFunction: ExpectFunction = (a, e) => expect(a).toEqual(e);

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -4,7 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { createLangiumGrammarServices, getEntryRule, replaceTokens } from '../../lib';
+import { getEntryRule, replaceTokens } from '../../lib';
+import { grammar } from '../../src/grammar/generated/grammar';
 
 describe('Token replacement', () => {
 
@@ -33,6 +34,5 @@ describe('Token replacement', () => {
 });
 
 test('Langium grammar entry rule', () => {
-    const grammar = createLangiumGrammarServices().Grammar;
-    expect(getEntryRule(grammar)?.name).toBe('Grammar');
+    expect(getEntryRule(grammar())?.name).toBe('Grammar');
 });

--- a/packages/langium/test/lsp/document-symbol.test.ts
+++ b/packages/langium/test/lsp/document-symbol.test.ts
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { Position, Range, SymbolKind } from 'vscode-languageserver';
+import { createLangiumGrammarServices } from '../../src';
+import { expectSymbols } from '../../src/test';
+import { expectFunction } from '../fixture';
+
+const text = `
+ grammar g hidden(hiddenTerminal)
+ X: name="X";
+ terminal hiddenTerminal: /x/;
+ `;
+
+const symbols = expectSymbols(createLangiumGrammarServices(), expectFunction);
+
+describe('Document symbols', () => {
+
+    test('Should show all document symbols', () => {
+        symbols({
+            text,
+            expectedSymbols: [
+                {
+                    name: 'g',
+                    kind: SymbolKind.Field,
+                    range: Range.create(Position.create(0, 0), Position.create(4, 1)),
+                    selectionRange: Range.create(Position.create(1, 9), Position.create(1, 10)),
+                    children: [
+                        {
+                            name: 'X',
+                            kind: SymbolKind.Field,
+                            range: Range.create(Position.create(2, 1), Position.create(2, 13)),
+                            selectionRange: Range.create(Position.create(2, 1), Position.create(2, 2))
+                        },
+                        {
+                            name: 'hiddenTerminal',
+                            kind: SymbolKind.Field,
+                            range: Range.create(Position.create(3, 1), Position.create(3, 30)),
+                            selectionRange: Range.create(Position.create(3, 10), Position.create(3, 24))
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+});

--- a/packages/langium/test/lsp/go-to/goto-definition.test.ts
+++ b/packages/langium/test/lsp/go-to/goto-definition.test.ts
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createLangiumGrammarServices } from '../../../src';
+import { expectGoToDefinition } from '../../../src/test';
+import { expectFunction } from '../../fixture';
+
+const text = `
+grammar test hidden(WS, <|>COMMENT)
+
+terminal ID: /\\w+/;
+terminal WS: /\\s+/;
+terminal <|COMMENT|>: /\\/\\/.*/;
+
+Model: value=<|>Ent<|>ity;
+
+<|Ent<|>ity|>: name=ID;
+`.trim();
+
+const gotoDefinition = expectGoToDefinition(createLangiumGrammarServices(), expectFunction);
+
+describe('GoToResolver', () => {
+
+    test('Must find SL_COMMENT inside of array of cross references', () => {
+        gotoDefinition({
+            text,
+            index: 0,
+            rangeIndex: 0
+        });
+    });
+
+    test('Entity must find itself when referenced from start of other location', () => {
+        gotoDefinition({
+            text,
+            index: 1,
+            rangeIndex: 1
+        });
+    });
+
+    test('Entity must find itself when referenced from within other location', () => {
+        gotoDefinition({
+            text,
+            index: 2,
+            rangeIndex: 1
+        });
+    });
+
+    test('Entity must find itself when referenced from source location', () => {
+        gotoDefinition({
+            text,
+            index: 3,
+            rangeIndex: 1
+        });
+    });
+});


### PR DESCRIPTION
Allow to run language specific unit test with jest.
Adds debugging support to jest test in VSCode.
Builds upon langium-config support.