### PR TITLE
Show grammar path and line number for parser validation errors

### DIFF
--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -10,13 +10,13 @@ import {
     isParserRule, LangiumDocument, resolveImport, resolveTransitiveImports
 } from 'langium';
 import path from 'path';
-import { URI, Utils } from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { generateAst } from './generator/ast-generator';
 import { serializeGrammar } from './generator/grammar-serializer';
 import { generateModule } from './generator/module-generator';
 import { generateTextMate } from './generator/textmate-generator';
 import { getUserChoice, log } from './generator/util';
-import { LangiumConfig, LangiumLanguageConfig, RelativePath } from './package';
+import { getFilePath, LangiumConfig, LangiumLanguageConfig, RelativePath } from './package';
 import { validateParser } from './parser-validation';
 
 export type GenerateOptions = {
@@ -114,7 +114,7 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
     for (const [path, buildResult] of all) {
         const diagnostics = buildResult.diagnostics;
         for (const diagnostic of diagnostics) {
-            const message = `${Utils.basename(URI.file(path))}:${diagnostic.range.start.line + 1}:${diagnostic.range.start.character + 1} - ${diagnostic.message}`;
+            const message = `${getFilePath(path, config)}:${diagnostic.range.start.line + 1}:${diagnostic.range.start.character + 1} - ${diagnostic.message}`;
             if (diagnostic.severity === 1) {
                 log('error', options, message.red);
             } else if (diagnostic.severity === 2) {
@@ -150,7 +150,7 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
     for (const grammar of grammars) {
         embedReferencedRules(grammar, ruleMap);
         // Create and validate the in-memory parser
-        const parserAnalysis = validateParser(grammar, config);
+        const parserAnalysis = validateParser(grammar, config, configMap, documents);
         if (parserAnalysis instanceof Error) {
             log('error', options, parserAnalysis.toString().red);
             return 'failure';

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -48,6 +48,11 @@ export interface LangiumLanguageConfig {
     chevrotainParserConfig?: IParserConfig
 }
 
+export function getFilePath(absPath: string, config: LangiumConfig): string {
+    const base = config[RelativePath] ?? process.cwd();
+    return path.relative(base, absPath);
+}
+
 export async function loadConfigs(options: GenerateOptions): Promise<LangiumConfig[]> {
     let filePath: string;
     if (options.file) {

--- a/packages/langium-cli/src/parser-validation.ts
+++ b/packages/langium-cli/src/parser-validation.ts
@@ -5,15 +5,17 @@
  ******************************************************************************/
 
 import {
-    createDefaultModule, createDefaultSharedModule, createLangiumParser, Grammar, inject,
-    IParserConfig, LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumServices,
-    LangiumSharedServices, Module
+    createDefaultModule, createDefaultSharedModule, getDocument, Grammar, inject, IParserConfig,
+    isGrammar, isParserRule, LangiumDocuments, LangiumGeneratedServices, LangiumGeneratedSharedServices,
+    LangiumParser, LangiumServices, LangiumSharedServices, Module, ParserRule, prepareLangiumParser
 } from 'langium';
-import { LangiumConfig } from './package';
+import { getFilePath, LangiumConfig, LangiumLanguageConfig } from './package';
 
-export function validateParser(grammar: Grammar, config: LangiumConfig): Error | undefined {
+export function validateParser(grammar: Grammar, config: LangiumConfig, grammarConfigMap: Map<Grammar, LangiumLanguageConfig>,
+    documents: LangiumDocuments): Error | undefined {
     const parserConfig: IParserConfig = {
         ...config.chevrotainParserConfig,
+        ...grammarConfigMap.get(grammar)?.chevrotainParserConfig,
         skipValidations: false
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,20 +25,61 @@ export function validateParser(grammar: Grammar, config: LangiumConfig): Error |
     };
     const generatedModule: Module<LangiumServices, LangiumGeneratedServices> = {
         Grammar: () => grammar,
-        LanguageMetaData: unavailable,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        LanguageMetaData: () => grammarConfigMap.get(grammar) as any,
         parser: {
             ParserConfig: () => parserConfig
         }
     };
     const shared = inject(createDefaultSharedModule(), generatedSharedModule);
     const services = inject(createDefaultModule({ shared }), generatedModule);
+
+    let parser: LangiumParser | undefined;
     try {
-        createLangiumParser(services);
+        parser = prepareLangiumParser(services);
+        // The finalization step invokes parser validation, which can lead to thrown errors
+        parser.finalize();
         return undefined;
     } catch (err) {
+        if (parser && parser.definitionErrors.length > 0) {
+            // Construct a message with tracing information
+            let message = 'Parser definition errors detected:';
+            for (const defError of parser.definitionErrors) {
+                message += '\n-------------------------------\n';
+                if (defError.ruleName) {
+                    const rule = findRule(defError.ruleName, grammar, documents);
+                    if (rule && rule.$cstNode) {
+                        const filePath = getFilePath(getDocument(rule).uri.fsPath, config);
+                        const line = rule.$cstNode.range.start.line + 1;
+                        message += `${filePath}:${line} - `;
+                    }
+                }
+                message += defError.message;
+            }
+            return new Error(message);
+        }
         if (err instanceof Error) {
             return err;
         }
         throw err;
     }
+}
+
+function findRule(name: string, grammar: Grammar, documents: LangiumDocuments): ParserRule | undefined {
+    for (const rule of grammar.rules) {
+        if (rule.name === name && isParserRule(rule)) {
+            return rule;
+        }
+    }
+    for (const document of documents.all) {
+        const ast = document.parseResult.value;
+        if (isGrammar(ast)) {
+            for (const rule of ast.rules) {
+                if (rule.name === name && isParserRule(rule)) {
+                    return rule;
+                }
+            }
+        }
+    }
+    return undefined;
 }

--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -34,7 +34,21 @@ type Predicate = (args: Args) => boolean;
 
 type Method = (args: Args) => void;
 
+/**
+ * Create and finalize a Langium parser. The parser rules are derived from the grammar, which is
+ * available at `services.Grammar`.
+ */
 export function createLangiumParser(services: LangiumServices): LangiumParser {
+    const parser = prepareLangiumParser(services);
+    parser.finalize();
+    return parser;
+}
+
+/**
+ * Create a Langium parser without finalizing it. This is used to extract more detailed error
+ * information when the parser is initially validated.
+ */
+export function prepareLangiumParser(services: LangiumServices): LangiumParser {
     const grammar = services.Grammar;
     const tokens = new Map<string, TokenType>();
     const buildTokens = services.parser.TokenBuilder.buildTokens(grammar, { caseInsensitive: services.LanguageMetaData.caseInsensitive });
@@ -49,7 +63,6 @@ export function createLangiumParser(services: LangiumServices): LangiumParser {
         rules
     };
     buildParserRules(parserContext, grammar);
-    parser.finalize();
     return parser;
 }
 

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -318,6 +318,17 @@ export class LangiumParser {
     finalize(): void {
         this.wrapper.wrapSelfAnalysis();
     }
+
+    get definitionErrors(): IParserDefinitionError[] {
+        return this.wrapper.definitionErrors;
+    }
+
+}
+
+export interface IParserDefinitionError {
+    message: string
+    type: number
+    ruleName?: string
 }
 
 const defaultConfig: IParserConfig = {
@@ -331,6 +342,9 @@ const defaultConfig: IParserConfig = {
  * This way, we can build the `LangiumParser` as a composition.
  */
 class ChevrotainWrapper extends EmbeddedActionsParser {
+
+    // This array is set in the base implementation of Chevrotain.
+    definitionErrors: IParserDefinitionError[];
 
     constructor(tokens: TokenType[], config?: IParserConfig) {
         super(tokens, {


### PR DESCRIPTION
Closes #201. When Chevrotain reports grammar validation errors, they are prefixed with the file path and line number of the corresponding parser rule.

How to verify:
 * Change one of the examples so there is an ambiguity or left-recursion, then run the CLI to see the validation errors.