### PR TITLE
Let inject() accept n modules. Infer module types. Validate result.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,10 +56,12 @@
             "default": "array-simple"
         }],
         "@typescript-eslint/ban-types": "error",                    // bans types like String in favor of string
-        "@typescript-eslint/indent": "error",                       // consistent indentation
+        "@typescript-eslint/indent": ["error", {                    // consistent indentation
+            "flatTernaryExpressions": true
+        }],
         "@typescript-eslint/no-explicit-any": "error",              // don't use :any type
         "@typescript-eslint/no-misused-new": "error",               // no constructors for interfaces or new for classes
-        "@typescript-eslint/no-namespace": "off",                   // disallow the use of custom TypeScript modules and namespaces 
+        "@typescript-eslint/no-namespace": "off",                   // disallow the use of custom TypeScript modules and namespaces
         "@typescript-eslint/no-non-null-assertion": "off",          // allow ! operator
         "@typescript-eslint/no-parameter-properties": "error",      // no property definitions in class constructors
         "@typescript-eslint/no-unused-vars": ["error", {            // disallow Unused Variables


### PR DESCRIPTION
# This experimental PR is work in progress

This is an experimental branch to check if we are able to improve the typings for dependency injection.

I see these hot spots for improvement:

* improve the user experience by deriving the module types instead of having to explicitly specify all argument types
* allow an arbitrary number of module definitions (instead of only 3 or 4)
* improve the compiler error messages in the case of malformed modules by adding errors to the result type
