### PR TITLE
Add the global maxLookahead configuration

### DIFF
--- a/examples/arithmetics/src/language-server/generated/module.ts
+++ b/examples/arithmetics/src/language-server/generated/module.ts
@@ -3,7 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, defaultParserConfig } from 'langium';
+import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module } from 'langium';
 import { ArithmeticsAstReflection } from './ast';
 import { grammar } from './grammar';
 
@@ -16,7 +16,5 @@ export const ArithmeticsGeneratedModule: Module<LangiumServices, LangiumGenerate
     Grammar: () => grammar(),
     AstReflection: () => new ArithmeticsAstReflection(),
     LanguageMetaData: () => languageMetaData,
-    parser: {
-        ParserConfig: () => defaultParserConfig
-    }
+    parser: {}
 };

--- a/examples/arithmetics/src/language-server/generated/module.ts
+++ b/examples/arithmetics/src/language-server/generated/module.ts
@@ -16,5 +16,7 @@ export const ArithmeticsGeneratedModule: Module<LangiumServices, LangiumGenerate
     Grammar: () => grammar(),
     AstReflection: () => new ArithmeticsAstReflection(),
     LanguageMetaData: () => languageMetaData,
-    ParserConfig: () => defaultParserConfig
+    parser: {
+        ParserConfig: () => defaultParserConfig
+    }
 };

--- a/examples/arithmetics/src/language-server/generated/module.ts
+++ b/examples/arithmetics/src/language-server/generated/module.ts
@@ -3,11 +3,11 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import { LangiumGeneratedServices, LangiumServices, Module } from 'langium';
+import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, defaultParserConfig } from 'langium';
 import { ArithmeticsAstReflection } from './ast';
 import { grammar } from './grammar';
 
-export const languageMetaData = {
+export const languageMetaData: LanguageMetaData = {
     languageId: 'arithmetics',
     fileExtensions: ['.calc']
 };
@@ -15,5 +15,6 @@ export const languageMetaData = {
 export const ArithmeticsGeneratedModule: Module<LangiumServices, LangiumGeneratedServices> = {
     Grammar: () => grammar(),
     AstReflection: () => new ArithmeticsAstReflection(),
-    LanguageMetaData: () => languageMetaData
+    LanguageMetaData: () => languageMetaData,
+    ParserConfig: () => defaultParserConfig
 };

--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -6,9 +6,6 @@
   ],
   "patterns": [
     {
-      "include": "#comments"
-    },
-    {
       "name": "keyword.control.arithmetics",
       "match": "\\b(def|module)\\b"
     },

--- a/examples/domainmodel/langium-config.json
+++ b/examples/domainmodel/langium-config.json
@@ -5,5 +5,12 @@
     "out": "src/language-server/generated",
     "textMate": {
         "out": "syntaxes/domain-model.tmLanguage.json"
+    },
+    "parserConfig": {
+      "chevrotainConfig": { 
+          "recoveryEnabled": true,
+          "nodeLocationTracking": "onlyOffset",
+          "maxLookahead": 3
+      }
     }
 }

--- a/examples/domainmodel/langium-config.json
+++ b/examples/domainmodel/langium-config.json
@@ -6,11 +6,9 @@
     "textMate": {
         "out": "syntaxes/domain-model.tmLanguage.json"
     },
-    "parserConfig": {
-      "chevrotainConfig": { 
-          "recoveryEnabled": true,
-          "nodeLocationTracking": "onlyOffset",
-          "maxLookahead": 3
-      }
+    "chevrotainParserConfig": {
+        "recoveryEnabled": true,
+        "nodeLocationTracking": "onlyOffset",
+        "maxLookahead": 3
     }
 }

--- a/examples/domainmodel/src/language-server/generated/module.ts
+++ b/examples/domainmodel/src/language-server/generated/module.ts
@@ -3,17 +3,26 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import { LangiumGeneratedServices, LangiumServices, Module } from 'langium';
+import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, ParserConfig } from 'langium';
 import { DomainModelAstReflection } from './ast';
 import { grammar } from './grammar';
 
