### PR TITLE
Support rule parameter and arguments

### DIFF
--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -9,7 +9,7 @@ import { AstNode, AstReflection, Reference } from '../../syntax-tree';
 import { isAstNode } from '../../utils/ast-util';
 
 export interface AbstractElement extends AstNode {
-    readonly $container: ParserRule | Alternatives | UnorderedGroup | Group | Assignment | CrossReference | TerminalRule | TerminalAlternatives | TerminalGroup | NegatedToken | UntilToken | CharacterRange;
+    readonly $container: ParserRule | Alternatives | Group | UnorderedGroup | Assignment | CrossReference | TerminalRule | TerminalAlternatives | TerminalGroup | NegatedToken | UntilToken | CharacterRange;
     cardinality: '?' | '*' | '+'
 }
 
@@ -33,7 +33,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
 }
 
 export interface Condition extends AstNode {
-    readonly $container: NamedArgument | Disjunction | Conjunction | Negation;
+    readonly $container: Group | NamedArgument | Disjunction | Conjunction | Negation;
 }
 
 export const Condition = 'Condition';
@@ -154,6 +154,7 @@ export function isCrossReference(item: unknown): item is CrossReference {
 export interface Group extends AbstractElement {
     elements: Array<AbstractElement>
     firstSetPredicated: boolean
+    guardCondition: Condition
     predicated: boolean
 }
 

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -603,7 +603,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "$type": "RuleCall",
             "arguments": [],
             "rule": {
-              "$refText": "UnorderedGroup"
+              "$refText": "ConditionalBranch"
             },
             "elements": []
           },
@@ -633,7 +633,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "$type": "RuleCall",
                       "arguments": [],
                       "rule": {
-                        "$refText": "UnorderedGroup"
+                        "$refText": "ConditionalBranch"
                       }
                     }
                   }
@@ -642,6 +642,70 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               }
             ],
             "cardinality": "?"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "ConditionalBranch",
+      "hiddenTokens": [],
+      "type": "AbstractElement",
+      "alternatives": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "UnorderedGroup"
+            },
+            "elements": []
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Action",
+                "type": "Group",
+                "elements": []
+              },
+              {
+                "$type": "Keyword",
+                "value": "<"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "guardCondition",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "Disjunction"
+                  }
+                }
+              },
+              {
+                "$type": "Keyword",
+                "value": ">"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "elements",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "AbstractToken"
+                  }
+                },
+                "elements": [],
+                "cardinality": "+"
+              }
+            ]
           }
         ]
       }
@@ -1203,7 +1267,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 }
               }
             ],
-            "cardinality": "?"
+            "cardinality": "*"
           }
         ]
       }
@@ -1252,7 +1316,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 }
               }
             ],
-            "cardinality": "?"
+            "cardinality": "*"
           }
         ]
       }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -32,7 +32,12 @@ Parameter:
 	name=ID;
 
 Alternatives returns AbstractElement:
-	UnorderedGroup ({Alternatives.elements+=current} ('|' elements+=UnorderedGroup)+)?;
+	ConditionalBranch ({Alternatives.elements+=current} ('|' elements+=ConditionalBranch)+)?;
+
+ConditionalBranch returns AbstractElement:
+	  UnorderedGroup
+	| {Group} '<' guardCondition=Disjunction '>' (elements+=AbstractToken)+
+;
 
 UnorderedGroup returns AbstractElement:
 	Group ({UnorderedGroup.elements+=current} ('&' elements+=Group)+)?;
@@ -72,10 +77,10 @@ LiteralCondition:
 	^true?='true' | 'false';
 
 Disjunction returns Condition:
-	Conjunction ({Disjunction.left=current} '|' right=Conjunction)?;
+	Conjunction ({Disjunction.left=current} '|' right=Conjunction)*;
 
 Conjunction returns Condition:
-	Negation ({Conjunction.left=current} '&' right=Negation)?;
+	Negation ({Conjunction.left=current} '&' right=Negation)*;
 
 Negation returns Condition:
 	Atom | {Negation} '!' value=Negation;

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -5,8 +5,8 @@
  ******************************************************************************/
 
 import { Lexer, TokenPattern, TokenType } from 'chevrotain';
