### PR TITLE
Listen to LSP connection file changes

### DIFF
--- a/examples/arithmetics/src/extension.ts
+++ b/examples/arithmetics/src/extension.ts
@@ -6,7 +6,6 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { workspace } from 'vscode';
 import {
     LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
 } from 'vscode-languageclient/node';
@@ -39,12 +38,15 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.calc');
+    context.subscriptions.push(fileSystemWatcher);
+
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'arithmetics' }],
         synchronize: {
             // Notify the server about file changes to files contained in the workspace
-            fileEvents: workspace.createFileSystemWatcher('**/*.[".calc"]')
+            fileEvents: fileSystemWatcher
         }
     };
 

--- a/examples/domainmodel/src/extension.ts
+++ b/examples/domainmodel/src/extension.ts
@@ -6,7 +6,6 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { workspace } from 'vscode';
 import {
     LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
 } from 'vscode-languageclient/node';
@@ -39,12 +38,15 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.dmodel');
+    context.subscriptions.push(fileSystemWatcher);
+
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'domain-model' }],
         synchronize: {
             // Notify the server about file changes to files contained in the workspace
-            fileEvents: workspace.createFileSystemWatcher('**/*.[".dmodel"]')
+            fileEvents: fileSystemWatcher
         }
     };
 

--- a/examples/statemachine/src/extension.ts
+++ b/examples/statemachine/src/extension.ts
@@ -6,7 +6,6 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { workspace } from 'vscode';
 import {
     LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
 } from 'vscode-languageclient/node';
@@ -39,12 +38,15 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.statemachine');
+    context.subscriptions.push(fileSystemWatcher);
+
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'statemachine' }],
         synchronize: {
             // Notify the server about file changes to files contained in the workspace
-            fileEvents: workspace.createFileSystemWatcher('**/*.[".statemachine"]')
+            fileEvents: fileSystemWatcher
         }
     };
 

--- a/packages/generator-langium/langium-template/src/extension.ts
+++ b/packages/generator-langium/langium-template/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { workspace } from 'vscode';
 import {
     LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
 } from 'vscode-languageclient/node';
@@ -34,12 +33,15 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     };
 
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.<%= file-glob-extension %>');
+    context.subscriptions.push(fileSystemWatcher);
+
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: '<%= language-id %>' }],
         synchronize: {
             // Notify the server about file changes to files contained in the workspace
-            fileEvents: workspace.createFileSystemWatcher('**/*.<%= file-extension %>')
+            fileEvents: fileSystemWatcher
         }
     };
 

--- a/packages/generator-langium/src/index.ts
+++ b/packages/generator-langium/src/index.ts
@@ -18,6 +18,7 @@ const CLOSE = ' %>';
 const EXTENSION_NAME = 'extension-name';
 const RAW_LANGUAGE_NAME = 'RawLanguageName';
 const FILE_EXTENSION = 'file-extension';
+const FILE_EXTENSION_GLOB = 'file-glob-extension';
 
 const LANGUAGE_NAME = 'LanguageName';
 const LANGUAGE_ID = 'language-id';
@@ -78,21 +79,12 @@ class LangiumGenerator extends Generator {
     }
 
     writing(): void {
-        this.answers.fileExtensions =
-            '[' +
-            [
-                ...new Set(
-                    this.answers.fileExtensions
-                        .split(/\s*,\s*/)
-                        .map(
-                            (fileExtension: string) =>
-                                '".' +
-                                _.trim(fileExtension).replace(/\./, '') +
-                                '"'
-                        )
-                ),
-            ].join(', ') +
-            ']';
+        const fileExtensions = [...new Set(this.answers.fileExtensions.split(',').map(ext => {
+            return ext.trim().replace('.', '');
+        }))];
+        this.answers.fileExtensions = `[${fileExtensions.map(ext => `".${ext}"`).join(', ')}]`;
+
+        const fileExtensionGlob = fileExtensions.length > 1 ? `{${fileExtensions.join(',')}}` : fileExtensions[0];
 
         this.answers.rawLanguageName = this.answers.rawLanguageName.replace(
             /(?![\w| |\-|_])./g,
@@ -114,6 +106,7 @@ class LangiumGenerator extends Generator {
                         [EXTENSION_NAME, this.answers.extensionName],
                         [RAW_LANGUAGE_NAME, this.answers.rawLanguageName],
                         [FILE_EXTENSION, this.answers.fileExtensions],
+                        [FILE_EXTENSION_GLOB, fileExtensionGlob],
                         [LANGUAGE_NAME, languageName],
                         [LANGUAGE_ID, languageId],
                     ].reduce(

--- a/packages/langium-vscode/src/extension.ts
+++ b/packages/langium-vscode/src/extension.ts
@@ -6,7 +6,6 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { workspace } from 'vscode';
 import {
 	LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
 } from 'vscode-languageclient/node';
@@ -44,13 +43,16 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
 	  }
 	};
 
+	const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.langium');
+	context.subscriptions.push(fileSystemWatcher);
+
 	// Options to control the language client
 	const clientOptions: LanguageClientOptions = {
 	  // Register the server for langium documents
 	  documentSelector: [{ scheme: 'file', language: 'langium' }],
 	  synchronize: {
 		// Notify the server about file changes to langium files contained in the workspace
-		fileEvents: workspace.createFileSystemWatcher('**/*.langium')
+		fileEvents: fileSystemWatcher
 	  }
 	};
 


### PR DESCRIPTION
Closes #243

Also fixes an issue related to the glob pattern which was used in the yeoman generator. The generated pattern was incorrect and changes were never picked up.

You can test this by opening the `domain-model` example workspace and **only** open one of the files in vscode. Deleting/Changing files in the workspace outside of vscode should invalidate references. Changing them back or restoring them should create valid files again.