-export const languageMetaData = {
+export const languageMetaData: LanguageMetaData = {
     languageId: 'domain-model',
     fileExtensions: ['.dmodel']
+};
+
+export const parserConfig: ParserConfig = {
+    chevrotainConfig: {
+        recoveryEnabled: true,
+        nodeLocationTracking: 'onlyOffset',
+        maxLookahead: 4,
+    }
 };
 
 export const DomainModelGeneratedModule: Module<LangiumServices, LangiumGeneratedServices> = {
     Grammar: () => grammar(),
     AstReflection: () => new DomainModelAstReflection(),
-    LanguageMetaData: () => languageMetaData
+    LanguageMetaData: () => languageMetaData,
+    ParserConfig: () => parserConfig
 };

--- a/examples/domainmodel/src/language-server/generated/module.ts
+++ b/examples/domainmodel/src/language-server/generated/module.ts
@@ -22,5 +22,7 @@ export const DomainModelGeneratedModule: Module<LangiumServices, LangiumGenerate
     Grammar: () => grammar(),
     AstReflection: () => new DomainModelAstReflection(),
     LanguageMetaData: () => languageMetaData,
-    ParserConfig: () => parserConfig
+    parser: {
+        ParserConfig: () => parserConfig
+    }
 };

--- a/examples/domainmodel/src/language-server/generated/module.ts
+++ b/examples/domainmodel/src/language-server/generated/module.ts
@@ -3,7 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, ParserConfig } from 'langium';
+import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, IParserConfig } from 'langium';
 import { DomainModelAstReflection } from './ast';
 import { grammar } from './grammar';
 
@@ -12,12 +12,10 @@ export const languageMetaData: LanguageMetaData = {
     fileExtensions: ['.dmodel']
 };
 
-export const parserConfig: ParserConfig = {
-    chevrotainConfig: {
-        recoveryEnabled: true,
-        nodeLocationTracking: 'onlyOffset',
-        maxLookahead: 4,
-    }
+export const parserConfig: IParserConfig = {
+    recoveryEnabled: true,
+    nodeLocationTracking: 'onlyOffset',
+    maxLookahead: 3,
 };
 
 export const DomainModelGeneratedModule: Module<LangiumServices, LangiumGeneratedServices> = {

--- a/examples/statemachine/src/language-server/generated/module.ts
+++ b/examples/statemachine/src/language-server/generated/module.ts
@@ -16,5 +16,7 @@ export const StatemachineGeneratedModule: Module<LangiumServices, LangiumGenerat
     Grammar: () => grammar(),
     AstReflection: () => new StatemachineAstReflection(),
     LanguageMetaData: () => languageMetaData,
-    ParserConfig: () => defaultParserConfig
+    parser: {
+        ParserConfig: () => defaultParserConfig
+    }
 };

--- a/examples/statemachine/src/language-server/generated/module.ts
+++ b/examples/statemachine/src/language-server/generated/module.ts
@@ -3,11 +3,11 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import { LangiumGeneratedServices, LangiumServices, Module } from 'langium';
+import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, defaultParserConfig } from 'langium';
 import { StatemachineAstReflection } from './ast';
 import { grammar } from './grammar';
 
-export const languageMetaData = {
+export const languageMetaData: LanguageMetaData = {
     languageId: 'statemachine',
     fileExtensions: ['.statemachine']
 };
@@ -15,5 +15,6 @@ export const languageMetaData = {
 export const StatemachineGeneratedModule: Module<LangiumServices, LangiumGeneratedServices> = {
     Grammar: () => grammar(),
     AstReflection: () => new StatemachineAstReflection(),
-    LanguageMetaData: () => languageMetaData
+    LanguageMetaData: () => languageMetaData,
+    ParserConfig: () => defaultParserConfig
 };

--- a/examples/statemachine/src/language-server/generated/module.ts
+++ b/examples/statemachine/src/language-server/generated/module.ts
@@ -3,7 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, defaultParserConfig } from 'langium';
+import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module } from 'langium';
 import { StatemachineAstReflection } from './ast';
 import { grammar } from './grammar';
 
