### PR TITLE
Specify minimum node version in engines field

### DIFF
--- a/examples/arithmetics/package.json
+++ b/examples/arithmetics/package.json
@@ -58,7 +58,7 @@
         "vscode-languageserver": "^7.0.0"
     },
     "devDependencies": {
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",

--- a/examples/domainmodel/package.json
+++ b/examples/domainmodel/package.json
@@ -61,7 +61,7 @@
         "vscode-languageserver": "^7.0.0"
     },
     "devDependencies": {
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",

--- a/examples/statemachine/package.json
+++ b/examples/statemachine/package.json
@@ -48,7 +48,7 @@
         "vscode-languageserver": "^7.0.0"
     },
     "devDependencies": {
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "jest": "^26.6.3",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2"
+      },
+      "engines": {
+        "npm": "^7.7.0"
       }
     },
     "examples/arithmetics": {
@@ -31,7 +34,7 @@
         "cli": "bin/cli.js"
       },
       "devDependencies": {
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -45,9 +48,9 @@
       }
     },
     "examples/arithmetics/node_modules/@types/node": {
-      "version": "14.17.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-      "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+      "version": "12.20.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
       "dev": true
     },
     "examples/arithmetics/node_modules/commander": {
@@ -108,8 +111,8 @@
         "domainmodel-cli": "bin/cli"
       },
       "devDependencies": {
-        "@types/jest": "^26.0.20",
-        "@types/node": "^14.17.3",
+      	"@types/jest": "^26.0.20",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -124,9 +127,9 @@
       }
     },
     "examples/domainmodel/node_modules/@types/node": {
-      "version": "14.17.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-      "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+      "version": "12.20.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
       "dev": true
     },
     "examples/domainmodel/node_modules/commander": {
@@ -145,7 +148,7 @@
         "vscode-languageserver": "^7.0.0"
       },
       "devDependencies": {
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -159,9 +162,9 @@
       }
     },
     "examples/statemachine/node_modules/@types/node": {
-      "version": "14.17.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
-      "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==",
+      "version": "12.20.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
       "dev": true
     },
     "node_modules/@babel/code-frame": {
@@ -6650,9 +6653,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9749,7 +9752,7 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.14.170",
-        "@types/node": "^14.14.31",
+        "@types/node": "^12.12.6",
         "@types/yeoman-generator": "^5.0.0",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
@@ -9757,12 +9760,15 @@
         "eslint-plugin-header": "^3.1.1",
         "rimraf": "^3.0.2",
         "typescript": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
       }
     },
     "packages/generator-langium/node_modules/@types/node": {
-      "version": "14.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-      "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
+      "version": "12.20.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
       "dev": true
     },
     "packages/langium": {
@@ -9776,7 +9782,7 @@
       },
       "devDependencies": {
         "@types/jest": "^26.0.20",
-        "@types/node": "^14.14.31",
+        "@types/node": "^12.12.6",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
         "eslint": "^7.20.0",
@@ -9786,6 +9792,9 @@
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
         "typescript": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "packages/langium-cli": {
@@ -9805,7 +9814,7 @@
       "devDependencies": {
         "@types/fs-extra": "^9.0.11",
         "@types/jest": "^26.0.20",
-        "@types/node": "^14.14.31",
+        "@types/node": "^12.12.6",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
         "eslint": "^7.20.0",
@@ -9814,12 +9823,15 @@
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
         "typescript": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "packages/langium-cli/node_modules/@types/node": {
-      "version": "14.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-      "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
+      "version": "12.20.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
       "dev": true
     },
     "packages/langium-vscode": {
@@ -9833,7 +9845,7 @@
       "devDependencies": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
-        "@types/node": "^12.11.7",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.53.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -9859,9 +9871,9 @@
       "dev": true
     },
     "packages/langium/node_modules/@types/node": {
-      "version": "14.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-      "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
+      "version": "12.20.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
       "dev": true
     },
     "packages/vscode-extension": {
@@ -11441,7 +11453,7 @@
     "arithmetics": {
       "version": "file:examples/arithmetics",
       "requires": {
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -11457,9 +11469,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-          "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
           "dev": true
         },
         "commander": {
@@ -12281,7 +12293,7 @@
       "version": "file:examples/domainmodel",
       "requires": {
         "@types/jest": "^26.0.20",
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -12299,9 +12311,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-          "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
           "dev": true
         },
         "commander": {
@@ -13143,7 +13155,7 @@
       "version": "file:packages/generator-langium",
       "requires": {
         "@types/lodash": "^4.14.170",
-        "@types/node": "^14.14.31",
+        "@types/node": "^12.12.6",
         "@types/yeoman-generator": "^5.0.0",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
@@ -13156,9 +13168,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-          "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
           "dev": true
         }
       }
@@ -14500,7 +14512,7 @@
       "version": "file:packages/langium",
       "requires": {
         "@types/jest": "^26.0.20",
-        "@types/node": "^14.14.31",
+        "@types/node": "^12.12.6",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
         "chevrotain": "^7.1.2",
@@ -14517,9 +14529,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-          "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
           "dev": true
         }
       }
@@ -14529,7 +14541,7 @@
       "requires": {
         "@types/fs-extra": "^9.0.11",
         "@types/jest": "^26.0.20",
-        "@types/node": "^14.14.31",
+        "@types/node": "^12.12.6",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
         "colors": "^1.4.0",
@@ -14547,9 +14559,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-          "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
           "dev": true
         }
       }
@@ -14559,7 +14571,7 @@
       "requires": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
-        "@types/node": "^12.11.7",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.53.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -15234,9 +15246,9 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -16336,7 +16348,7 @@
     "statemachine": {
       "version": "file:examples/statemachine",
       "requires": {
-        "@types/node": "^14.17.3",
+        "@types/node": "^12.12.6",
         "@types/vscode": "^1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -16350,9 +16362,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
-          "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==",
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "langium-workspaces",
   "private": true,
+  "engineStrict": true,
+  "engines": {
+    "npm": "^7.7.0"
+  },
   "scripts": {
     "clean": "rimraf \"packages/**/lib\" \"packages/**/*.tsbuildinfo\"",
     "build": "tsc -b tsconfig.build.json",

--- a/packages/generator-langium/package.json
+++ b/packages/generator-langium/package.json
@@ -2,6 +2,9 @@
   "name": "generator-langium",
   "version": "0.1.0",
   "description": "Yeoman generator for Langium - the language engineering tool",
+  "engines": {
+    "node": ">=12.10.0"
+  },
   "keywords": [
     "yeoman-generator",
     "language",
@@ -33,7 +36,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.170",
-    "@types/node": "^14.14.31",
+    "@types/node": "^12.12.6",
     "@types/yeoman-generator": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",

--- a/packages/langium-cli/package.json
+++ b/packages/langium-cli/package.json
@@ -2,6 +2,9 @@
   "name": "langium-cli",
   "version": "0.1.0",
   "description": "CLI for Langium - the language engineering tool",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "keywords": [
     "cli",
     "dsl",
@@ -39,7 +42,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^26.0.20",
-    "@types/node": "^14.14.31",
+    "@types/node": "^12.12.6",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "eslint": "^7.20.0",

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^12.11.7",
+    "@types/node": "^12.12.6",
     "@types/vscode": "^1.53.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -2,6 +2,9 @@
   "name": "langium",
   "version": "0.1.0",
   "description": "A language engineering tool for the Language Server Protocol",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "keywords": [
     "language",
     "dsl",
@@ -45,7 +48,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/node": "^14.14.31",
+    "@types/node": "^12.12.6",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "eslint": "^7.20.0",


### PR DESCRIPTION
Closes #192 

We use Node `12.10.0` as the minimum version now, as that is required by `yeoman@5.3.0`.