### PR TITLE
Made grammar object optional

### DIFF
--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -572,5 +572,6 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       }
     }
   ],
+  "isDeclared": true,
   "name": "Arithmetics"
 }`));

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -397,5 +397,6 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
       }
     }
   ],
+  "isDeclared": true,
   "name": "DomainModel"
 }`));

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -328,5 +328,6 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
       }
     }
   ],
+  "isDeclared": true,
   "name": "Statemachine"
 }`));

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -141,12 +141,17 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
         const buildResult = all.get(absGrammarPath);
         if (buildResult) {
             const grammar = buildResult.document.parseResult.value as Grammar;
+            if(!grammar.isDeclared) {
+                log('error', options, `${absGrammarPath}: The entry grammar must start with the 'grammar' keyword.`.red);
+                return 'failure';
+            }
             grammars.push(grammar);
             configMap.set(grammar, languageConfig);
         }
     }
 
     const ruleMap = mapRules(grammars);
+
     for (const grammar of grammars) {
         embedReferencedRules(grammar, ruleMap);
         // Create and validate the in-memory parser

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -46,6 +46,7 @@ export interface Grammar extends AstNode {
     definesHiddenTokens: boolean
     hiddenTokens: Array<Reference<AbstractRule>>
     imports: Array<GrammarImport>
+    isDeclared: boolean
     name: string
     rules: Array<AbstractRule>
     usedGrammars: Array<Reference<Grammar>>

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -23,45 +23,27 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "$type": "Group",
         "elements": [
           {
-            "$type": "Keyword",
-            "value": "grammar",
-            "elements": []
-          },
-          {
-            "$type": "Assignment",
-            "feature": "name",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "arguments": [],
-              "rule": {
-                "$refText": "ID"
-              }
-            }
-          },
-          {
             "$type": "Group",
             "elements": [
               {
-                "$type": "Keyword",
-                "value": "with",
+                "$type": "Assignment",
+                "feature": "isDeclared",
+                "operator": "?=",
+                "terminal": {
+                  "$type": "Keyword",
+                  "value": "grammar"
+                },
                 "elements": []
               },
               {
                 "$type": "Assignment",
-                "feature": "usedGrammars",
-                "operator": "+=",
+                "feature": "name",
+                "operator": "=",
                 "terminal": {
-                  "$type": "CrossReference",
-                  "type": {
-                    "$refText": "Grammar"
-                  },
-                  "terminal": {
-                    "$type": "RuleCall",
-                    "arguments": [],
-                    "rule": {
-                      "$refText": "ID"
-                    }
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "ID"
                   }
                 }
               },
@@ -70,7 +52,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "elements": [
                   {
                     "$type": "Keyword",
-                    "value": ",",
+                    "value": "with",
                     "elements": []
                   },
                   {
@@ -90,51 +72,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         }
                       }
                     }
-                  }
-                ],
-                "cardinality": "*"
-              }
-            ],
-            "cardinality": "?"
-          },
-          {
-            "$type": "Group",
-            "elements": [
-              {
-                "$type": "Assignment",
-                "feature": "definesHiddenTokens",
-                "operator": "?=",
-                "terminal": {
-                  "$type": "Keyword",
-                  "value": "hidden"
-                },
-                "elements": []
-              },
-              {
-                "$type": "Keyword",
-                "value": "("
-              },
-              {
-                "$type": "Group",
-                "elements": [
-                  {
-                    "$type": "Assignment",
-                    "feature": "hiddenTokens",
-                    "operator": "+=",
-                    "terminal": {
-                      "$type": "CrossReference",
-                      "type": {
-                        "$refText": "AbstractRule"
-                      },
-                      "terminal": {
-                        "$type": "RuleCall",
-                        "arguments": [],
-                        "rule": {
-                          "$refText": "ID"
-                        }
-                      }
-                    },
-                    "elements": []
                   },
                   {
                     "$type": "Group",
@@ -146,12 +83,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       },
                       {
                         "$type": "Assignment",
-                        "feature": "hiddenTokens",
+                        "feature": "usedGrammars",
                         "operator": "+=",
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractRule"
+                            "$refText": "Grammar"
                           },
                           "terminal": {
                             "$type": "RuleCall",
@@ -169,8 +106,82 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "cardinality": "?"
               },
               {
-                "$type": "Keyword",
-                "value": ")"
+                "$type": "Group",
+                "elements": [
+                  {
+                    "$type": "Assignment",
+                    "feature": "definesHiddenTokens",
+                    "operator": "?=",
+                    "terminal": {
+                      "$type": "Keyword",
+                      "value": "hidden"
+                    },
+                    "elements": []
+                  },
+                  {
+                    "$type": "Keyword",
+                    "value": "("
+                  },
+                  {
+                    "$type": "Group",
+                    "elements": [
+                      {
+                        "$type": "Assignment",
+                        "feature": "hiddenTokens",
+                        "operator": "+=",
+                        "terminal": {
+                          "$type": "CrossReference",
+                          "type": {
+                            "$refText": "AbstractRule"
+                          },
+                          "terminal": {
+                            "$type": "RuleCall",
+                            "arguments": [],
+                            "rule": {
+                              "$refText": "ID"
+                            }
+                          }
+                        },
+                        "elements": []
+                      },
+                      {
+                        "$type": "Group",
+                        "elements": [
+                          {
+                            "$type": "Keyword",
+                            "value": ",",
+                            "elements": []
+                          },
+                          {
+                            "$type": "Assignment",
+                            "feature": "hiddenTokens",
+                            "operator": "+=",
+                            "terminal": {
+                              "$type": "CrossReference",
+                              "type": {
+                                "$refText": "AbstractRule"
+                              },
+                              "terminal": {
+                                "$type": "RuleCall",
+                                "arguments": [],
+                                "rule": {
+                                  "$refText": "ID"
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "cardinality": "*"
+                      }
+                    ],
+                    "cardinality": "?"
+                  },
+                  {
+                    "$type": "Keyword",
+                    "value": ")"
+                  }
+                ],
+                "cardinality": "?"
               }
             ],
             "cardinality": "?"

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -2649,5 +2649,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       }
     }
   ],
+  "isDeclared": true,
   "name": "LangiumGrammar"
 }`));

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -105,7 +105,7 @@ export class LangiumGrammarValidator {
                 accept('error', 'This grammar is missing an entry parser rule.', { node: grammar, property: 'name' });
             }
         } else if(!grammar.isDeclared && entryRules.length >= 1) {
-            entryRules.forEach(rule => accept('error', 'Cannot declare entry rules for unnamed grammars.', { node: entryRules[0], property: 'name' }));
+            entryRules.forEach(rule => accept('error', 'Cannot declare entry rules for unnamed grammars.', { node: rule, property: 'name' }));
         } else if (entryRules.length > 1) {
             entryRules.forEach(rule => accept('error', 'The entry rule has to be unique.', { node: rule, property: 'name' }));
         } else if (isDataTypeRule(entryRules[0])) {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -105,7 +105,7 @@ export class LangiumGrammarValidator {
                 accept('error', 'This grammar is missing an entry parser rule.', { node: grammar, property: 'name' });
             }
         } else if(!grammar.isDeclared && entryRules.length === 1) {
-            accept('error', 'A rule marked as entry is illegal if the containing grammar is not declared.', { node: entryRules[0], property: 'name' });
+            accept('error', 'Cannot declare entry rules for unnamed grammars.', { node: entryRules[0], property: 'name' });
         } else if (entryRules.length > 1) {
             entryRules.forEach(rule => accept('error', 'The entry rule has to be unique.', { node: rule, property: 'name' }));
         } else if (isDataTypeRule(entryRules[0])) {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -104,8 +104,8 @@ export class LangiumGrammarValidator {
             } else {
                 accept('error', 'This grammar is missing an entry parser rule.', { node: grammar, property: 'name' });
             }
-        } else if(!grammar.isDeclared && entryRules.length === 1) {
-            accept('error', 'Cannot declare entry rules for unnamed grammars.', { node: entryRules[0], property: 'name' });
+        } else if(!grammar.isDeclared && entryRules.length >= 1) {
+            entryRules.forEach(rule => accept('error', 'Cannot declare entry rules for unnamed grammars.', { node: entryRules[0], property: 'name' }));
         } else if (entryRules.length > 1) {
             entryRules.forEach(rule => accept('error', 'The entry rule has to be unique.', { node: rule, property: 'name' }));
         } else if (isDataTypeRule(entryRules[0])) {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -97,13 +97,15 @@ export class LangiumGrammarValidator {
 
     checkEntryGrammarRule(grammar: ast.Grammar, accept: ValidationAcceptor): void {
         const entryRules = grammar.rules.filter(e => ast.isParserRule(e) && e.entry) as ast.ParserRule[];
-        if (entryRules.length === 0) {
+        if (grammar.isDeclared && entryRules.length === 0) {
             const possibleEntryRule = grammar.rules.find(e => ast.isParserRule(e) && !isDataTypeRule(e));
             if (possibleEntryRule) {
                 accept('error', 'The grammar is missing an entry parser rule. This rule can be an entry one.', { node: possibleEntryRule, property: 'name', code: IssueCodes.EntryRuleTokenSyntax });
             } else {
                 accept('error', 'This grammar is missing an entry parser rule.', { node: grammar, property: 'name' });
             }
+        } else if(!grammar.isDeclared && entryRules.length === 1) {
+            accept('error', 'A rule marked as entry is illegal if the containing grammar is not declared.', { node: entryRules[0], property: 'name' });
         } else if (entryRules.length > 1) {
             entryRules.forEach(rule => accept('error', 'The entry rule has to be unique.', { node: rule, property: 'name' }));
         } else if (isDataTypeRule(entryRules[0])) {

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -6,8 +6,10 @@
 grammar LangiumGrammar
 
 entry Grammar:
-	'grammar' name=ID ('with' usedGrammars+=[Grammar:ID] (',' usedGrammars+=[Grammar:ID])*)?
-	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')?
+	(
+        isDeclared?='grammar' name=ID ('with' usedGrammars+=[Grammar:ID] (',' usedGrammars+=[Grammar:ID])*)?
+        (definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')?
+    )?
 	imports+=GrammarImport*
 	(rules+=AbstractRule)+;
 


### PR DESCRIPTION
Grammar top level object is optional now.
However if it is missing in grammar which is configured in langium-config.json then langium generator fails.

Fixes #299