@@ -16,7 +16,5 @@ export const StatemachineGeneratedModule: Module<LangiumServices, LangiumGenerat
     Grammar: () => grammar(),
     AstReflection: () => new StatemachineAstReflection(),
     LanguageMetaData: () => languageMetaData,
-    parser: {
-        ParserConfig: () => defaultParserConfig
-    }
+    parser: {}
 };

--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -60,10 +60,6 @@
                             "description": "Enable computation of CST nodes location",
                             "type": "string"
                         },
-                        "errorMessageProvider": {
-                            "description": "A custom error message provider",
-                            "type": "object"
-                        },
                         "traceInitPerf": {
                             "description": "A flag to print performance tracing logs during parser initialization",
                             "type": ["boolean", "number"]

--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -40,49 +40,40 @@
                         "out"
                     ]
                 },
-                "parserConfig": {
-                    "description": "An object to describe the parser configuration",
+                "chevrotainParserConfig": {
+                    "description": "An object to describe the Chevrotain parser configuration",
                     "type": "object",
                     "properties": {
-                        "chevrotainConfig": {
-                            "description": "An object to describe the Chevrotain parser configuration",
-                            "type": "object",
-                            "properties": {
-                                "recoveryEnabled": {
-                                    "description": "Is the error recovery / fault tolerance of the Chevrotain Parser enabled",
-                                    "type": "boolean"
-                                },
-                                "maxLookahead": {
-                                    "description": "Maximum number of tokens the parser will use to choose between alternatives",
-                                    "type": "number"
-                                },
-                                "dynamicTokensEnabled": {
-                                    "description": "A flag to support Dynamically defined Tokens",
-                                    "type": "boolean"
-                                },
-                                "nodeLocationTracking": {
-                                    "description": "Enable computation of CST nodes location",
-                                    "type": "string"
-                                },
-                                "errorMessageProvider": {
-                                    "description": "A custom error message provider",
-                                    "type": "object"
-                                },
-                                "traceInitPerf": {
-                                    "description": "A flag to print performance tracing logs during parser initialization",
-                                    "type": ["boolean", "number"]
-                                },
-                                "skipValidations": {
-                                    "description": "A flag to avoid running the grammar validations during Parser initialization",
-                                    "type": "boolean"
-                                }
-                            },
-                            "required": []
+                        "recoveryEnabled": {
+                            "description": "Is the error recovery / fault tolerance of the Chevrotain Parser enabled",
+                            "type": "boolean"
+                        },
+                        "maxLookahead": {
+                            "description": "Maximum number of tokens the parser will use to choose between alternatives",
+                            "type": "number"
+                        },
+                        "dynamicTokensEnabled": {
+                            "description": "A flag to support Dynamically defined Tokens",
+                            "type": "boolean"
+                        },
+                        "nodeLocationTracking": {
+                            "description": "Enable computation of CST nodes location",
+                            "type": "string"
+                        },
+                        "errorMessageProvider": {
+                            "description": "A custom error message provider",
+                            "type": "object"
+                        },
+                        "traceInitPerf": {
+                            "description": "A flag to print performance tracing logs during parser initialization",
+                            "type": ["boolean", "number"]
+                        },
+                        "skipValidations": {
+                            "description": "A flag to avoid running the grammar validations during Parser initialization",
+                            "type": "boolean"
                         }
                     },
-                    "required": [
-                        "chevrotainConfig"
-                    ]
+                    "required": []
                 },
                 "langiumInternal": {
                     "description": "A flag to determine whether langium uses itself to bootstrap",

--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -40,6 +40,50 @@
                         "out"
                     ]
                 },
+                "parserConfig": {
+                    "description": "An object to describe the parser configuration",
+                    "type": "object",
+                    "properties": {
+                        "chevrotainConfig": {
+                            "description": "An object to describe the Chevrotain parser configuration",
+                            "type": "object",
+                            "properties": {
+                                "recoveryEnabled": {
+                                    "description": "Is the error recovery / fault tolerance of the Chevrotain Parser enabled",
+                                    "type": "boolean"
+                                },
+                                "maxLookahead": {
+                                    "description": "Maximum number of tokens the parser will use to choose between alternatives",
+                                    "type": "number"
+                                },
+                                "dynamicTokensEnabled": {
+                                    "description": "A flag to support Dynamically defined Tokens",
+                                    "type": "boolean"
+                                },
+                                "nodeLocationTracking": {
+                                    "description": "Enable computation of CST nodes location",
+                                    "type": "string"
+                                },
+                                "errorMessageProvider": {
+                                    "description": "A custom error message provider",
+                                    "type": "object"
+                                },
+                                "traceInitPerf": {
+                                    "description": "A flag to print performance tracing logs during parser initialization",
+                                    "type": ["boolean", "number"]
+                                },
+                                "skipValidations": {
+                                    "description": "A flag to avoid running the grammar validations during Parser initialization",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": []
+                        }
+                    },
+                    "required": [
+                        "chevrotainConfig"
+                    ]
+                },
                 "langiumInternal": {
                     "description": "A flag to determine whether langium uses itself to bootstrap",
                     "type": "boolean"

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -13,29 +13,48 @@ export function generateModule(grammar: langium.Grammar, config: LangiumConfig):
     const node = new CompositeGeneratorNode();
     node.append(generatedHeader);
     if (config.langiumInternal) {
+        node.append(`import { LanguageMetaData, ${config.parserConfig ? 'ParserConfig' : 'defaultParserConfig'} } from '../..';`, NL);
         node.append("import { Module } from '../../dependency-injection';", NL);
         node.contents.push("import { LangiumGeneratedServices, LangiumServices } from '../../services';", NL);
     } else {
-        node.append("import { LangiumGeneratedServices, LangiumServices, Module } from 'langium';", NL);
+        node.append(`import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, ${config.parserConfig ? 'ParserConfig' : 'defaultParserConfig'} } from 'langium';`, NL);
     }
     node.append(
         'import { ', grammar.name, "AstReflection } from './ast';", NL,
         "import { grammar } from './grammar';", NL, NL
     );
 
-    node.append('export const languageMetaData = {', NL);
+    node.append('export const languageMetaData: LanguageMetaData = {', NL);
     node.indent(metaData => {
         metaData.append(`languageId: '${config.languageId}',`, NL);
         metaData.append(`fileExtensions: [${config.fileExtensions && config.fileExtensions.map(e => appendQuotesAndDot(e)).join(', ')}]`, NL);
     });
     node.append('};', NL, NL);
 
+    if (config.parserConfig) {
+        node.append('export const parserConfig: ParserConfig = {', NL);
+        node.indent(configNode => {
+            const chevrotainConfig = config.parserConfig!.chevrotainConfig;
+            configNode.append('chevrotainConfig: {', NL);
+            configNode.indent(chevrotainConfigNode =>
+                Object.keys(chevrotainConfig).forEach(key => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const value = (chevrotainConfig as any)[key];
+                    chevrotainConfigNode.append(`${key}: ${typeof value === 'string' ? `'${value}'` : value},`, NL);
+                })
+            );
+            configNode.append('}', NL);
+        });
+        node.append('};', NL, NL);
+    }
+
     node.append('export const ', grammar.name, 'GeneratedModule: Module<LangiumServices, LangiumGeneratedServices> = {', NL);
     node.indent(moduleNode => {
         moduleNode.append(
             'Grammar: () => grammar(),', NL,
             'AstReflection: () => new ', grammar.name, 'AstReflection(),', NL,
-            'LanguageMetaData: () => languageMetaData', NL
+            'LanguageMetaData: () => languageMetaData,', NL,
+            `ParserConfig: () => ${config.parserConfig ? 'parserConfig' : 'defaultParserConfig'}`, NL
         );
     });
     node.append('};', NL);

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -15,11 +15,11 @@ export function generateModule(grammar: langium.Grammar, config: LangiumConfig):
 
     node.append(generatedHeader);
     if (config.langiumInternal) {
-        node.append(`import { LanguageMetaData, ${parserConfig ? 'IParserConfig' : 'defaultParserConfig'} } from '../..';`, NL);
+        node.append(`import { LanguageMetaData${parserConfig ? ', IParserConfig' : ''} } from '../..';`, NL);
         node.append("import { Module } from '../../dependency-injection';", NL);
         node.contents.push("import { LangiumGeneratedServices, LangiumServices } from '../../services';", NL);
     } else {
-        node.append(`import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module, ${parserConfig ? 'IParserConfig' : 'defaultParserConfig'} } from 'langium';`, NL);
+        node.append(`import { LangiumGeneratedServices, LangiumServices, LanguageMetaData, Module${parserConfig ? ', IParserConfig' : ''} } from 'langium';`, NL);
     }
     node.append(
         'import { ', grammar.name, "AstReflection } from './ast';", NL,
@@ -51,11 +51,14 @@ export function generateModule(grammar: langium.Grammar, config: LangiumConfig):
             'Grammar: () => grammar(),', NL,
             'AstReflection: () => new ', grammar.name, 'AstReflection(),', NL,
             'LanguageMetaData: () => languageMetaData,', NL,
-            'parser: {', NL
+            'parser: {',
         );
-        moduleNode.indent(parserGroupNode => {
-            parserGroupNode.append(`ParserConfig: () => ${parserConfig ? 'parserConfig' : 'defaultParserConfig'}`, NL);
-        });
+        if (parserConfig) {
+            moduleNode.append(NL);
+            moduleNode.indent(parserGroupNode => {
+                parserGroupNode.append('ParserConfig: () => parserConfig', NL);
+            });
+        }
         moduleNode.append('}', NL);
     });
     node.append('};', NL);

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -51,8 +51,12 @@ export function generateModule(grammar: langium.Grammar, config: LangiumConfig):
             'Grammar: () => grammar(),', NL,
             'AstReflection: () => new ', grammar.name, 'AstReflection(),', NL,
             'LanguageMetaData: () => languageMetaData,', NL,
-            `ParserConfig: () => ${parserConfig ? 'parserConfig' : 'defaultParserConfig'}`, NL
+            'parser: {', NL
         );
