### PR TITLE
Update token builder to use multiple longer alts

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -1,5 +1,5 @@
 grammar Arithmetics
-hidden(WS, COMMENT)
+hidden(WS, SL_COMMENT, ML_COMMENT)
 
 Module:
 	'module' name=ID
@@ -39,5 +39,5 @@ terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal NUMBER returns number: /[0-9]+(\.[0-9])?/;
 
-// This is both a single line AND multi line comment
-terminal COMMENT: /\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/;
+terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
+terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -14,7 +14,10 @@ export const grammar = (): Grammar => loaded || (loaded = loadGrammar(`{
       "$refName": "WS"
     },
     {
-      "$refName": "COMMENT"
+      "$refName": "SL_COMMENT"
+    },
+    {
+      "$refName": "ML_COMMENT"
     }
   ],
   "metamodelDeclarations": [],
@@ -568,8 +571,13 @@ export const grammar = (): Grammar => loaded || (loaded = loadGrammar(`{
     },
     {
       "$type": "TerminalRule",
-      "name": "COMMENT",
-      "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/|\\\\/\\\\/[^\\\\n\\\\r]*"
+      "name": "ML_COMMENT",
+      "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/"
+    },
+    {
+      "$type": "TerminalRule",
+      "name": "SL_COMMENT",
+      "regex": "\\\\/\\\\/[^\\\\n\\\\r]*"
     }
   ],
   "name": "Arithmetics",

--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -6,6 +6,9 @@
   ],
   "patterns": [
     {
+      "include": "#comments"
+    },
+    {
       "name": "keyword.control.arithmetics",
       "match": "\\b(def|module)\\b"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -737,6 +737,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@chevrotain/types": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-9.1.0.tgz",
+      "integrity": "sha512-3hbCD1CThkv9gnaSIPq0GUXwKni68e0ph6jIHwCvcWiQ4JB2xi8bFxBain0RF04qHUWuDjgnZLj4rLgimuGO+g=="
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-9.1.0.tgz",
+      "integrity": "sha512-llLJZ8OAlZrjGlBvamm6Zdo/HmGAcCLq5gx7cSwUX8No+n/8ip+oaC4x33IdZIif8+Rh5dQUIZXmfbSghiOmNQ=="
+    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -2751,10 +2761,12 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.2.tgz",
-      "integrity": "sha512-9bQsXVQ7UAvzMs7iUBBJ9Yv//exOy7bIR3PByOEk4M64vIE/LsiOiX7VIkMF/vEMlrSStwsaE884Bp9CpjtC5g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-9.1.0.tgz",
+      "integrity": "sha512-A86/55so63HCfu0dgGg3j9u8uuuBOrSqly1OhBZxRu2x6sAKILLzfVjbGMw45kgier6lz45EzcjjWtTRgoT84Q==",
       "dependencies": {
+        "@chevrotain/types": "^9.1.0",
+        "@chevrotain/utils": "^9.1.0",
         "regexp-to-ast": "0.5.0"
       }
     },
@@ -10066,7 +10078,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "chevrotain": "^7.1.2",
+        "chevrotain": "^9.1.0",
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-uri": "^3.0.2"
@@ -10653,6 +10665,16 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@chevrotain/types": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-9.1.0.tgz",
+      "integrity": "sha512-3hbCD1CThkv9gnaSIPq0GUXwKni68e0ph6jIHwCvcWiQ4JB2xi8bFxBain0RF04qHUWuDjgnZLj4rLgimuGO+g=="
+    },
+    "@chevrotain/utils": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-9.1.0.tgz",
+      "integrity": "sha512-llLJZ8OAlZrjGlBvamm6Zdo/HmGAcCLq5gx7cSwUX8No+n/8ip+oaC4x33IdZIif8+Rh5dQUIZXmfbSghiOmNQ=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -12321,10 +12343,12 @@
       "dev": true
     },
     "chevrotain": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.2.tgz",
-      "integrity": "sha512-9bQsXVQ7UAvzMs7iUBBJ9Yv//exOy7bIR3PByOEk4M64vIE/LsiOiX7VIkMF/vEMlrSStwsaE884Bp9CpjtC5g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-9.1.0.tgz",
+      "integrity": "sha512-A86/55so63HCfu0dgGg3j9u8uuuBOrSqly1OhBZxRu2x6sAKILLzfVjbGMw45kgier6lz45EzcjjWtTRgoT84Q==",
       "requires": {
+        "@chevrotain/types": "^9.1.0",
+        "@chevrotain/utils": "^9.1.0",
         "regexp-to-ast": "0.5.0"
       }
     },
@@ -14907,7 +14931,7 @@
         "@types/node": "^12.12.6",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
-        "chevrotain": "^7.1.2",
+        "chevrotain": "^9.1.0",
         "eslint": "^7.20.0",
         "eslint-plugin-header": "^3.1.1",
         "jest": "^26.6.3",

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -32,7 +32,7 @@
     "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {
-    "chevrotain": "^7.1.2",
+    "chevrotain": "^9.1.0",
     "vscode-uri": "^3.0.2",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1"

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { TokenType } from '@chevrotain/types';
+import { createLangiumGrammarServices, Grammar } from '../../src';
+import {  parseHelper } from '../../src/test';
+
+const services = createLangiumGrammarServices();
+const tokenBuilder = services.parser.TokenBuilder;
+
+const text = `
+grammar test
+
+Main: {Main} 'A' 'AB' 'ABC';
+terminal AB: /ABD?/;
+`;
+const grammar = parseHelper<Grammar>(services)(text).parseResult.value;
+
+const tokens = tokenBuilder.buildTokens(grammar);
+const aToken = tokens[2]; // 'A' keyword
+const abToken = tokens[1]; // 'AB' keyword
+const abcToken = tokens[0]; // 'ABC' keyword
+const abTerminalToken = tokens[3]; // 'AB' terminal
+
+describe('tokenBuilder#longerAlts', () => {
+
+    test('should create longer alts for keywords # 1', () => {
+        expect(Array.isArray(aToken.LONGER_ALT)).toBeTruthy();
+        const longerAlts = aToken.LONGER_ALT as TokenType[];
+        expect(longerAlts).toEqual([abcToken, abToken, abTerminalToken]);
+    });
+
+    test('should create longer alts for keywords # 2', () => {
+        expect(Array.isArray(abToken.LONGER_ALT)).toBeTruthy();
+        const longerAlts = abToken.LONGER_ALT as TokenType[];
+        expect(longerAlts).toEqual([abcToken, abTerminalToken]);
+    });
+
+    test('should create no longer alts for longest keyword', () => {
+        expect(abcToken.LONGER_ALT).toEqual([]);
+    });
+
+    test('should create no longer alts for terminals', () => {
+        expect(abTerminalToken.LONGER_ALT).toBeUndefined();
+    });
+
+});


### PR DESCRIPTION
Closes #38

Updates Chevrotain to 9.1.0 and improves the token builder to make use of multiple longer alternative. Also adds tests to the default token builder.