### PR TITLE
Replace '|' with ':' in cross-references

### DIFF
--- a/examples/domainmodel/src/language-server/domain-model.langium
+++ b/examples/domainmodel/src/language-server/domain-model.langium
@@ -18,12 +18,12 @@ DataType:
     'datatype' name=ID;
 
 Entity:
-    'entity' name=ID ('extends' superType=[Entity|QualifiedName])? '{'
+    'entity' name=ID ('extends' superType=[Entity:QualifiedName])? '{'
         (features+=Feature)*
     '}';
 
 Feature:
-    (many?='many')? name=ID ':' type=[Type|QualifiedName];
+    (many?='many')? name=ID ':' type=[Type:QualifiedName];
 
 QualifiedName returns string:
     ID ('.' ID)*;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -151,6 +151,7 @@ export function isCharacterRange(item: unknown): item is CharacterRange {
 }
 
 export interface CrossReference extends AbstractElement {
+    deprecatedSyntax: boolean
     terminal: AbstractElement
     type: Reference<ParserRule>
 }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -2000,9 +2000,19 @@ export const grammar = (): Grammar => loaded || (loaded = loadGrammar(`{
             "$type": "Group",
             "elements": [
               {
-                "$type": "Keyword",
-                "value": "|",
-                "elements": []
+                "$type": "Alternatives",
+                "elements": [
+                  {
+                    "$type": "Keyword",
+                    "value": "|",
+                    "elements": []
+                  },
+                  {
+                    "$type": "Keyword",
+                    "value": ":",
+                    "elements": []
+                  }
+                ]
               },
               {
                 "$type": "Assignment",

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -2003,8 +2003,13 @@ export const grammar = (): Grammar => loaded || (loaded = loadGrammar(`{
                 "$type": "Alternatives",
                 "elements": [
                   {
-                    "$type": "Keyword",
-                    "value": "|",
+                    "$type": "Assignment",
+                    "feature": "deprecatedSyntax",
+                    "operator": "?=",
+                    "terminal": {
+                      "$type": "Keyword",
+                      "value": "|"
+                    },
                     "elements": []
                   },
                   {

--- a/packages/langium/src/grammar/langium-grammar-code-actions.ts
+++ b/packages/langium/src/grammar/langium-grammar-code-actions.ts
@@ -38,9 +38,9 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
                 return this.fixHiddenTerminals(diagnostic, document);
             case IssueCodes.UseRegexTokens:
                 return this.fixRegexTokens(diagnostic, document);
-            case IssueCodes.MakeRuleEntry:
+            case IssueCodes.EntryRuleTokenSyntax:
                 return this.addEntryKeyword(diagnostic, document);
-            case IssueCodes.CrossRefSyntaxFix:
+            case IssueCodes.CrossRefTokenSyntax:
                 return this.fixCrossRefSyntax(diagnostic, document);
             default:
                 return undefined;
@@ -119,7 +119,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
 
     private fixCrossRefSyntax(diagnostic: Diagnostic, document: LangiumDocument): CodeAction {
         return {
-            title: 'Replace \'|\' with \':\'',
+            title: "Replace '|' with ':'",
             kind: CodeActionKind.QuickFix,
             diagnostics: [diagnostic],
             isPreferred: true,
@@ -127,7 +127,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
                 changes: {
                     [document.textDocument.uri]: [{
                         range: diagnostic.range,
-                        newText: document.textDocument.getText(diagnostic.range).replace(/\|/, ':')
+                        newText: ':'
                     }]
                 }
             }

--- a/packages/langium/src/grammar/langium-grammar-code-actions.ts
+++ b/packages/langium/src/grammar/langium-grammar-code-actions.ts
@@ -40,6 +40,8 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
                 return this.fixRegexTokens(diagnostic, document);
             case IssueCodes.MakeRuleEntry:
                 return this.addEntryKeyword(diagnostic, document);
+            case IssueCodes.CrossRefSyntaxFix:
+                return this.fixCrossRefSyntax(diagnostic, document);
             default:
                 return undefined;
         }
@@ -113,6 +115,23 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
             }
         }
         return undefined;
+    }
+
+    private fixCrossRefSyntax(diagnostic: Diagnostic, document: LangiumDocument): CodeAction {
+        return {
+            title: 'Replace \'|\' with \':\'',
+            kind: CodeActionKind.QuickFix,
+            diagnostics: [diagnostic],
+            isPreferred: true,
+            edit: {
+                changes: {
+                    [document.textDocument.uri]: [{
+                        range: diagnostic.range,
+                        newText: document.textDocument.getText(diagnostic.range).replace(/\|/, ':')
+                    }]
+                }
+            }
+        };
     }
 
     private fixHiddenTerminals(diagnostic: Diagnostic, document: LangiumDocument): CodeAction {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -40,7 +40,8 @@ export class LangiumGrammarValidationRegistry extends ValidationRegistry {
             ],
             CharacterRange: validator.checkInvalidCharacterRange,
             RuleCall: validator.checkUsedHiddenTerminalRule,
-            TerminalRuleCall: validator.checkUsedHiddenTerminalRule
+            TerminalRuleCall: validator.checkUsedHiddenTerminalRule,
+            CrossReference: validator.checkCrossReferenceSyntax
         };
         this.register(checks, validator);
     }
@@ -53,6 +54,7 @@ export namespace IssueCodes {
     export const HiddenGrammarTokens = 'hidden-grammar-tokens';
     export const UseRegexTokens = 'use-regex-tokens';
     export const MakeRuleEntry = 'entry-rule-token-syntax';
+    export const CrossRefSyntaxFix = 'cross-ref-syntax-fix';
 }
 
 export class LangiumGrammarValidator {
@@ -143,6 +145,12 @@ export class LangiumGrammarValidator {
             if (ast.isTerminalRule(ref) && ref.hidden) {
                 accept('error', 'Cannot use hidden terminal in non-hidden rule', { node: ruleCall, property: 'rule' });
             }
+        }
+    }
+
+    checkCrossReferenceSyntax(crossRef: ast.CrossReference, accept: ValidationAcceptor): void {
+        if (crossRef.terminal && crossRef.$cstNode?.text.includes('|')) {
+            accept('error', '\'|\' is depreceted. Please, use \':\' instead.', { node: crossRef, code: IssueCodes.CrossRefSyntaxFix });
         }
     }
 

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -53,8 +53,8 @@ export namespace IssueCodes {
     export const RuleNameUppercase = 'rule-name-uppercase';
     export const HiddenGrammarTokens = 'hidden-grammar-tokens';
     export const UseRegexTokens = 'use-regex-tokens';
-    export const MakeRuleEntry = 'entry-rule-token-syntax';
-    export const CrossRefSyntaxFix = 'cross-ref-syntax-fix';
+    export const EntryRuleTokenSyntax = 'entry-rule-token-syntax';
+    export const CrossRefTokenSyntax = 'cross-ref-token-syntax';
 }
 
 export class LangiumGrammarValidator {
@@ -79,7 +79,7 @@ export class LangiumGrammarValidator {
         if (entryRules.length === 0) {
             const possibleEntryRule = grammar.rules.find(e => ast.isParserRule(e) && !isDataTypeRule(e));
             if (possibleEntryRule) {
-                accept('error', 'The grammar is missing an entry parser rule. This rule can be an entry one.', { node: possibleEntryRule, property: 'name', code: IssueCodes.MakeRuleEntry });
+                accept('error', 'The grammar is missing an entry parser rule. This rule can be an entry one.', { node: possibleEntryRule, property: 'name', code: IssueCodes.EntryRuleTokenSyntax });
             } else {
                 accept('error', 'This grammar is missing an entry parser rule.', { node: grammar, property: 'name' });
             }
@@ -149,8 +149,8 @@ export class LangiumGrammarValidator {
     }
 
     checkCrossReferenceSyntax(crossRef: ast.CrossReference, accept: ValidationAcceptor): void {
-        if (crossRef.terminal && crossRef.$cstNode?.text.includes('|')) {
-            accept('error', '\'|\' is depreceted. Please, use \':\' instead.', { node: crossRef, code: IssueCodes.CrossRefSyntaxFix });
+        if (crossRef.deprecatedSyntax) {
+            accept('error', "'|' is deprecated. Please, use ':' instead.", { node: crossRef, property: 'deprecatedSyntax', code: IssueCodes.CrossRefTokenSyntax });
         }
     }
 

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -9,8 +9,8 @@ hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;
 
 entry Grammar:
-	'grammar' name=ID ('with' usedGrammars+=[Grammar|ID] (',' usedGrammars+=[Grammar|ID])*)?
-	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule|ID] (',' hiddenTokens+=[AbstractRule|ID])*)? ')')?
+	'grammar' name=ID ('with' usedGrammars+=[Grammar:ID] (',' usedGrammars+=[Grammar:ID])*)?
+	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')?
 	metamodelDeclarations+=AbstractMetamodelDeclaration*
 	(rules+=AbstractRule)+;
 
@@ -34,7 +34,7 @@ ParserRule :
 	  (^entry?='entry' | ^fragment?='fragment') RuleNameAndParams (wildcard?='*' | ('returns' type=ID)?)
 	| RuleNameAndParams ('returns' type=ID)?
 	)
-	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule|ID] (',' hiddenTokens+=[AbstractRule|ID])*)? ')')? ':'
+	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
 		alternatives=Alternatives
 	';';
 