+        moduleNode.indent(parserGroupNode => {
+            parserGroupNode.append(`ParserConfig: () => ${parserConfig ? 'parserConfig' : 'defaultParserConfig'}`, NL);
+        });
+        moduleNode.append('}', NL);
     });
     node.append('};', NL);
 

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import fs from 'fs-extra';
-import { ParserConfig } from 'langium';
+import { IParserConfig } from 'langium';
 import path from 'path';
 import { getTime } from './generator/util';
 
@@ -33,8 +33,8 @@ export interface LangiumConfig {
         /** Output path to syntax highlighting file */
         out: string
     }
-    /** Configure the parser */
-    parserConfig?: ParserConfig,
+    /** Configure the chevrotain parser */
+    chevrotainParserConfig?: IParserConfig,
     /** The following option is meant to be used only by Langium itself */
     langiumInternal?: boolean
 }

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import fs from 'fs-extra';
+import { ParserConfig } from 'langium';
 import path from 'path';
 import { getTime } from './generator/util';
 
@@ -32,6 +33,8 @@ export interface LangiumConfig {
         /** Output path to syntax highlighting file */
         out: string
     }
+    /** Configure the parser */
+    parserConfig?: ParserConfig,
     /** The following option is meant to be used only by Langium itself */
     langiumInternal?: boolean
 }

