### PR TITLE
Validate duplicate imported grammar rules

### DIFF
--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -348,8 +348,18 @@ export function resolveImport(documents: LangiumDocuments, imp: ast.GrammarImpor
     return undefined;
 }
 
-export function resolveTransitiveImports(documents: LangiumDocuments, grammar: ast.Grammar): ast.Grammar[] {
-    return resolveTransitiveImportsInternal(documents, grammar);
+export function resolveTransitiveImports(documents: LangiumDocuments, grammar: ast.Grammar | ast.GrammarImport): ast.Grammar[] {
+    if (ast.isGrammarImport(grammar)) {
+        const resolvedGrammar = resolveImport(documents, grammar);
+        if (resolvedGrammar) {
+            const transitiveGrammars = resolveTransitiveImportsInternal(documents, resolvedGrammar);
+            transitiveGrammars.push(resolvedGrammar);
+            return transitiveGrammars;
+        }
+        return [];
+    } else {
+        return resolveTransitiveImportsInternal(documents, grammar);
+    }
 }
 
 function resolveTransitiveImportsInternal(documents: LangiumDocuments, grammar: ast.Grammar, initialGrammar = grammar, visited: Set<URI> = new Set(), grammars: Set<ast.Grammar> = new Set()): ast.Grammar[] {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -11,6 +11,7 @@ import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { getContainerOfType, getDocument, streamAllContents } from '../utils/ast-util';
 import { MultiMap } from '../utils/collections';
+import { stream } from '../utils/stream';
 import { ValidationAcceptor, ValidationCheck, ValidationRegistry } from '../validation/validation-registry';
 import { LangiumDocument, LangiumDocuments } from '../workspace/documents';
 import * as ast from './generated/ast';
@@ -39,6 +40,7 @@ export class LangiumGrammarValidationRegistry extends ValidationRegistry {
                 validator.checkGrammarName,
                 validator.checkEntryGrammarRule,
                 validator.checkUniqueRuleName,
+                validator.checkUniqueImportedRules,
                 validator.checkGrammarHiddenTokens,
                 validator.checkGrammarForUnusedRules,
                 validator.checkGrammarImports
@@ -99,6 +101,9 @@ export class LangiumGrammarValidator {
         }
     }
 
+    /**
+     * Check whether any rule defined in this grammar is a duplicate of an already defined rule or an imported rule
+     */
     checkUniqueRuleName(grammar: ast.Grammar, accept: ValidationAcceptor): void {
         const ruleMap = new MultiMap<string, ast.AbstractRule>();
         for (const rule of grammar.rules) {
@@ -112,6 +117,69 @@ export class LangiumGrammarValidator {
                 });
             }
         }
+        const importedRules = new Set<string>();
+        const resolvedGrammars = resolveTransitiveImports(this.documents, grammar);
+        for (const resolvedGrammar of resolvedGrammars) {
+            for (const rule of resolvedGrammar.rules) {
+                importedRules.add(rule.name.toLowerCase());
+            }
+        }
+        for (const name of ruleMap.keys()) {
+            if (importedRules.has(name)) {
+                const rules = ruleMap.get(name);
+                rules.forEach(e => {
+                    accept('error', `A rule with the name '${e.name}' already exists in an imported grammar.`, { node: e, property: 'name' });
+                });
+            }
+        }
+    }
+
+    /**
+     * Compared to the validation above, this validation only checks whether two imported grammars export the same grammar rule.
+     */
+    checkUniqueImportedRules(grammar: ast.Grammar, accept: ValidationAcceptor): void {
+        const imports = new Map<ast.GrammarImport, ast.Grammar[]>();
+        for (const imp of grammar.imports) {
+            const importedGrammars = resolveTransitiveImports(this.documents, imp);
+            imports.set(imp, importedGrammars);
+        }
+        const allDuplicates = new MultiMap<ast.GrammarImport, string>();
+        for (const outerImport of grammar.imports) {
+            const outerGrammars = imports.get(outerImport)!;
+            for (const innerImport of grammar.imports) {
+                if (outerImport === innerImport) {
+                    continue;
+                }
+                const innerGrammars = imports.get(innerImport)!;
+                const duplicates = this.getDuplicateExportedRules(outerGrammars, innerGrammars);
+                for (const duplicate of duplicates) {
+                    allDuplicates.add(outerImport, duplicate);
+                }
+            }
+        }
+        for (const imp of grammar.imports) {
+            const duplicates = allDuplicates.get(imp);
+            if (duplicates.length > 0) {
+                accept('error', 'Some rules exported by this grammar are also included in other imports: ' + stream(duplicates).distinct().join(', '), { node: imp, property: 'path' });
+            }
+        }
+    }
+
+    private getDuplicateExportedRules(outer: ast.Grammar[], inner: ast.Grammar[]): Set<string> {
+        const exclusiveOuter = outer.filter(g => !inner.includes(g));
+        const outerRules = exclusiveOuter.flatMap(e => e.rules);
+        const innerRules = inner.flatMap(e => e.rules);
+        const duplicates = new Set<string>();
+        for (const outerRule of outerRules) {
+            const outerName = outerRule.name.toLowerCase();
+            for (const innerRule of innerRules) {
+                const innerName = innerRule.name.toLowerCase();
+                if (outerName === innerName) {
+                    duplicates.add(innerRule.name);
+                }
+            }
+        }
+        return duplicates;
     }
 
     checkGrammarHiddenTokens(grammar: ast.Grammar, accept: ValidationAcceptor): void {


### PR DESCRIPTION
Closes #302

#### How to test

Add these lines to the `arithmetics` example grammar:

```
import '../../../domainmodel/src/language-server/domain-model';
import '../../../statemachine/src/language-server/statemachine';
```

Any terminals/rule names which already exist inside of the `domain-model` grammar will be highlighted with an error. This also works for transitive dependencies. Furthermore, both imports will be highlighted, since they export the same rules.