### PR TITLE
Fix in cross-references

### DIFF
--- a/packages/langium/src/workspace/ast-descriptions.ts
+++ b/packages/langium/src/workspace/ast-descriptions.ts
@@ -10,7 +10,7 @@ import { getReferenceId, Linker } from '../references/linker';
 import { NameProvider } from '../references/naming';
 import { LangiumServices } from '../services';
 import { AstNode, AstNodeDescription, ReferenceInfo } from '../syntax-tree';
-import { getDocument, isLinkingError, streamAllContents, streamContents, streamReferences } from '../utils/ast-util';
+import { getDocument, isLinkingError, streamAllContents, streamReferences } from '../utils/ast-util';
 import { toDocumentSegment } from '../utils/cst-util';
 import { interruptAndCheck } from '../utils/promise-util';
 import { AstNodeLocator } from './ast-node-locator';
@@ -67,7 +67,7 @@ export class DefaultAstNodeDescriptionProvider implements AstNodeDescriptionProv
         if (name) {
             descr.push(this.createDescription(rootNode, name, document));
         }
-        for (const content of streamContents(rootNode)) {
+        for (const content of streamAllContents(rootNode)) {
             await interruptAndCheck(cancelToken);
             const name = this.nameProvider.getName(content.node);
             if (name) {


### PR DESCRIPTION
This PR comes from [336](https://github.com/langium/langium/discussions/336), and the main goal is to evaluate a minor fix.

In resume: Cross-reference are not detected if this references are out of the scopes. In  [domain model example index ](https://github.com/langium/langium/blob/main/examples/domainmodel/src/language-server/domain-model-index.ts) fix it by using streamAllContent() instead of streamContent().  The initial proposal is to change [DefaultAstNodeDescriptionProvider ](https://github.com/langium/langium/blob/main/packages/langium/src/workspace/ast-descriptions.ts) to use streamAllContent(). It fix the issue, and cross-file cross-reference still works. 

Probably there will be cases where we want that the cross-reference cannot be detected if it is not in the scope. In this case, maybe developing a way to express the scope of the cross-reference(global/local) in the grammar could be a better solution.

![Captura de pantalla 2022-01-06 222249](https://user-images.githubusercontent.com/5485515/148455073-a81f21bb-cb21-46a2-bf5b-1be24e50bd86.png)
![Captura de pantalla 2022-01-06 222134](https://user-images.githubusercontent.com/5485515/148455076-fc498cbd-4800-4e65-8e0b-8aaf913c022c.png)