--- a/packages/langium/src/grammar/generated/module.ts
+++ b/packages/langium/src/grammar/generated/module.ts
@@ -3,7 +3,7 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
-import { LanguageMetaData, defaultParserConfig } from '../..';
+import { LanguageMetaData } from '../..';
 import { Module } from '../../dependency-injection';
 import { LangiumGeneratedServices, LangiumServices } from '../../services';
 import { LangiumGrammarAstReflection } from './ast';
@@ -18,7 +18,5 @@ export const LangiumGrammarGeneratedModule: Module<LangiumServices, LangiumGener
     Grammar: () => grammar(),
     AstReflection: () => new LangiumGrammarAstReflection(),
     LanguageMetaData: () => languageMetaData,
-    parser: {
-        ParserConfig: () => defaultParserConfig
-    }
+    parser: {}
 };

--- a/packages/langium/src/grammar/generated/module.ts
+++ b/packages/langium/src/grammar/generated/module.ts
@@ -3,12 +3,13 @@
  * DO NOT EDIT MANUALLY!
  ******************************************************************************/
 
+import { LanguageMetaData, defaultParserConfig } from '../..';
 import { Module } from '../../dependency-injection';
 import { LangiumGeneratedServices, LangiumServices } from '../../services';
 import { LangiumGrammarAstReflection } from './ast';
 import { grammar } from './grammar';
 
