### PR TITLE
Fixed unassigned call of a datatype rule

### DIFF
--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -8,7 +8,7 @@ import { TokenType } from 'chevrotain';
 import { AbstractElement, Action, Alternatives, CrossReference, Grammar, Group, isAction, isAlternatives, isAssignment, isCrossReference, isGroup, isKeyword, isParserRule, isRuleCall, isTerminalRule, isUnorderedGroup, Keyword, ParserRule, RuleCall, UnorderedGroup } from '../grammar/generated/ast';
 import { Cardinality, getTypeName, isArrayOperator, isDataTypeRule } from '../grammar/grammar-util';
 import { LangiumServices } from '../services';
-import { getContainerOfType, streamAllContents } from '../utils/ast-util';
+import { hasContainerOfType, streamAllContents } from '../utils/ast-util';
 import { stream } from '../utils/stream';
 import { DatatypeSymbol, LangiumParser } from './langium-parser';
 
@@ -132,7 +132,7 @@ function buildRuleCall(ctx: RuleContext, ruleCall: RuleCall): Method {
     const rule = ruleCall.rule.ref;
     if (isParserRule(rule)) {
         const idx = ctx.subrule++;
-        if (getContainerOfType(ruleCall, isAssignment)) {
+        if (hasContainerOfType(ruleCall, isAssignment) || isDataTypeRule(rule)) {
             return () => ctx.parser.subrule(idx, getRule(ctx, rule.name), ruleCall);
         } else {
             return () => ctx.parser.unassignedSubrule(idx, getRule(ctx, rule.name), ruleCall);

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -24,13 +24,23 @@ export function isReference(obj: unknown): obj is Reference {
 export function getContainerOfType<T extends AstNode>(node: AstNode | undefined, typePredicate: (n: AstNode) => n is T): T | undefined {
     let item = node;
     while (item) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (typePredicate(item)) {
             return item;
         }
         item = item.$container;
     }
     return undefined;
+}
+
+export function hasContainerOfType(node: AstNode | undefined, predicate: (n: AstNode) => boolean): boolean {
+    let item = node;
+    while (item) {
+        if (predicate(item)) {
+            return true;
+        }
+        item = item.$container;
+    }
+    return false;
 }
 
 export function getDocument(node: AstNode): LangiumDocument {


### PR DESCRIPTION
This fixes the case when a datatype rule has an unassigned call of another datatype rule. In that case the result is a primitive data type, so we cannot transfer properties like we do for other unassigned rule calls.