-import { terminalRegex } from '..';
-import { Grammar, isKeyword, isTerminalRule, Keyword, TerminalRule } from '../grammar/generated/ast';
+import { Grammar, isKeyword, isParserRule, isTerminalRule, Keyword, TerminalRule } from '../grammar/generated/ast';
+import { terminalRegex } from '../grammar/grammar-util';
 import { streamAllContents } from '../utils/ast-util';
 import { getCaseInsensitivePattern, partialMatches } from '../utils/regex-util';
 import { stream } from '../utils/stream';
@@ -32,7 +32,9 @@ export class DefaultTokenBuilder implements TokenBuilder {
         }
 
         const tokens: TokenType[] = [];
-        const keywords = streamAllContents(grammar).map(e => e.node).filter(isKeyword).distinct(e => e.value).toArray()
+        // We filter by parser rules, since keywords in terminal rules get transformed into regex and are not actual tokens
+        const parserRuleKeywords = grammar.rules.filter(isParserRule).flatMap(rule => streamAllContents(rule).map(e => e.node).filter(isKeyword).toArray());
+        const keywords = stream(parserRuleKeywords).distinct(e => e.value).toArray()
             // Sort keywords by descending length
             .sort((a, b) => b.value.length - a.value.length);
 

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createDefaultModule, createDefaultSharedModule, createLangiumGrammarServices, createLangiumParser, Grammar, inject, IParserConfig, LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumParser, LangiumServices, LangiumSharedServices, Module } from '../../src';
+import { parseHelper } from '../../src/test';
+
+const grammarServices = createLangiumGrammarServices().grammar;
+const helper = parseHelper<Grammar>(grammarServices);
+
+describe('Predicated grammar rules', () => {
+
+    let grammar: Grammar;
+    let parser: LangiumParser;
+    const content = `
+    grammar TestGrammar
+
+    entry Main: RuleA | RuleB | RuleC | RuleD | RuleE | RuleF | RuleG;
+
+    RuleA: 'a' TestSimple<true, true>;
+    RuleB: 'b' TestSimple<false, true>;
+    RuleC: 'c' TestSimple<true, false>;
+    RuleD: 'd' TestSimple<false, false>;
+    RuleE: 'e' TestComplex<true, true, true>;
+    RuleF: 'f' TestComplex<true, false, true>;
+    RuleG: 'g' TestComplex<false, true, false>;
+
+    TestSimple<A, B>: <A & B> a=ID | <B> b=ID | <A> c=ID | <!A> d=ID;
+    TestComplex<A, B, C>: <A & B & C> e=ID | <(B | C) & A> f=ID | <A | (C & false) | B> g=ID;
+
+    terminal ID: '1';
+    `;
+
+    beforeAll(async () => {
+        grammar = (await helper(content)).document.parseResult.value;
+        parser = parserFromGrammar(grammar);
+    });
+
+    function hasProp(prop: string): void {
+        const main = parser.parse(prop + '1').value;
+        expect(main).toHaveProperty(prop);
+    }
+
+    test('Should parse RuleA correctly', () => {
+        hasProp('a');
+    });
+
+    test('Should parse RuleB correctly', () => {
+        hasProp('b');
+    });
+
+    test('Should parse RuleC correctly', () => {
+        hasProp('c');
+    });
+
+    test('Should parse RuleD correctly', () => {
+        hasProp('d');
+    });
+
+    test('Should parse RuleE correctly', () => {
+        hasProp('e');
+    });
+
+    test('Should parse RuleF correctly', () => {
+        hasProp('f');
+    });
+
+    test('Should parse RuleG correctly', () => {
+        hasProp('g');
+    });
+
+});
+
+function parserFromGrammar(grammar: Grammar): LangiumParser {
+    const parserConfig: IParserConfig = {
+        skipValidations: false
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const unavailable: () => any = () => ({});
+    const generatedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedServices> = {
+        AstReflection: unavailable,
+    };
+    const generatedModule: Module<LangiumServices, LangiumGeneratedServices> = {
+        Grammar: () => grammar,
+        LanguageMetaData: unavailable,
+        parser: {
+            ParserConfig: () => parserConfig
+        }
+    };
+    const shared = inject(createDefaultSharedModule(), generatedSharedModule);
+    const services = inject(createDefaultModule({ shared }), generatedModule);
+    return createLangiumParser(services);
+}


### PR DESCRIPTION
Accidentally fixes https://github.com/langium/langium/issues/313 (My tests wouldn't run without fixing it)

Makes use of Chevrotain's semantic predicate feature to build `GATES` from the guard conditions of alternatives. Also adds validations to check for the correct amount of arguments and unused rule parameters.