### PR TITLE
Deduplicate and sort types

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -8,7 +8,7 @@
 import { AstNode, AstReflection, Reference, isAstNode } from 'langium';
 
 export interface AbstractDefinition extends AstNode {
-    readonly $container: Module | Definition;
+    readonly $container: Definition | Module;
     name: string
 }
 
@@ -19,7 +19,7 @@ export function isAbstractDefinition(item: unknown): item is AbstractDefinition 
 }
 
 export interface Expression extends AstNode {
-    readonly $container: Definition | Evaluation | BinaryExpression | FunctionCall;
+    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
 }
 
 export const Expression = 'Expression';
@@ -40,7 +40,7 @@ export function isModule(item: unknown): item is Module {
 }
 
 export interface Statement extends AstNode {
-    readonly $container: Module | Definition;
+    readonly $container: Definition | Module;
 }
 
 export const Statement = 'Statement';
@@ -71,7 +71,7 @@ export function isDefinition(item: unknown): item is Definition {
 
 export interface BinaryExpression extends Expression {
     left: Expression
-    operator: '+' | '-' | '*' | '/'
+    operator: '*' | '+' | '-' | '/'
     right: Expression
 }
 

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -9,8 +9,8 @@ import { AstNode, AstReflection, Reference } from '../../syntax-tree';
 import { isAstNode } from '../../utils/ast-util';
 
 export interface AbstractElement extends AstNode {
-    readonly $container: ParserRule | Alternatives | Group | UnorderedGroup | Assignment | CrossReference | TerminalRule | TerminalAlternatives | TerminalGroup | NegatedToken | UntilToken | CharacterRange;
-    cardinality: '?' | '*' | '+'
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    cardinality: '*' | '+' | '?'
 }
 
 export const AbstractElement = 'AbstractElement';
@@ -33,7 +33,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
 }
 
 export interface Condition extends AstNode {
-    readonly $container: Group | NamedArgument | Disjunction | Conjunction | Negation;
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
 }
 
 export const Condition = 'Condition';
@@ -94,7 +94,7 @@ export function isParameter(item: unknown): item is Parameter {
 
 export interface Action extends AbstractElement {
     feature: string
-    operator: '=' | '+='
+    operator: '+=' | '='
     type: string
 }
 


### PR DESCRIPTION
Fixes #363, fixes #367.

We now deduplicate type collections using `Set` and sort the resulting arrays before generating.