@@ -75,10 +75,10 @@ Keyword:
 	value=string;
 
 RuleCall:
-	rule=[AbstractRule|ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
+	rule=[AbstractRule:ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
 
 NamedArgument:
-	( parameter=[Parameter|ID] calledByName?= '=')?
+	( parameter=[Parameter:ID] calledByName?= '=')?
 	( value=Disjunction );
 
 LiteralCondition:
@@ -100,13 +100,13 @@ ParenthesizedCondition returns Condition:
 	'(' Disjunction ')';
 
 ParameterReference:
-	parameter=[Parameter|ID];
+	parameter=[Parameter:ID];
 
 PredicatedKeyword returns Keyword:
 	(predicated?='=>' | firstSetPredicated?='->') value=string;
 
 PredicatedRuleCall returns RuleCall:
-	(predicated?='=>' | firstSetPredicated?='->') rule=[AbstractRule|ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
+	(predicated?='=>' | firstSetPredicated?='->') rule=[AbstractRule:ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
 
 Assignment returns AbstractElement:
 	{Assignment} (predicated?='=>' | firstSetPredicated?='->')? feature=ID operator=('+='|'='|'?=') ^terminal=AssignableTerminal;
@@ -121,7 +121,7 @@ AssignableAlternatives returns AbstractElement:
 	AssignableTerminal ({Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
 CrossReference returns AbstractElement:
-	{CrossReference} '[' type=[ParserRule|ID] (('|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
+	{CrossReference} '[' type=[ParserRule:ID] (('|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
 
 CrossReferenceableTerminal returns AbstractElement:
 	Keyword | RuleCall;
@@ -155,7 +155,7 @@ ParenthesizedTerminalElement returns AbstractElement:
 	'(' TerminalAlternatives ')';
 
 TerminalRuleCall returns AbstractElement:
-	{TerminalRuleCall} rule=[TerminalRule|ID];
+	{TerminalRuleCall} rule=[TerminalRule:ID];
 
 NegatedToken returns AbstractElement:
 	{NegatedToken} '!' ^terminal=TerminalTokenElement;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -121,7 +121,7 @@ AssignableAlternatives returns AbstractElement:
 	AssignableTerminal ({Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
 CrossReference returns AbstractElement:
-	{CrossReference} '[' type=[ParserRule:ID] (('|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
+	{CrossReference} '[' type=[ParserRule:ID] ((deprecatedSyntax?='|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
 
 CrossReferenceableTerminal returns AbstractElement:
 	Keyword | RuleCall;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -121,7 +121,7 @@ AssignableAlternatives returns AbstractElement:
 	AssignableTerminal ({Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
 CrossReference returns AbstractElement:
-	{CrossReference} '[' type=[ParserRule|ID] ('|' ^terminal=CrossReferenceableTerminal )? ']';
+	{CrossReference} '[' type=[ParserRule|ID] (('|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
 
 CrossReferenceableTerminal returns AbstractElement:
 	Keyword | RuleCall;


### PR DESCRIPTION
Closes [#200](https://github.com/langium/langium/issues/200).