### PR TITLE
Fix generator watch mode

### DIFF
--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -27,6 +27,7 @@ const services = createLangiumGrammarServices();
 export async function generate(config: LangiumConfig): Promise<GeneratorResult> {
     const relPath = config[RelativePath];
     const absGrammarPath = URI.file(path.resolve(relPath, config.grammar));
+    services.documents.LangiumDocuments.invalidateDocument(absGrammarPath);
     const document = services.documents.LangiumDocuments.getOrCreateDocument(absGrammarPath);
     const buildResult = services.documents.DocumentBuilder.build(document);
     const diagnostics = buildResult.diagnostics;


### PR DESCRIPTION
With #172, we accidentally broke the support for watching langium grammars with the generator. The first grammar file that was read was cached and never invalidated. This change invalidates the grammar file without recreating the `services` instance.