### PR TITLE
Ignore terminal fragments in token builder

### DIFF
--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -24,7 +24,7 @@ export class DefaultTokenBuilder implements TokenBuilder {
     buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenType[] {
         const tokenMap = new Map<string, TokenType>();
         const terminalsTokens: TokenType[] = [];
-        const terminals = Array.from(stream(grammar.rules).filter(isTerminalRule));
+        const terminals = Array.from(stream(grammar.rules).filter(isTerminalRule)).filter(e => !e.fragment);
         for (const terminal of terminals) {
             const token = this.buildTerminalToken(terminal);
             terminalsTokens.push(token);

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -31,6 +31,7 @@ describe('Predicated grammar rules', () => {
     TestComplex<A, B, C>: <A & B & C> e=ID | <(B | C) & A> f=ID | <A | (C & false) | B> g=ID;
 
     terminal ID: '1';
+    hidden terminal WS: /\\s+/;
     `;
 
     beforeAll(async () => {
@@ -41,6 +42,11 @@ describe('Predicated grammar rules', () => {
     function hasProp(prop: string): void {
         const main = parser.parse(prop + '1').value;
         expect(main).toHaveProperty(prop);
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g'].forEach(property => {
+            if (property !== prop) {
+                expect(main).not.toHaveProperty(property);
+            }
+        });
     }
 
     test('Should parse RuleA correctly', () => {


### PR DESCRIPTION
Fixes an issue brought up in #365.