### PR TITLE
Auto detect multiline comments

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -40,4 +40,4 @@ terminal ID: /[_a-zA-Z][\w_]*/;
 terminal NUMBER returns number: /[0-9]+(\.[0-9])?/;
 
 // This is both a single line AND multi line comment
-terminal COMMENT: /\/(\*[\s\S]*?\*\/|\/[^\n\r]*)/;
+terminal COMMENT: /\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/;

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -569,7 +569,7 @@ export const grammar = (): Grammar => loaded || (loaded = loadGrammar(`{
     {
       "$type": "TerminalRule",
       "name": "COMMENT",
-      "regex": "\\\\/(\\\\*[\\\\s\\\\S]*?\\\\*\\\\/|\\\\/[^\\\\n\\\\r]*)"
+      "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/|\\\\/\\\\/[^\\\\n\\\\r]*"
     }
   ],
   "name": "Arithmetics",

--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -36,10 +36,10 @@
           }
         },
         {
-          "begin": "(^\\s+)?(?=//)",
+          "begin": "//",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.whitespace.comment.leading.cs"
+              "name": "punctuation.whitespace.comment.leading.arithmetics"
             }
           },
           "end": "(?=$)",

--- a/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
+++ b/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
@@ -6,6 +6,9 @@
   ],
   "patterns": [
     {
+      "include": "#comments"
+    },
+    {
       "name": "keyword.control.domain-model",
       "match": "\\b(datatype|entity|extends|many|package)\\b"
     },
@@ -33,10 +36,10 @@
           }
         },
         {
-          "begin": "(^\\s+)?(?=//)",
+          "begin": "//",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.whitespace.comment.leading.cs"
+              "name": "punctuation.whitespace.comment.leading.domain-model"
             }
           },
           "end": "(?=$)",

--- a/examples/statemachine/syntaxes/statemachine.tmLanguage.json
+++ b/examples/statemachine/syntaxes/statemachine.tmLanguage.json
@@ -6,6 +6,9 @@
   ],
   "patterns": [
     {
+      "include": "#comments"
+    },
+    {
       "name": "keyword.control.statemachine",
       "match": "\\b(actions|commands|end|events|initialState|state|statemachine)\\b"
     },
@@ -33,10 +36,10 @@
           }
         },
         {
-          "begin": "(^\\s+)?(?=//)",
+          "begin": "//",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.whitespace.comment.leading.cs"
+              "name": "punctuation.whitespace.comment.leading.statemachine"
             }
           },
           "end": "(?=$)",

--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -9,6 +9,7 @@ import { Connection, TextDocuments } from 'vscode-languageserver/node';
 import { Module } from './dependency-injection';
 import { DefaultLangiumDocumentFactory, DefaultLangiumDocuments, DefaultTextDocumentFactory } from './documents/document';
 import { DefaultDocumentBuilder } from './documents/document-builder';
+import { createGrammarConfig } from './grammar/grammar-config';
 import { DefaultAstNodeDescriptionProvider, DefaultReferenceDescriptionProvider } from './index/ast-descriptions';
 import { DefaultAstNodeLocator } from './index/ast-node-locator';
 import { DefaultIndexManager } from './index/index-manager';
@@ -39,9 +40,7 @@ export type DefaultModuleContext = {
 export function createDefaultModule(context: DefaultModuleContext = {}): Module<LangiumServices, LangiumDefaultServices> {
     return {
         parser: {
-            GrammarConfig: () => ({
-                multilineCommentRules: ['ML_COMMENT']
-            }),
+            GrammarConfig: (injector) => createGrammarConfig(injector),
             LangiumParser: (injector) => createLangiumParser(injector),
             ValueConverter: () => new DefaultValueConverter(),
             TokenBuilder: () => new DefaultTokenBuilder()

--- a/packages/langium/src/grammar/grammar-config.ts
+++ b/packages/langium/src/grammar/grammar-config.ts
@@ -4,6 +4,22 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { LangiumServices } from '../services';
+import { isMultilineComment } from '../utils/regex-util';
+import { isTerminalRule } from './generated/ast';
+import { isCommentTerminal } from './grammar-util';
+
 export interface GrammarConfig {
     multilineCommentRules: string[]
+}
+
+export function createGrammarConfig(services: LangiumServices): GrammarConfig {
+    const rules: string[] = [];
+    const grammar = services.Grammar;
+    for (const rule of grammar.rules) {
+        if (isTerminalRule(rule) && isCommentTerminal(rule) && isMultilineComment(rule.regex)) {
+            rules.push(rule.name);
+        }
+    }
+    return { multilineCommentRules: rules };
 }

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -44,6 +44,10 @@ export function isDataTypeRule(rule: ast.ParserRule): boolean {
     return false;
 }
 
+export function isCommentTerminal(terminalRule: ast.TerminalRule): boolean {
+    return terminalRule.$container.hiddenTokens.some(e => e.ref === terminalRule) && !' '.match(terminalRule.regex);
+}
+
 interface RuleWithAlternatives {
     alternatives: ast.AbstractElement;
 }

--- a/packages/langium/test/utils/regex-util.test.ts
+++ b/packages/langium/test/utils/regex-util.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { partialMatches } from '../../src';
+import { getCommentParts, isMultilineComment, partialMatches } from '../../src';
 
 describe('partial regex', () => {
 
@@ -68,4 +68,62 @@ describe('partial regex', () => {
         expect(partialMatches(/^ab/, 'b')).toBeFalsy();
     });
 
+});
+
+describe('multiline comment detection', () => {
+
+    test('single character string should be not multiline comment', () => {
+        expect(isMultilineComment('x')).toBeFalsy();
+    });
+
+    test('single character regex should be not multiline comment', () => {
+        expect(isMultilineComment(/x/)).toBeFalsy();
+    });
+
+    test('single newline character should be multiline comment', () => {
+        expect(isMultilineComment(/\n/)).toBeTruthy();
+    });
+
+    test('JS style singleline comment should not be multiline comment', () => {
+        expect(isMultilineComment(/\/\/[^\n\r]*/)).toBeFalsy();
+    });
+
+    test('JS style multiline comment should be multiline comment', () => {
+        expect(isMultilineComment(/\/\*[\s\S]*?\*\//)).toBeTruthy();
+    });
+
+});
+
+describe('comment start/end parts', () => {
+
+    test('JS style singleline comment should start with //', () => {
+        expect(getCommentParts(/\/\/[^\n\r]*/)).toEqual([{
+            start: '//',
+            end: ''
+        }]);
+    });
+
+    test('JS style multiline comment should start with /* and end with */', () => {
+        expect(getCommentParts(/\/\*[\s\S]*?\*\//)).toEqual([{
+            start: '/\\*',
+            end: '\\*/'
+        }]);
+    });
+
+    test('JS style combined comment should contain both /* */ and // parts', () => {
+        expect(getCommentParts(/\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/)).toEqual([{
+            start: '/\\*',
+            end: '\\*/'
+        }, {
+            start: '//',
+            end: ''
+        }]);
+    });
+
+    test('Shell style single line comment starts with #', () => {
+        expect(getCommentParts(/#[^\n\r]*/)).toEqual([{
+            start: '#',
+            end: ''
+        }]);
+    });
 });


### PR DESCRIPTION
Closes #204
Closes #228

Automatically detects multiline comments by visiting the input regex. Courtesy of the `regex-to-ast` package that is included in Chevrotain.

This affects both the default `GrammarConfig` object that no longer assumes `ML_COMMENT` by default. Also changes the textMate generator to include all comments in a single comment regex.