-export const languageMetaData = {
+export const languageMetaData: LanguageMetaData = {
     languageId: 'langium',
     fileExtensions: ['.langium']
 };
@@ -16,5 +17,6 @@ export const languageMetaData = {
 export const LangiumGrammarGeneratedModule: Module<LangiumServices, LangiumGeneratedServices> = {
     Grammar: () => grammar(),
     AstReflection: () => new LangiumGrammarAstReflection(),
-    LanguageMetaData: () => languageMetaData
+    LanguageMetaData: () => languageMetaData,
+    ParserConfig: () => defaultParserConfig
 };

--- a/packages/langium/src/grammar/generated/module.ts
+++ b/packages/langium/src/grammar/generated/module.ts
@@ -18,5 +18,7 @@ export const LangiumGrammarGeneratedModule: Module<LangiumServices, LangiumGener
     Grammar: () => grammar(),
     AstReflection: () => new LangiumGrammarAstReflection(),
     LanguageMetaData: () => languageMetaData,
-    ParserConfig: () => defaultParserConfig
+    parser: {
+        ParserConfig: () => defaultParserConfig
+    }
 };

--- a/packages/langium/src/index.ts
+++ b/packages/langium/src/index.ts
@@ -24,6 +24,7 @@ export * from './lsp/language-server';
 export * from './validation/document-validator';
 export * from './validation/validation-registry';
 export * from './parser/langium-parser';
+export * from './parser/parser-config';
 export * from './references/linker';
 export * from './references/naming';
 export * from './references/scope';

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -41,7 +41,7 @@ export class LangiumParser {
     }
 
     constructor(services: LangiumServices, tokens: TokenType[]) {
-        this.config = services.ParserConfig;
+        this.config = services.parser.ParserConfig;
         this.wrapper = new ChevrotainWrapper(tokens, this.config);
         this.linker = services.references.Linker;
         this.converter = services.parser.ValueConverter;

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -14,7 +14,7 @@ import { Linker } from '../references/linker';
 import { LangiumServices } from '../services';
 import { getContainerOfType } from '../utils/ast-util';
 import { ValueConverter } from './value-converter';
-import { ParserConfig } from './parser-config';
+import { IParserConfig } from './parser-config';
 
 export type ParseResult<T = AstNode> = {
     value: T,
@@ -32,7 +32,7 @@ export class LangiumParser {
     private readonly lexer: Lexer;
     private readonly nodeBuilder = new CstNodeBuilder();
     private readonly wrapper: ChevrotainWrapper;
-    private readonly config: ParserConfig;
+    private readonly config: IParserConfig;
     private stack: any[] = [];
     private mainRule!: RuleResult;
 
@@ -305,8 +305,8 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
 
     private analysed = false;
 
-    constructor(tokens: TokenType[], config: ParserConfig) {
-        super(tokens, config.chevrotainConfig);
+    constructor(tokens: TokenType[], config: IParserConfig) {
+        super(tokens, config);
     }
 
     get IS_RECORDING(): boolean {

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -14,6 +14,7 @@ import { Linker } from '../references/linker';
 import { LangiumServices } from '../services';
 import { getContainerOfType } from '../utils/ast-util';
 import { ValueConverter } from './value-converter';
+import { ParserConfig } from './parser-config';
 
 export type ParseResult<T = AstNode> = {
     value: T,
@@ -31,6 +32,7 @@ export class LangiumParser {
     private readonly lexer: Lexer;
     private readonly nodeBuilder = new CstNodeBuilder();
     private readonly wrapper: ChevrotainWrapper;
+    private readonly config: ParserConfig;
     private stack: any[] = [];
     private mainRule!: RuleResult;
 
@@ -39,7 +41,8 @@ export class LangiumParser {
     }
 
     constructor(services: LangiumServices, tokens: TokenType[]) {
-        this.wrapper = new ChevrotainWrapper(tokens);
+        this.config = services.ParserConfig;
+        this.wrapper = new ChevrotainWrapper(tokens, this.config);
         this.linker = services.references.Linker;
         this.converter = services.parser.ValueConverter;
         this.lexer = new Lexer(tokens);
@@ -302,8 +305,8 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
 
     private analysed = false;
 
-    constructor(tokens: TokenType[]) {
-        super(tokens, { recoveryEnabled: true, nodeLocationTracking: 'onlyOffset' });
+    constructor(tokens: TokenType[], config: ParserConfig) {
+        super(tokens, config.chevrotainConfig);
     }
 
     get IS_RECORDING(): boolean {

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -32,7 +32,6 @@ export class LangiumParser {
     private readonly lexer: Lexer;
     private readonly nodeBuilder = new CstNodeBuilder();
     private readonly wrapper: ChevrotainWrapper;
-    private readonly config: IParserConfig | undefined;
     private stack: any[] = [];
     private mainRule!: RuleResult;
 
@@ -41,8 +40,7 @@ export class LangiumParser {
     }
 
     constructor(services: LangiumServices, tokens: TokenType[]) {
-        this.config = services.parser.ParserConfig;
-        this.wrapper = new ChevrotainWrapper(tokens, this.config);
+        this.wrapper = new ChevrotainWrapper(tokens, services.parser.ParserConfig);
         this.linker = services.references.Linker;
         this.converter = services.parser.ValueConverter;
         this.lexer = new Lexer(tokens);

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -32,7 +32,7 @@ export class LangiumParser {
     private readonly lexer: Lexer;
     private readonly nodeBuilder = new CstNodeBuilder();
     private readonly wrapper: ChevrotainWrapper;
-    private readonly config: IParserConfig;
+    private readonly config: IParserConfig | undefined;
     private stack: any[] = [];
     private mainRule!: RuleResult;
 
@@ -305,8 +305,12 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
 
     private analysed = false;
 
-    constructor(tokens: TokenType[], config: IParserConfig) {
-        super(tokens, config);
+    constructor(tokens: TokenType[], config?: IParserConfig) {
+        super(tokens, {
+            recoveryEnabled: true,
+            nodeLocationTracking: 'onlyOffset',
+            ...config
+        });
     }
 
     get IS_RECORDING(): boolean {

--- a/packages/langium/src/parser/parser-config.ts
+++ b/packages/langium/src/parser/parser-config.ts
@@ -4,11 +4,4 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { IParserConfig } from 'chevrotain';
-
 export { IParserConfig } from 'chevrotain';
-
-export const defaultParserConfig: IParserConfig = {
-    recoveryEnabled: true,
-    nodeLocationTracking: 'onlyOffset'
-};

--- a/packages/langium/src/parser/parser-config.ts
+++ b/packages/langium/src/parser/parser-config.ts
@@ -8,10 +8,7 @@ import { IParserConfig } from 'chevrotain';
 
 export { IParserConfig } from 'chevrotain';
 
-export interface ParserConfig {
-    chevrotainConfig: IParserConfig
-}
-
-export const defaultParserConfig: ParserConfig = {
-    chevrotainConfig: { recoveryEnabled: true, nodeLocationTracking: 'onlyOffset' }
+export const defaultParserConfig: IParserConfig = {
+    recoveryEnabled: true,
+    nodeLocationTracking: 'onlyOffset'
 };

--- a/packages/langium/src/parser/parser-config.ts
+++ b/packages/langium/src/parser/parser-config.ts
@@ -1,0 +1,17 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { IParserConfig } from 'chevrotain';
+
+export { IParserConfig } from 'chevrotain';
+
+export interface ParserConfig {
+    chevrotainConfig: IParserConfig
+}
+
+export const defaultParserConfig: ParserConfig = {
+    chevrotainConfig: { recoveryEnabled: true, nodeLocationTracking: 'onlyOffset' }
+};

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -6,7 +6,7 @@
 
 import { Connection, TextDocuments } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { AstReflection, CompletionProvider, DocumentBuilder, LangiumDocumentFactory, LangiumDocuments, DocumentValidator, Grammar, JsonSerializer, LangiumParser, LanguageMetaData, Linker, NameProvider, RuleInterpreter, ScopeComputation, ScopeProvider, TextDocumentFactory, ValidationRegistry, ParserConfig } from '.';
+import { AstReflection, CompletionProvider, DocumentBuilder, LangiumDocumentFactory, LangiumDocuments, DocumentValidator, Grammar, JsonSerializer, LangiumParser, LanguageMetaData, Linker, NameProvider, RuleInterpreter, ScopeComputation, ScopeProvider, TextDocumentFactory, ValidationRegistry, IParserConfig } from '.';
 import { AstNodeDescriptionProvider, ReferenceDescriptionProvider } from './index/ast-descriptions';
 import { AstNodeLocator } from './index/ast-node-locator';
 import { IndexManager } from './index/index-manager';
@@ -26,7 +26,7 @@ export type LangiumGeneratedServices = {
     Grammar: Grammar
     AstReflection: AstReflection
     LanguageMetaData: LanguageMetaData
-    ParserConfig: ParserConfig
+    ParserConfig: IParserConfig
 }
 
 export type LangiumLspServices = {

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -26,7 +26,9 @@ export type LangiumGeneratedServices = {
     Grammar: Grammar
     AstReflection: AstReflection
     LanguageMetaData: LanguageMetaData
-    ParserConfig: IParserConfig
+    parser: {
+        ParserConfig: IParserConfig
+    }
 }
 
 export type LangiumLspServices = {

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -6,7 +6,7 @@
 
 import { Connection, TextDocuments } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { AstReflection, CompletionProvider, DocumentBuilder, LangiumDocumentFactory, LangiumDocuments, DocumentValidator, Grammar, JsonSerializer, LangiumParser, LanguageMetaData, Linker, NameProvider, RuleInterpreter, ScopeComputation, ScopeProvider, TextDocumentFactory, ValidationRegistry } from '.';
+import { AstReflection, CompletionProvider, DocumentBuilder, LangiumDocumentFactory, LangiumDocuments, DocumentValidator, Grammar, JsonSerializer, LangiumParser, LanguageMetaData, Linker, NameProvider, RuleInterpreter, ScopeComputation, ScopeProvider, TextDocumentFactory, ValidationRegistry, ParserConfig } from '.';
 import { AstNodeDescriptionProvider, ReferenceDescriptionProvider } from './index/ast-descriptions';
 import { AstNodeLocator } from './index/ast-node-locator';
 import { IndexManager } from './index/index-manager';
@@ -26,6 +26,7 @@ export type LangiumGeneratedServices = {
     Grammar: Grammar
     AstReflection: AstReflection
     LanguageMetaData: LanguageMetaData
+    ParserConfig: ParserConfig
 }
 
 export type LangiumLspServices = {

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -27,7 +27,7 @@ export type LangiumGeneratedServices = {
     AstReflection: AstReflection
     LanguageMetaData: LanguageMetaData
     parser: {
-        ParserConfig: IParserConfig
+        ParserConfig?: IParserConfig
     }
 }
 


### PR DESCRIPTION
Closes [the issue/202](https://github.com/langium/langium/issues/202).
Allows to configure Chevrotain's `IParserConfig` as part of `LangiumConfig`; provides a new service `ParserConfig` similarly to the `LanguageMetaData` service.