### PR TITLE
Re-export external APIs

### DIFF
--- a/examples/arithmetics/src/cli/cli-util.ts
+++ b/examples/arithmetics/src/cli/cli-util.ts
@@ -5,9 +5,9 @@
  ******************************************************************************/
 
 import fs from 'fs';
+import path from 'path';
 import colors from 'colors';
 import { AstNode, LangiumDocument, LangiumServices } from 'langium';
-import path from 'path';
 import { URI } from 'vscode-uri';
 
 export async function extractDocument<T extends AstNode>(fileName: string, extensions: string[], services: LangiumServices): Promise<LangiumDocument<T>> {

--- a/examples/domainmodel/src/cli/cli-util.ts
+++ b/examples/domainmodel/src/cli/cli-util.ts
@@ -5,9 +5,9 @@
  ******************************************************************************/
 
 import fs from 'fs';
+import path from 'path';
 import colors from 'colors';
 import { AstNode, LangiumDocument, LangiumServices } from 'langium';
-import path from 'path';
 import { URI } from 'vscode-uri';
 import { WorkspaceFolder } from 'vscode-languageserver';
 

--- a/examples/domainmodel/src/cli/generator.ts
+++ b/examples/domainmodel/src/cli/generator.ts
@@ -5,14 +5,14 @@
  ******************************************************************************/
 
 import fs from 'fs';
+import path from 'path';
+import colors from 'colors';
 import _ from 'lodash';
 import { CompositeGeneratorNode, IndentNode, NL, processGeneratorNode } from 'langium';
 import { AbstractElement, Domainmodel, Entity, Feature, isEntity, isPackageDeclaration, Type } from '../language-server/generated/ast';
 import { extractAstNode, extractDestinationAndName, setRootFolder } from './cli-util';
 import { createDomainModelServices } from '../language-server/domain-model-module';
 import { DomainModelLanguageMetaData } from '../language-server/generated/module';
-import colors from 'colors';
-import path from 'path';
 
 export const generateAction = async (fileName: string, opts: GenerateOptions): Promise<void> => {
     const services = createDomainModelServices().domainmodel;

--- a/examples/statemachine/src/cli/cli-util.ts
+++ b/examples/statemachine/src/cli/cli-util.ts
@@ -5,9 +5,9 @@
  ******************************************************************************/
 
 import fs from 'fs';
+import path from 'path';
 import colors from 'colors';
 import { AstNode, LangiumDocument, LangiumServices } from 'langium';
-import path from 'path';
 import { URI } from 'vscode-uri';
 
 export async function extractDocument(fileName: string, extensions: string[], services: LangiumServices): Promise<LangiumDocument> {

--- a/packages/generator-langium/langium-template/package.json
+++ b/packages/generator-langium/langium-template/package.json
@@ -43,11 +43,13 @@
         "langium:watch": "langium generate --watch"
     },
     "dependencies": {
+        "chevrotain": "^9.1.0",
         "colors": "^1.4.0",
         "commander": "^8.0.0",
         "langium": "^0.2.0",
         "vscode-languageclient": "^7.0.0",
-        "vscode-languageserver": "^7.0.0"
+        "vscode-languageserver": "^7.0.0",
+        "vscode-uri": "^3.0.2"
     },
     "devDependencies": {
         "@types/node": "^14.17.3",

--- a/packages/generator-langium/langium-template/src/cli/cli-util.ts
+++ b/packages/generator-langium/langium-template/src/cli/cli-util.ts
@@ -1,7 +1,7 @@
 import colors from 'colors';
+import path from 'path';
 import fs from 'fs';
 import { AstNode, LangiumDocument, LangiumServices } from 'langium';
-import path from 'path';
 import { URI } from 'vscode-uri';
 
 export async function extractDocument(fileName: string, services: LangiumServices): Promise<LangiumDocument> {

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -17,7 +17,9 @@
   "license": "MIT",
   "files": [
     "lib",
-    "src"
+    "src",
+	"test.js",
+	"test.d.ts"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/langium/test.d.ts
+++ b/packages/langium/test.d.ts
@@ -1,0 +1,2 @@
+/* eslint-disable header/header */
+export * from './src/test';

--- a/packages/langium/test.js
+++ b/packages/langium/test.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/test');


### PR DESCRIPTION
Closes #361. 

Additionally exports the `langium/lib/test` package in such a way that it can be consumed using `langium/test`.