### PR TITLE
Store LSP range on CST nodes

### DIFF
--- a/examples/arithmetics/src/cli/interpreter.ts
+++ b/examples/arithmetics/src/cli/interpreter.ts
@@ -15,7 +15,7 @@ export const evalAction = async (fileName: string): Promise<void> => {
     for (const [evaluation, value] of interpretEvaluations(module)) {
         const cstNode = evaluation.expression.$cstNode;
         if (cstNode) {
-            const line = document.textDocument.positionAt(cstNode.offset).line + 1;
+            const line = cstNode.range.start.line + 1;
             console.log(`line ${line}:`, cstNode.text.green, '===>', value);
         }
     }

--- a/examples/domainmodel/langium-config.json
+++ b/examples/domainmodel/langium-config.json
@@ -8,7 +8,7 @@
     },
     "chevrotainParserConfig": {
         "recoveryEnabled": true,
-        "nodeLocationTracking": "onlyOffset",
+        "nodeLocationTracking": "full",
         "maxLookahead": 3
     }
 }

--- a/packages/langium/src/documents/document.ts
+++ b/packages/langium/src/documents/document.ts
@@ -65,22 +65,6 @@ export interface DocumentSegment {
     readonly end: number
 }
 
-export function toDocumentSegment(document: TextDocument, start: number, end: number): DocumentSegment {
-    const startPos = document.positionAt(start);
-    const endPos = document.positionAt(end);
-    return {
-        range: {
-            start: startPos,
-            end: endPos
-        },
-        offset: start,
-        end: end,
-        get length() {
-            return end - start;
-        }
-    };
-}
-
 export function documentFromText<T extends AstNode = AstNode>(textDocument: TextDocument, parseResult: ParseResult<T>): LangiumDocument<T> {
     const doc = {
         parseResult,

--- a/packages/langium/src/index/ast-descriptions.ts
+++ b/packages/langium/src/index/ast-descriptions.ts
@@ -6,12 +6,13 @@
 
 import { CancellationToken } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
-import { DocumentSegment, LangiumDocument, toDocumentSegment } from '../documents/document';
+import { DocumentSegment, LangiumDocument } from '../documents/document';
 import { Linker, getReferenceId } from '../references/linker';
 import { NameProvider } from '../references/naming';
 import { LangiumServices } from '../services';
 import { AstNode, AstNodeDescription, ReferenceInfo } from '../syntax-tree';
 import { getDocument, isLinkingError, streamAllContents, streamContents, streamReferences } from '../utils/ast-util';
+import { toDocumentSegment } from '../utils/cst-util';
 import { interruptAndCheck } from '../utils/promise-util';
 import { AstNodeLocator } from './ast-node-locator';
 
@@ -97,13 +98,13 @@ export class DefaultReferenceDescriptionProvider implements ReferenceDescription
                 return undefined;
             const doc = getDocument(refInfo.container);
             const docUri = doc.uri;
-            const refNodeRange = refInfo.reference.$refNode.range;
+            const refCstNode = refInfo.reference.$refNode;
             return {
                 sourceUri: docUri,
                 sourcePath: this.nodeLocator.getAstNodePath(refInfo.container),
                 targetUri: refAstNodeDescr.documentUri,
                 targetPath: refAstNodeDescr.path,
-                segment: toDocumentSegment(doc.textDocument, refNodeRange.start, refNodeRange.end),
+                segment: toDocumentSegment(refCstNode),
                 local: refAstNodeDescr.documentUri.toString() === docUri.toString()
             };
         };

--- a/packages/langium/src/lsp/completion/rule-interpreter.ts
+++ b/packages/langium/src/lsp/completion/rule-interpreter.ts
@@ -47,7 +47,7 @@ export class RuleInterpreter {
     featureMatches(feature: ast.AbstractElement, node: CstNode, offset: number): MatchType {
         if (ast.isKeyword(feature)) {
             const content = feature.value;
-            const nodeEnd = node.range.end;
+            const nodeEnd = node.end;
             const text = nodeEnd > offset ? node.text.substring(0, nodeEnd - offset) : node.text;
             if (content === text) {
                 return 'full';

--- a/packages/langium/src/lsp/document-highlighter.ts
+++ b/packages/langium/src/lsp/document-highlighter.ts
@@ -11,7 +11,6 @@ import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { AstNode, CstNode, Reference } from '../syntax-tree';
 import { findLeafNodeAtOffset, findLocalReferences, getDocument } from '../utils/ast-util';
-import { toRange } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 
 export interface DocumentHighlighter {
@@ -55,7 +54,7 @@ export class DefaultDocumentHighlighter implements DocumentHighlighter {
                 refs.push([ref.$refNode, this.getHighlightKind(ref.$refNode, ref)]);
             });
             return refs.map(([node, kind]) =>
-                DocumentHighlight.create(toRange(node, document), kind)
+                DocumentHighlight.create(node.range, kind)
             );
         }
         return undefined;

--- a/packages/langium/src/lsp/document-symbol-provider.ts
+++ b/packages/langium/src/lsp/document-symbol-provider.ts
@@ -38,20 +38,12 @@ export class DefaultDocumentSymbolProvider implements DocumentSymbolProvider {
         const node = astNode.$cstNode;
         const nameNode = this.nameProvider.getNameNode(astNode);
         if (nameNode && node) {
-            const { start, end } = node.range;
-            const { start: nameStart, end: nameEnd } = nameNode.range;
             const name = this.nameProvider.getName(astNode);
             return [{
                 kind: this.getSymbolKind(astNode.$type),
                 name: name ?? nameNode.text,
-                range: {
-                    start: document.textDocument.positionAt(start),
-                    end: document.textDocument.positionAt(end)
-                },
-                selectionRange: {
-                    start: document.textDocument.positionAt(nameStart),
-                    end: document.textDocument.positionAt(nameEnd)
-                },
+                range: node.range,
+                selectionRange: nameNode.range,
                 children: this.getChildSymbols(document, astNode)
             }];
         } else {

--- a/packages/langium/src/lsp/folding-range-provider.ts
+++ b/packages/langium/src/lsp/folding-range-provider.ts
@@ -109,19 +109,19 @@ export class DefaultFoldingRangeProvider implements FoldingRangeProvider {
     }
 
     protected toFoldingRange(document: LangiumDocument, node: CstNode, kind?: string): FoldingRange | undefined {
-        const { start, end } = node.range;
-        const startPosition = document.textDocument.positionAt(start);
-        let endPosition = document.textDocument.positionAt(end);
+        const range = node.range;
+        const start = range.start;
+        let end = range.end;
         // Don't generate foldings for nodes that are less than 3 lines
-        if (endPosition.line - startPosition.line < 2) {
+        if (end.line - start.line < 2) {
             return undefined;
         }
         // As we don't want to hide the end token like 'if { ... --> } <--',
         // we simply select the end of the previous line as the end position
         if (!this.includeLastFoldingLine(node, kind)) {
-            endPosition = document.textDocument.positionAt(document.textDocument.offsetAt({ line: endPosition.line, character: 0 }) - 1);
+            end = document.textDocument.positionAt(document.textDocument.offsetAt({ line: end.line, character: 0 }) - 1);
         }
-        return FoldingRange.create(startPosition.line, endPosition.line, startPosition.character, endPosition.character, kind);
+        return FoldingRange.create(start.line, end.line, start.character, end.character, kind);
     }
 
     /**

--- a/packages/langium/src/lsp/goto.ts
+++ b/packages/langium/src/lsp/goto.ts
@@ -11,7 +11,6 @@ import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { CstNode } from '../syntax-tree';
 import { findLeafNodeAtOffset, getDocument } from '../utils/ast-util';
-import { toRange } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 
 export interface GoToResolver {
@@ -52,9 +51,9 @@ export class DefaultGoToResolverProvider implements GoToResolver {
         }
         return targetCstNodes.map(link => LocationLink.create(
             link.targetDocument.textDocument.uri,
-            toRange(this.findActualNodeFor(link.target) ?? link.target, link.targetDocument),
-            toRange(link.target, link.targetDocument),
-            toRange(link.source, document)
+            (this.findActualNodeFor(link.target) ?? link.target).range,
+            link.target.range,
+            link.source.range
         ));
     }
     protected findActualNodeFor(cstNode: CstNode): CstNode | undefined {

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -106,8 +106,7 @@ export function addCompletionHandler(connection: Connection, services: LangiumSe
     const completionProvider = services.lsp.completion.CompletionProvider;
     connection.onCompletion(createHandler(
         (document, params, cancelToken) => {
-            const offset = document.textDocument.offsetAt(params.position);
-            return completionProvider.getCompletion(document, offset, params, cancelToken);
+            return completionProvider.getCompletion(document, params, cancelToken);
         },
         services
     ));

--- a/packages/langium/src/lsp/reference-finder.ts
+++ b/packages/langium/src/lsp/reference-finder.ts
@@ -12,7 +12,7 @@ import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { AstNode, CstNode } from '../syntax-tree';
 import { findLeafNodeAtOffset, getDocument, isReference } from '../utils/ast-util';
-import { flatten, toRange } from '../utils/cst-util';
+import { flatten } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 
 export interface ReferenceFinder {
@@ -50,11 +50,11 @@ export class DefaultReferenceFinder implements ReferenceFinder {
                 const declDoc = getDocument(targetAstNode);
                 const nameNode = this.findNameNode(targetAstNode, selectedNode.text);
                 if (nameNode)
-                    refs.push({ docUri: declDoc.uri, range: toRange(nameNode, declDoc) });
+                    refs.push({ docUri: declDoc.uri, range: nameNode.range });
             }
             this.references.findReferences(targetAstNode).forEach(reference => {
                 if (isReference(reference)) {
-                    refs.push({ docUri: document.uri, range: toRange(reference.$refNode, document) });
+                    refs.push({ docUri: document.uri, range: reference.$refNode.range });
                 } else {
                     const range = reference.segment.range;
                     refs.push({ docUri: reference.sourceUri, range });

--- a/packages/langium/src/lsp/rename-refactoring.ts
+++ b/packages/langium/src/lsp/rename-refactoring.ts
@@ -12,7 +12,6 @@ import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { CstNode } from '../syntax-tree';
 import { findLeafNodeAtOffset } from '../utils/ast-util';
-import { toRange } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { ReferenceFinder } from './reference-finder';
 
@@ -78,7 +77,7 @@ export class DefaultRenameHandler implements RenameHandler {
             const isCrossRef = this.references.findDeclaration(leafNode);
             // return range if selected CstNode is the name node or it is a crosslink which points to a declaration
             if (isCrossRef || this.isNameNode(leafNode)) {
-                return toRange(leafNode, doc);
+                return leafNode.range;
             }
         }
         return undefined;

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -6,7 +6,7 @@
 
 import { TokenType } from 'chevrotain';
 import { URI } from 'vscode-uri';
-import { LangiumDocument } from './documents/document';
+import { DocumentSegment, LangiumDocument } from './documents/document';
 import { AbstractElement } from './grammar/generated/ast';
 
 /**
@@ -90,15 +90,9 @@ export interface AstReflection {
 /**
  * A node in the Concrete Syntax Tree (CST).
  */
-export interface CstNode {
+export interface CstNode extends DocumentSegment {
     /** The container node in the CST */
     readonly parent?: CompositeCstNode;
-    /** Offset in the document text */
-    readonly offset: number;
-    /** Length of the text range */
-    readonly length: number;
-    /** Start and end offsets of the text range */
-    readonly range: CstRange;
     /** The actual text */
     readonly text: string;
     /** The root CST node */

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -92,7 +92,7 @@ export function expectCompletion(services: LangiumServices, expectEqual: ExpectF
         const document = await parseDocument(services, output);
         const completionProvider = services.lsp.completion.CompletionProvider;
         const offset = indices[expectedCompletion.index];
-        const completions = await completionProvider.getCompletion(document, offset, textDocumentPositionParams(document, offset));
+        const completions = await completionProvider.getCompletion(document, textDocumentPositionParams(document, offset));
         const items = completions.items.sort((a, b) => a.sortText?.localeCompare(b.sortText || '0') || 0);
         expectEqual(items.length, expectedCompletion.expectedItems.length);
         for (let i = 0; i < expectedCompletion.expectedItems.length; i++) {


### PR DESCRIPTION
Simplifies dealing with ranges when handling CST nodes by storing the position (line+character) info on the cst nodes. This alleviates the need to deal with range/offset transformation in different services.