### PR TITLE
Correctly escape keywords for textmate and remove symbols

### DIFF
--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -11,10 +11,6 @@
     {
       "name": "keyword.control.arithmetics",
       "match": "\\b(def|module)\\b"
-    },
-    {
-      "name": "keyword.symbol.arithmetics",
-      "match": "(\\-|\\,|\\;|\\:|\\(|\\)|\\*|\\/|\\+)"
     }
   ],
   "repository": {

--- a/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
+++ b/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
@@ -13,10 +13,6 @@
       "match": "\\b(datatype|entity|extends|many|package)\\b"
     },
     {
-      "name": "keyword.symbol.domain-model",
-      "match": "(\\:|\\.|\\{|\\})"
-    },
-    {
       "name": "string.quoted.double.domain-model",
       "begin": "\"",
       "end": "\""

--- a/examples/statemachine/syntaxes/statemachine.tmLanguage.json
+++ b/examples/statemachine/syntaxes/statemachine.tmLanguage.json
@@ -13,10 +13,6 @@
       "match": "\\b(actions|commands|end|events|initialState|state|statemachine)\\b"
     },
     {
-      "name": "keyword.symbol.statemachine",
-      "match": "(\\{|\\}|\\=>)"
-    },
-    {
       "name": "string.quoted.double.statemachine",
       "begin": "\"",
       "end": "\""

--- a/packages/langium-cli/src/generator/textmate-generator.ts
+++ b/packages/langium-cli/src/generator/textmate-generator.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import * as langium from 'langium';
-import { getTerminalParts, isCommentTerminal, isTerminalRule } from 'langium';
+import { escapeRegExp, getTerminalParts, isCommentTerminal, isTerminalRule } from 'langium';
 import { LangiumConfig } from '../package';
 import { collectKeywords } from './util';
 
@@ -63,8 +63,7 @@ function getPatterns(grammar: langium.Grammar, config: LangiumConfig): Pattern[]
     patterns.push({
         include: '#comments'
     });
-    patterns.push(getKeywordControl(grammar, config));
-    patterns.push(getKeywordSymbols(grammar, config));
+    patterns.push(getControlKeywords(grammar, config));
     patterns.push(...getStringPatterns(grammar, config));
     return patterns;
 }
@@ -115,21 +114,13 @@ function getRepository(grammar: langium.Grammar, config: LangiumConfig): Reposit
     return repository;
 }
 
-function getKeywordControl(grammar: langium.Grammar, pack: LangiumConfig): Pattern {
-    const regex = /[A-Za-z]+/;
-    const keywords = collectKeywords(grammar).filter(kw => regex.test(kw));
+function getControlKeywords(grammar: langium.Grammar, pack: LangiumConfig): Pattern {
+    const regex = /[A-Za-z]/;
+    const controlKeywords = collectKeywords(grammar).filter(kw => regex.test(kw));
+    const keywords = controlKeywords.map(escapeRegExp);
     return {
         'name': `keyword.control.${pack.languageId}`,
         'match': `\\b(${keywords.join('|')})\\b`
-    };
-}
-function getKeywordSymbols(grammar: langium.Grammar, pack: LangiumConfig): Pattern {
-    const regex = /\W/;
-    const keywordsFiltered = collectKeywords(grammar).filter(kw => regex.test(kw));
-    const keywords = keywordsFiltered.map(kw => `\\${kw}`);
-    return {
-        'name': `keyword.symbol.${pack.languageId}`,
-        'match': `(${keywords.join('|')})`
     };
 }
 

--- a/packages/langium/src/utils/regex-util.ts
+++ b/packages/langium/src/utils/regex-util.ts
@@ -110,7 +110,7 @@ export function isMultilineComment(regex: RegExp | string): boolean {
     }
 }
 
-function escapeRegExp(value: string): string {
+export function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 


### PR DESCRIPTION
Closes #292 

Also fixes a bug that prevents correct highlighting when the input isn't regex escaped.