### PR TITLE
Add descriptions to Yeoman questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8395,6 +8395,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sort-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
+      "dependencies": {
+        "is-plain-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-keys/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10020,9 +10042,9 @@
       }
     },
     "node_modules/yeoman-generator": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-5.4.2.tgz",
-      "integrity": "sha512-xgS3A4r5VoEYq3vPdk1fWPVZ30y5NHlT2hn0OEyhKG79xojCtPkPkfWcKQamgvC9QLhaotVGvambBxwxwBeDTg==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-5.5.2.tgz",
+      "integrity": "sha512-GY5VoKQb+sS41Lu0WBlCDeEn8UbV7AFTY5hI3f4DXzqEylhwBqL40h5FSeKljhrsbrixPciSKlwke13RoXtBBw==",
       "dependencies": {
         "chalk": "^4.1.0",
         "dargs": "^7.0.0",
@@ -10035,6 +10057,7 @@
         "run-async": "^2.0.0",
         "semver": "^7.2.1",
         "shelljs": "^0.8.4",
+        "sort-keys": "^4.2.0",
         "text-table": "^0.2.0"
       },
       "engines": {
@@ -10065,9 +10088,9 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "colors": "^1.4.0",
+        "chalk": "^4.1.2",
         "lodash": "^4.17.21",
-        "yeoman-generator": "^5.3.0"
+        "yeoman-generator": "^5.5.2"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.170",
@@ -13831,13 +13854,13 @@
         "@types/yeoman-generator": "^5.0.0",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
-        "colors": "^1.4.0",
+        "chalk": "^4.1.2",
         "eslint": "^7.28.0",
         "eslint-plugin-header": "^3.1.1",
         "lodash": "^4.17.21",
         "rimraf": "^3.0.2",
         "typescript": "^4.2.2",
-        "yeoman-generator": "^5.3.0"
+        "yeoman-generator": "^5.5.2"
       }
     },
     "gensync": {
@@ -16885,6 +16908,21 @@
         }
       }
     },
+    "sort-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
+      "requires": {
+        "is-plain-obj": "^2.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18151,9 +18189,9 @@
       }
     },
     "yeoman-generator": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-5.4.2.tgz",
-      "integrity": "sha512-xgS3A4r5VoEYq3vPdk1fWPVZ30y5NHlT2hn0OEyhKG79xojCtPkPkfWcKQamgvC9QLhaotVGvambBxwxwBeDTg==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-5.5.2.tgz",
+      "integrity": "sha512-GY5VoKQb+sS41Lu0WBlCDeEn8UbV7AFTY5hI3f4DXzqEylhwBqL40h5FSeKljhrsbrixPciSKlwke13RoXtBBw==",
       "requires": {
         "chalk": "^4.1.0",
         "dargs": "^7.0.0",
@@ -18166,6 +18204,7 @@
         "run-async": "^2.0.0",
         "semver": "^7.2.1",
         "shelljs": "^0.8.4",
+        "sort-keys": "^4.2.0",
         "text-table": "^0.2.0"
       }
     },

--- a/packages/generator-langium/package.json
+++ b/packages/generator-langium/package.json
@@ -31,9 +31,9 @@
     "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {
-    "colors": "^1.4.0",
+    "chalk": "^4.1.2",
     "lodash": "^4.17.21",
-    "yeoman-generator": "^5.3.0"
+    "yeoman-generator": "^5.5.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.170",
@@ -53,7 +53,7 @@
   },
   "bugs": "https://github.com/langium/langium/issues",
   "author": {
-      "name": "TypeFox",
-      "url": "https://www.typefox.io"
+    "name": "TypeFox",
+    "url": "https://www.typefox.io"
   }
 }

--- a/packages/generator-langium/src/index.ts
+++ b/packages/generator-langium/src/index.ts
@@ -6,8 +6,8 @@
 
 import Generator from 'yeoman-generator';
 import _ from 'lodash';
+import chalk from 'chalk';
 import path from 'path';
-import 'colors';
 
 const TEMPLATE_DIR = '../langium-template';
 const USER_DIR = '.';
@@ -38,6 +38,10 @@ function printLogo(log: (message: string) => void): void {
     log('');
 }
 
+function description(...d: string[]): string {
+    return chalk.reset(chalk.dim(d.join(' ') + '\n')) + chalk.green('?');
+}
+
 class LangiumGenerator extends Generator {
     private answers: Answers;
 
@@ -51,12 +55,22 @@ class LangiumGenerator extends Generator {
             {
                 type: 'input',
                 name: 'extensionName',
+                prefix: description(
+                    'Welcome to Langium!',
+                    'This tool generates a VS Code extension with a "Hello World" language to get started quickly.',
+                    'The extension name is an identifier used in the extension marketplace or package registry.'
+                ),
                 message: 'Your extension name:',
                 default: 'hello-world',
             },
             {
                 type: 'input',
                 name: 'rawLanguageName',
+                prefix: description(
+                    'The language name is used to identify your language in VS Code.',
+                    'Please provide a name to be shown in the UI.',
+                    'CamelCase and kebab-case variants will be created and used in different parts of the extension and language server.'
+                ),
                 message: 'Your language name:',
                 default: 'Hello World',
                 validate: (input: string): boolean | string =>
@@ -67,13 +81,16 @@ class LangiumGenerator extends Generator {
             {
                 type: 'input',
                 name: 'fileExtensions',
-                message:
-                    'File extensions of your language, separated by commas:',
+                prefix: description(
+                    'Source files of your language are identified by their file name extension.',
+                    'You can specify multiple file extensions separated by commas.'
+                ),
+                message: 'File extensions:',
                 default: '.hello',
                 validate: (input: string): boolean | string =>
                     /^\.?\w+(\s*,\s*\.?\w+)*$/.test(input)
                         ? true
-                        : 'The file extension can start with . and must contain only letters and digits. Extensions must be separated by commas.',
+                        : 'A file extension can start with . and must contain only letters and digits. Extensions must be separated by commas.',
             },
         ]);
     }


### PR DESCRIPTION
Closes #258. The descriptions are printed above each question and colored in gray.

I removed the `colors` dependency because it's not used. Yeoman uses `chalk` instead.