### PR TITLE
Add correct flat type

### DIFF
--- a/packages/langium/src/utils/stream.ts
+++ b/packages/langium/src/utils/stream.ts
@@ -231,10 +231,12 @@ export interface Stream<T> extends Iterable<T> {
 
 export type FlatStream<T, Depth extends number> = {
     'done': Stream<T>,
-    'recur': T extends Array<infer InnerArr>
-        ? FlatStream<InnerArr, [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20][Depth]>
+    'recur': T extends Iterable<infer Content>
+        ? FlatStream<Content, MinusOne<Depth>>
         : Stream<T>
 }[Depth extends 0 ? 'done' : 'recur'];
+
+export type MinusOne<N extends number> = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20][N];
 
 /**
  * The default implementation of `Stream` works with two input functions:

--- a/packages/langium/test/utils/stream.test.ts
+++ b/packages/langium/test/utils/stream.test.ts
@@ -448,6 +448,12 @@ describe('Stream.flatMap', () => {
 
 describe('Stream.flat', () => {
 
+    test('compiles to correct type', () => {
+        const stream = s.stream([[1, 2], [[3, 4]]]);
+        const flattened: s.Stream<number> = stream.flat(2);
+        expect(flattened.toArray()).toMatchObject([1, 2, 3, 4]);
+    });
+
     test('one level', () => {
         const stream = s.stream([1, [2, [3, [4, [5]]]]]);
         expect(stream.flat().toArray()).toMatchObject([1, 2, [3, [4, [5]]]]);

--- a/packages/langium/test/utils/stream.test.ts
+++ b/packages/langium/test/utils/stream.test.ts
@@ -448,8 +448,14 @@ describe('Stream.flatMap', () => {
 
 describe('Stream.flat', () => {
 
-    test('compiles to correct type', () => {
+    test('correct type with arrays', () => {
         const stream = s.stream([[1, 2], [[3, 4]]]);
+        const flattened: s.Stream<number> = stream.flat(2);
+        expect(flattened.toArray()).toMatchObject([1, 2, 3, 4]);
+    });
+
+    test('correct type with streams', () => {
+        const stream = s.stream([s.stream([1, 2]), s.stream([s.stream([3, 4])])]);
         const flattened: s.Stream<number> = stream.flat(2);
         expect(flattened.toArray()).toMatchObject([1, 2, 3, 4]);
     });


### PR DESCRIPTION
Changes the return type for `Stream.flat` from `Stream<T>` to `FlatStream<T, D>`.

Contains a lot of casting, since the flat operation isn't really typesafe. For example a call like `stream.flat<5>()` will flatten the stream only by a single layer, while the actual type is flattened by 5 layers. Consumers of this method should never use the generic parameter and only call this using `stream.flat(5)`. (`Array.flat` has the same problem)