### PR TITLE
Implement change affection computation #237

### DIFF
--- a/packages/langium/src/documents/document-builder.ts
+++ b/packages/langium/src/documents/document-builder.ts
@@ -95,7 +95,7 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
     }
 
     protected async buildDocument(document: LangiumDocument, cancelToken: CancellationToken): Promise<void> {
-        const affectedDocuments = this.indexManager.getAffectedDocuments(document);
+        const affectedDocuments = this.indexManager.getAffectedDocuments(document).toArray();
         affectedDocuments.forEach(e => {
             this.linker.unlink(e);
             e.state = DocumentState.Indexed;

--- a/packages/langium/src/documents/document.ts
+++ b/packages/langium/src/documents/document.ts
@@ -82,7 +82,7 @@ export function toDocumentSegment(document: TextDocument, start: number, end: nu
 }
 
 export function documentFromText<T extends AstNode = AstNode>(textDocument: TextDocument, parseResult: ParseResult<T>): LangiumDocument<T> {
-    const doc = {
+    const doc: LangiumDocument<T> = {
         parseResult,
         textDocument,
         uri: URI.parse(textDocument.uri),

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { getEntryRule, replaceTokens } from '../../lib';
+import { getEntryRule, replaceTokens } from '../../src';
 import { grammar } from '../../src/grammar/generated/grammar';
 
 describe('Token replacement', () => {


### PR DESCRIPTION
Closes #237 

Computes which documents are affected by changes in different documents. By default this affects documents with linking errors or ones which reference the changed document.