### PR TITLE
Add hover lsp service

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -19,6 +19,7 @@ import { DefaultDocumentHighlighter } from './lsp/document-highlighter';
 import { DefaultDocumentSymbolProvider } from './lsp/document-symbol-provider';
 import { DefaultFoldingRangeProvider } from './lsp/folding-range-provider';
 import { DefaultGoToResolverProvider } from './lsp/goto';
+import { MultilineCommentHoverProvider } from './lsp/hover-provider';
 import { DefaultReferenceFinder } from './lsp/reference-finder';
 import { DefaultRenameHandler } from './lsp/rename-refactoring';
 import { createLangiumParser } from './parser/langium-parser-builder';
@@ -59,6 +60,7 @@ export function createDefaultModule(context: DefaultModuleContext = {}): Module<
             },
             Connection: () => context.connection,
             DocumentSymbolProvider: (injector) => new DefaultDocumentSymbolProvider(injector),
+            HoverProvider: (injector) => new MultilineCommentHoverProvider(injector),
             FoldingRangeProvider: (injector) => new DefaultFoldingRangeProvider(injector),
             ReferenceFinder: (injector) => new DefaultReferenceFinder(injector),
             GoToResolver: (injector) => new DefaultGoToResolverProvider(injector),

--- a/packages/langium/src/lsp/hover-provider.ts
+++ b/packages/langium/src/lsp/hover-provider.ts
@@ -1,0 +1,88 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { Hover, HoverParams } from 'vscode-languageserver';
+import { LangiumDocument } from '../documents/document';
+import { GrammarConfig } from '../grammar/grammar-config';
+import { References } from '../references/references';
+import { LangiumServices } from '../services';
+import { AstNode } from '../syntax-tree';
+import { findLeafNodeAtOffset } from '../utils/ast-util';
+import { findCommentNode } from '../utils/cst-util';
+
+export interface HoverProvider {
+    getHoverContent(document: LangiumDocument, params: HoverParams): Hover | undefined;
+}
+
+export abstract class AstNodeHoverProvider implements HoverProvider {
+
+    protected readonly references: References;
+
+    constructor(services: LangiumServices) {
+        this.references = services.references.References;
+    }
+
+    getHoverContent(document: LangiumDocument, params: HoverParams): Hover | undefined {
+        const rootNode = document.parseResult?.value?.$cstNode;
+        if (rootNode) {
+            const offset = document.textDocument.offsetAt(params.position);
+            const cstNode = findLeafNodeAtOffset(rootNode, offset);
+            if (cstNode && cstNode.offset + cstNode.length > offset) {
+                const targetNode = this.references.findDeclaration(cstNode);
+                if (targetNode) {
+                    return this.getAstNodeHoverContent(targetNode.element);
+                }
+            }
+        }
+        return;
+    }
+
+    abstract getAstNodeHoverContent(node: AstNode): Hover | undefined;
+
+}
+
+export class MultilineCommentHoverProvider extends AstNodeHoverProvider {
+
+    protected readonly commentContentRegex = /\/\*([\s\S]*?)\*\//;
+    protected readonly grammarConfig: GrammarConfig;
+
+    constructor(services: LangiumServices) {
+        super(services);
+        this.grammarConfig = services.parser.GrammarConfig;
+    }
+
+    getAstNodeHoverContent(node: AstNode): Hover | undefined {
+        const lastNode = findCommentNode(node.$cstNode, this.grammarConfig.multilineCommentRules);
+        let content: string | undefined;
+        if (lastNode) {
+            const exec = this.commentContentRegex.exec(lastNode.text);
+            if (exec && exec[1]) {
+                content = this.getCommentContent(exec[1]);
+            }
+        }
+        if (content) {
+            return {
+                contents: {
+                    kind: 'markdown',
+                    value: content
+                }
+            };
+        }
+        return undefined;
+    }
+
+    getCommentContent(commentText: string): string {
+        const split = commentText.split('\n').map(e => {
+            e = e.trim();
+            if (e.startsWith('*')) {
+                e = e.substring(1).trim();
+            }
+            return e;
+        });
+        return split.join(' ').trim();
+    }
+
+}

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -37,8 +37,7 @@ export function startLanguageServer(services: LangiumServices): void {
                 documentHighlightProvider: {},
                 codeActionProvider: services.lsp.CodeActionProvider ? {} : undefined,
                 foldingRangeProvider: {},
-                // hoverProvider needs to be created for mouse-over events, etc.
-                hoverProvider: false,
+                hoverProvider: {},
                 renameProvider: {
                     prepareProvider: true
                 }
@@ -78,6 +77,7 @@ export function startLanguageServer(services: LangiumServices): void {
     addFoldingRangeHandler(connection, services);
     addCodeActionHandler(connection, services);
     addRenameHandler(connection, services);
+    addHoverHandler(connection, services);
 
     // Make the text document manager listen on the connection for open, change and close text document events.
     documents.listen(connection);
@@ -165,6 +165,14 @@ export function addDocumentHighlightsHandler(connection: Connection, services: L
         } else {
             return [];
         }
+    });
+}
+
+export function addHoverHandler(connection: Connection, services: LangiumServices): void {
+    const hoverProvider = services.lsp.HoverProvider;
+    connection.onHover(params => {
+        const document = paramsDocument(params, services);
+        return document && hoverProvider.getHoverContent(document, params);
     });
 }
 

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -97,8 +97,8 @@ export class LangiumParser {
         } else {
             for (let i = 0; i < node.children.length; i++) {
                 const child = node.children[i];
-                const { start: childStart, end: childEnd } = child.range;
-                if (child instanceof CompositeCstNodeImpl && tokenStart > childStart && tokenEnd < childEnd) {
+                const { end: childEnd } = child.range;
+                if (child instanceof CompositeCstNodeImpl && tokenEnd < childEnd) {
                     this.addHiddenToken(child, token);
                     return;
                 } else if (tokenEnd <= child.offset) {

--- a/packages/langium/src/references/references.ts
+++ b/packages/langium/src/references/references.ts
@@ -65,8 +65,10 @@ export class DefaultReferences implements References {
                 }
                 else {
                     const nameNode = this.nameProvider.getNameNode(nodeElem);
-                    if (nameNode === sourceCstNode) {
-                        return sourceCstNode;
+                    if (nameNode === sourceCstNode
+                        || nameNode && nameNode.offset <= sourceCstNode.offset
+                        && nameNode.offset + nameNode.length > sourceCstNode.offset) {
+                        return nameNode;
                     }
                 }
             }

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -17,6 +17,7 @@ import { GoToResolver } from './lsp/goto';
 import { ReferenceFinder } from './lsp/reference-finder';
 import { RenameHandler } from './lsp/rename-refactoring';
 import { TokenBuilder } from './parser/token-builder';
+import { HoverProvider } from './lsp/hover-provider';
 import { FoldingRangeProvider } from './lsp/folding-range-provider';
 import { GrammarConfig } from './grammar/grammar-config';
 import { References } from './references/references';
@@ -39,6 +40,7 @@ export type LangiumLspServices = {
     Connection?: Connection
     DocumentHighlighter: DocumentHighlighter
     DocumentSymbolProvider: DocumentSymbolProvider
+    HoverProvider: HoverProvider
     FoldingRangeProvider: FoldingRangeProvider
     GoToResolver: GoToResolver
     ReferenceFinder: ReferenceFinder

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -44,6 +44,7 @@ export interface CstNode {
     readonly root: CompositeCstNode;
     readonly feature: AbstractElement;
     readonly element: AstNode;
+    readonly hidden: boolean;
 }
 
 export interface CompositeCstNode extends CstNode {
@@ -51,6 +52,5 @@ export interface CompositeCstNode extends CstNode {
 }
 
 export interface LeafCstNode extends CstNode {
-    readonly hidden: boolean;
     readonly tokenType: TokenType;
 }

--- a/packages/langium/src/utils/cst-util.ts
+++ b/packages/langium/src/utils/cst-util.ts
@@ -51,3 +51,18 @@ export function findRelevantNode(cstNode: CstNode): AstNode | undefined {
     } while (n);
     return undefined;
 }
+
+export function findCommentNode(cstNode: CstNode | undefined, commentNames: string[]): CstNode | undefined {
+    let lastNode: CstNode | undefined;
+    if (cstNode instanceof CompositeCstNodeImpl) {
+        for (const node of cstNode.children) {
+            if (!node.hidden) {
+                break;
+            }
+            if (node instanceof LeafCstNodeImpl && commentNames.includes(node.tokenType.name)) {
+                lastNode = node;
+            }
+        }
+    }
+    return lastNode;
+}

--- a/packages/langium/test/lsp/hover.test.ts
+++ b/packages/langium/test/lsp/hover.test.ts
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createLangiumGrammarServices } from '../../src';
+import { expectHover } from '../../src/test';
+import { expectFunction } from '../fixture';
+
+const text = `
+  grammar g
+  /**
+   * Hi I am Rule 'X'
+   */
+  <|>X: name="X";
+  Y: value=<|>X;
+  `;
+
+const hover = expectHover(createLangiumGrammarServices(), expectFunction);
+
+describe('Hover', () => {
+
+    test('Hovering over X definition shows the comment hovering', () => {
+        hover({
+            text,
+            index: 0,
+            hover: "Hi I am Rule 'X'"
+        });
+    });
+
+    test('Hovering over X reference shows the comment hovering', () => {
+        hover({
+            text,
+            index: 1,
+            hover: "Hi I am Rule 'X'"
+        });
+    });
+});


### PR DESCRIPTION
Also improves some parser behavior regarding cst nodes of datatype rules and fragments, as well as hidden nodes.