### PR TITLE
Added attach launch config to generator template

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,41 +4,6 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-		{
-			"name": "Bootstrap",
-			"request": "launch",
-			"runtimeArgs": [
-				"${workspaceFolder}/packages/langium-cli/lib/langium",
-				"generate"
-			],
-			"runtimeExecutable": "node",
-			"cwd": "${workspaceFolder}/packages/langium",
-			"skipFiles": [
-				"<node_internals>/**"
-			],
-			"sourceMaps": true,
-			"outFiles": [
-				"${workspaceFolder}/packages/langium-cli/lib/**/*.js",
-				"${workspaceFolder}/packages/langium/lib/**/*.js"
-			],
-			"type": "pwa-node"
-		},
-		{
-			"name": "Attach",
-			"port": 6009,
-			"request": "attach",
-			"skipFiles": [
-				"<node_internals>/**"
-			],
-			"sourceMaps": true,
-			"outFiles": [
-				"${workspaceFolder}/packages/langium/lib/**/*.js",
-				"${workspaceFolder}/examples/arithmetics/out/**/*.js",
-				"${workspaceFolder}/examples/domainmodel/out/**/*.js",
-				"${workspaceFolder}/examples/statemachine/out/**/*.js"
-			],
-			"type": "pwa-node"
-		},
         {
 			"name": "Run Grammar Extension",
 			"type": "extensionHost",
@@ -80,6 +45,41 @@
 			]
 		},
 		{
+			"name": "Attach to Language Server",
+			"type": "pwa-node",
+			"port": 6009,
+			"request": "attach",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/packages/langium/lib/**/*.js",
+				"${workspaceFolder}/examples/arithmetics/out/**/*.js",
+				"${workspaceFolder}/examples/domainmodel/out/**/*.js",
+				"${workspaceFolder}/examples/statemachine/out/**/*.js"
+			]
+		},
+		{
+			"name": "Bootstrap",
+			"type": "pwa-node",
+			"request": "launch",
+			"runtimeArgs": [
+				"${workspaceFolder}/packages/langium-cli/lib/langium",
+				"generate"
+			],
+			"runtimeExecutable": "node",
+			"cwd": "${workspaceFolder}/packages/langium",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/packages/langium-cli/lib/**/*.js",
+				"${workspaceFolder}/packages/langium/lib/**/*.js"
+			]
+		},
+		{
 			"name": "Extension Tests",
 			"type": "extensionHost",
 			"request": "launch",
@@ -90,9 +90,9 @@
 			]
 		},
 		{
+			"name": "Jest: Run All",
 			"type": "node",
 			"request": "launch",
-			"name": "Jest Langium: Run All",
 			"program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
 			"args": [
 				"--config=${workspaceFolder}/jest.config.json",
@@ -104,9 +104,9 @@
 			"internalConsoleOptions": "neverOpen"
 		},
 		{
+			"name": "Jest: Run Selected File",
 			"type": "node",
 			"request": "launch",
-			"name": "Jest Langium: Run Selected File",
 			"program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
 			"args": [
 				"${fileBasename}",

--- a/packages/generator-langium/langium-template/.vscode/launch.json
+++ b/packages/generator-langium/langium-template/.vscode/launch.json
@@ -6,12 +6,25 @@
 	"version": "0.2.0",
     "configurations": [
         {
-            "name": "Extension",
+            "name": "Run Extension",
             "type": "extensionHost",
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]
-        }
+        },
+		{
+			"name": "Attach to Language Server",
+			"type": "pwa-node",
+			"port": 6009,
+			"request": "attach",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			]
+		}
     ]
 }


### PR DESCRIPTION
As mentioned in https://github.com/langium/langium/discussions/376#discussioncomment-1997781, this adds an `attach` launch config to generated projects to users can debug their language server.

I also reordered the entries in our main launch config so the most used ones are shown first in the list.