### PR TITLE
Extract string patterns for textmate grammar

### DIFF
--- a/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
+++ b/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
@@ -15,6 +15,16 @@
     {
       "name": "keyword.symbol.domain-model",
       "match": "(\\:|\\.|\\{|\\})"
+    },
+    {
+      "name": "string.quoted.double.domain-model",
+      "begin": "\"",
+      "end": "\""
+    },
+    {
+      "name": "string.quoted.single.domain-model",
+      "begin": "'",
+      "end": "'"
     }
   ],
   "repository": {

--- a/examples/statemachine/syntaxes/statemachine.tmLanguage.json
+++ b/examples/statemachine/syntaxes/statemachine.tmLanguage.json
@@ -15,6 +15,16 @@
     {
       "name": "keyword.symbol.statemachine",
       "match": "(\\{|\\}|\\=>)"
+    },
+    {
+      "name": "string.quoted.double.statemachine",
+      "begin": "\"",
+      "end": "\""
+    },
+    {
+      "name": "string.quoted.single.statemachine",
+      "begin": "'",
+      "end": "'"
     }
   ],
   "repository": {

--- a/packages/langium/src/utils/regex-util.ts
+++ b/packages/langium/src/utils/regex-util.ts
@@ -73,7 +73,7 @@ class CommentRegexVisitor extends BaseRegExpVisitor {
 
 const visitor = new CommentRegexVisitor();
 
-export function getCommentParts(regex: RegExp | string): Array<{ start: string, end: string }> {
+export function getTerminalParts(regex: RegExp | string): Array<{ start: string, end: string }> {
     try {
         if (typeof regex !== 'string') {
             regex = regex.source;

--- a/packages/langium/test/utils/regex-util.test.ts
+++ b/packages/langium/test/utils/regex-util.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { getCommentParts, isMultilineComment, partialMatches } from '../../src';
+import { getTerminalParts, isMultilineComment, partialMatches } from '../../src';
 
 describe('partial regex', () => {
 
@@ -97,21 +97,21 @@ describe('multiline comment detection', () => {
 describe('comment start/end parts', () => {
 
     test('JS style singleline comment should start with //', () => {
-        expect(getCommentParts(/\/\/[^\n\r]*/)).toEqual([{
+        expect(getTerminalParts(/\/\/[^\n\r]*/)).toEqual([{
             start: '//',
             end: ''
         }]);
     });
 
     test('JS style multiline comment should start with /* and end with */', () => {
-        expect(getCommentParts(/\/\*[\s\S]*?\*\//)).toEqual([{
+        expect(getTerminalParts(/\/\*[\s\S]*?\*\//)).toEqual([{
             start: '/\\*',
             end: '\\*/'
         }]);
     });
 
     test('JS style combined comment should contain both /* */ and // parts', () => {
-        expect(getCommentParts(/\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/)).toEqual([{
+        expect(getTerminalParts(/\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/)).toEqual([{
             start: '/\\*',
             end: '\\*/'
         }, {
@@ -121,7 +121,7 @@ describe('comment start/end parts', () => {
     });
 
     test('Shell style single line comment starts with #', () => {
-        expect(getCommentParts(/#[^\n\r]*/)).toEqual([{
+        expect(getTerminalParts(/#[^\n\r]*/)).toEqual([{
             start: '#',
             end: ''
         }]);


### PR DESCRIPTION
Closes #281

Extracts string patterns from the grammar to generate the textmate grammar. The issue only occurred because there was no string pattern in the textmate grammar in the first place, which would've prevented the keyword/comment pattern to be highlighted.