### PR TITLE
Delete target folder before generation

### DIFF
--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -56,7 +56,12 @@ export function generate(config: LangiumConfig): boolean {
 
     const output = path.join(relPath, config.out ?? 'src/generated');
     console.log(`${getTime()}Writing generated files to ${output.white.bold}`);
-    mkdirWithFail(output);
+    if (rmdirWithFail(output)) {
+        return false;
+    }
+    if (mkdirWithFail(output)) {
+        return false;
+    }
 
     const genAst = generateAst(grammar, config);
     writeWithFail(path.join(output, 'ast.ts'), genAst);
@@ -78,11 +83,23 @@ export function generate(config: LangiumConfig): boolean {
     return true;
 }
 
-function mkdirWithFail(path: string): void {
+function rmdirWithFail(path: string): boolean {
+    try {
+        fs.removeSync(path);
+        return false;
+    } catch (e) {
+        console.error(`${getTime()}Failed to delete directory ${path.red.bold}`, e);
+        return true;
+    }
+}
+
+function mkdirWithFail(path: string): boolean {
     try {
         fs.mkdirsSync(path);
+        return false;
     } catch (e) {
         console.error(`${getTime()}Failed to create directory ${path.red.bold}`, e);
+        return true;
     }
 }
 

--- a/packages/langium-cli/src/generator/util.ts
+++ b/packages/langium-cli/src/generator/util.ts
@@ -8,6 +8,7 @@ import * as langium from 'langium';
 import { CompositeGeneratorNode, GeneratorNode, NL, stream } from 'langium';
 import fs from 'fs-extra';
 import path from 'path';
+import * as readline from 'readline';
 
 let start = process.hrtime();
 
@@ -63,6 +64,31 @@ function collectElementKeywords(element: langium.AbstractElement, keywords: Set<
     } else if (langium.isKeyword(element)) {
         keywords.add(element.value);
     }
+}
+
+export function getUserInput(text: string): Promise<string> {
+    return new Promise(resolve => {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        rl.question(text, answer => {
+            resolve(answer);
+            rl.close();
+        });
+    });
+}
+
+export async function getUserChoice<R extends string>(text: string, values: R[], defaultValue: R, lowerCase = true): Promise<R> {
+    const prompt = text + ' ' + values.map(v => v === defaultValue ? `[${v}]` : v).join('/') + ': ';
+    const answer = await getUserInput(prompt);
+    if (!answer) {
+        return defaultValue;
+    }
+    const lcAnswer = lowerCase ? answer.toLowerCase() : answer;
+    for (const value of values) {
+        if (value.startsWith(lcAnswer)) {
+            return value;
+        }
+    }
+    return defaultValue;
 }
 
 export const cliVersion = getLangiumCliVersion();


### PR DESCRIPTION
Closes #167

Simply deletes the `output` folder before generation, therefore removing any old files.