### PR TITLE
References in other files don't detect name changes #307

### DIFF
--- a/examples/arithmetics/src/cli/cli-util.ts
+++ b/examples/arithmetics/src/cli/cli-util.ts
@@ -22,9 +22,9 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    const buildResult = await services.shared.workspace.DocumentBuilder.build(document);
+    await services.shared.workspace.DocumentBuilder.build([document]);
 
-    const validationErrors = buildResult.diagnostics.filter(e => e.severity === 1);
+    const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         console.error(colors.red('There are validation errors:'));
         for (const validationError of validationErrors) {

--- a/examples/domainmodel/src/cli/cli-util.ts
+++ b/examples/domainmodel/src/cli/cli-util.ts
@@ -23,9 +23,9 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    const buildResult = await services.shared.workspace.DocumentBuilder.build(document);
+    await services.shared.workspace.DocumentBuilder.build([document]);
 
-    const validationErrors = buildResult.diagnostics.filter(e => e.severity === 1);
+    const validationErrors = (document.diagnostics??[]).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         console.error(colors.red('There are validation errors:'));
         for (const validationError of validationErrors) {

--- a/examples/domainmodel/test/cross-refs.test.ts
+++ b/examples/domainmodel/test/cross-refs.test.ts
@@ -39,9 +39,10 @@ describe('Cross references from declaration', () => {
 });
 
 async function getReferences(): Promise<ReferenceDescription[]> {
-    const datatypeDoc: LangiumDocument = await parseDocument(services, datatypeFile);
-    const referencingDoc: LangiumDocument = await parseDocument(services, referencingFile);
-    services.shared.workspace.IndexManager.update([referencingDoc, datatypeDoc]);
+    const datatypeDoc: LangiumDocument<AstNode> = await parseDocument(services, datatypeFile);
+    const referencingDoc: LangiumDocument<AstNode> = await parseDocument(services, referencingFile);
+
+    await services.shared.workspace.DocumentBuilder.build([referencingDoc, datatypeDoc]);
     const model = (datatypeDoc.parseResult.value as Domainmodel);
 
     const stringType = model.elements[0];

--- a/examples/domainmodel/test/refs-index.test.ts
+++ b/examples/domainmodel/test/refs-index.test.ts
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { AstNode, getDocument, LangiumDocument, ReferenceDescription } from 'langium';
+import { parseDocument } from 'langium/lib/test';
+import { TextDocument } from 'vscode-languageserver-protocol';
+import { URI } from 'vscode-uri';
+import { createDomainModelServices } from '../src/language-server/domain-model-module';
+import { Domainmodel } from '../src/language-server/generated/ast';
+
+const services = createDomainModelServices().domainmodel;
+
+describe('Cross references indexed after affected process', () => {
+    test('Fixed reference is in index', async () => {
+        const docs = await updateDocuments('entity SomeEntity extends SuperEntity {}', 'entity NoSuperEntity {}');
+        const superDoc = docs.super;
+        let allRefs = await getReferences((superDoc.parseResult.value as Domainmodel).elements[0]);
+        expect(allRefs.length).toEqual(0); // linking error
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const textDocs: any = services.shared.workspace.TextDocuments;
+        textDocs._documents[superDoc.textDocument.uri.toString()] =
+            TextDocument.create(superDoc.textDocument.uri.toString(), superDoc.textDocument.languageId, 0, 'entity SuperEntity {}');
+        await services.shared.workspace.DocumentBuilder.update([superDoc.uri], []);
+
+        const updatedSuperDoc = await services.shared.workspace.LangiumDocuments.getOrCreateDocument(superDoc.uri);
+        const superEntity = (updatedSuperDoc.parseResult.value as Domainmodel).elements[0];
+        allRefs = await getReferences(superEntity);
+        expect(allRefs.length).toEqual(1); // re-linked
+
+        const extendsEntity = (docs.extends.parseResult.value as Domainmodel).elements[0];
+        expect(refString(allRefs[0])).toEqual(nodeRefString(extendsEntity, superEntity));
+    });
+});
+
+async function updateDocuments(extendsFile: string, superFile: string): Promise<{ 'super': LangiumDocument, 'extends': LangiumDocument }> {
+    const superDoc: LangiumDocument = await parseDocument(services, superFile);
+    const extendsDoc: LangiumDocument = await parseDocument(services, extendsFile);
+    services.shared.workspace.LangiumDocuments.addDocument(superDoc);
+    services.shared.workspace.LangiumDocuments.addDocument(extendsDoc);
+
+    await services.shared.workspace.DocumentBuilder.build([extendsDoc, superDoc]);
+    return { 'super': superDoc, 'extends': extendsDoc };
+}
+
+async function getReferences(node: AstNode): Promise<ReferenceDescription[]> {
+    const allRefs: ReferenceDescription[] = [];
+    services.shared.workspace.IndexManager.findAllReferences(node, createPath(node))
+        .forEach((ref) => allRefs.push(ref));
+    return allRefs;
+}
+
+function refString(ref: ReferenceDescription): string {
+    return asString(ref.sourceUri, ref.sourcePath, ref.targetUri, ref.targetPath);
+}
+
+function nodeRefString(from: AstNode, to: AstNode): string {
+    return asString(getDocument(from).uri, createPath(from), getDocument(to).uri, createPath(to));
+}
+
+function createPath(node: AstNode): string {
+    return services.index.AstNodeLocator.getAstNodePath(node);
+}
+
+function asString(fromUri: URI, fromPath: string, toUri: URI, toPath: string): string {
+    return fromUri + fromPath + ' -> ' + toUri + toPath;
+}

--- a/examples/statemachine/src/cli/cli-util.ts
+++ b/examples/statemachine/src/cli/cli-util.ts
@@ -22,9 +22,9 @@ export async function extractDocument(fileName: string, extensions: string[], se
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    const buildResult = await services.shared.workspace.DocumentBuilder.build(document);
+    await services.shared.workspace.DocumentBuilder.build([document]);
 
-    const validationErrors = buildResult.diagnostics.filter(e => e.severity === 1);
+    const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         console.error(colors.red('There are validation errors:'));
         for (const validationError of validationErrors) {

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -44,6 +44,9 @@ export interface Reference<T extends AstNode = AstNode> {
     readonly $refNode: CstNode;
     /** The actual text used to look up in the surrounding scope */
     readonly $refText: string;
+
+    /** The node description for the AstNode returned by `ref`  */
+    readonly $nodeDescription?: AstNodeDescription;
 }
 
 /**

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -46,14 +46,16 @@ export enum DocumentState {
     Changed = 0,
     /** An AST has been created from the text content. */
     Parsed = 1,
-    /** The `IndexManager` service has processed this document. */
-    Indexed = 2,
+    /** The `IndexManager` service has processed AST nodes of this document. */
+    IndexedContent = 2,
     /** Pre-processing steps such as scope precomputation have been executed. */
     Processed = 3,
     /** The `Linker` service has processed this document. */
     Linked = 4,
+    /** The `IndexManager` service has processed AST node references of this document. */
+    IndexedReferences = 5,
     /** The `DocumentValidator` service has processed this document. */
-    Validated = 5
+    Validated = 6
 }
 
 /**

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -10,8 +10,8 @@ import { WorkspaceFolder } from 'vscode-languageserver';
 import { URI, Utils } from 'vscode-uri';
 import { ServiceRegistry } from '../service-registry';
 import { LangiumSharedServices } from '../services';
+import { DocumentBuilder } from './document-builder';
 import { LangiumDocument, LangiumDocuments } from './documents';
-import { IndexManager } from './index-manager';
 
 /**
  * The workspace manager is responsible for finding source files in the workspace.
@@ -34,12 +34,12 @@ export class DefaultWorkspaceManager {
 
     protected readonly serviceRegistry: ServiceRegistry;
     protected readonly langiumDocuments: LangiumDocuments;
-    protected readonly indexManager: IndexManager;
+    protected readonly documentBuilder: DocumentBuilder;
 
     constructor(services: LangiumSharedServices) {
         this.serviceRegistry = services.ServiceRegistry;
         this.langiumDocuments = services.workspace.LangiumDocuments;
-        this.indexManager = services.workspace.IndexManager;
+        this.documentBuilder = services.workspace.DocumentBuilder;
     }
 
     async initializeWorkspace(folders: WorkspaceFolder[]): Promise<void> {
@@ -51,7 +51,7 @@ export class DefaultWorkspaceManager {
                 .map(async rf => this.traverseFolder(rf, fileExtensions, collector))
         );
         await this.loadAdditionalDocuments(folders, collector);
-        await this.indexManager.update(documents);
+        await this.documentBuilder.build(documents);
     }
 
     /**

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -24,7 +24,7 @@ describe('Data type rules', () => {
     let rules: ParserRule[] = [];
 
     beforeAll(async () => {
-        rules = (await parser(grammar)).document.parseResult.value.rules
+        rules = (await parser(grammar)).parseResult.value.rules
             .filter(e => isParserRule(e))
             .map(e => e as ParserRule);
     });
@@ -63,7 +63,7 @@ describe('Find name assignment in parser rules', () => {
     let rules: ParserRule[] = [];
 
     beforeAll(async () => {
-        rules = (await parser(grammar)).document.parseResult.value.rules
+        rules = (await parser(grammar)).parseResult.value.rules
             .filter(e => isParserRule(e))
             .map(e => e as ParserRule);
     });
@@ -166,7 +166,7 @@ describe('TerminalRule to regex', () => {
         grammar Test
         ${input}
         `;
-        const grammar = (await parse(text)).document.parseResult.value;
+        const grammar = (await parse(text)).parseResult.value;
         const terminals = stream(grammar.rules).filter(isTerminalRule);
         const terminal = name ? terminals.find(e => e.name === name) : terminals.head();
         if (!terminal) {

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -35,7 +35,7 @@ describe('Predicated grammar rules', () => {
     `;
 
     beforeAll(async () => {
-        grammar = (await helper(content)).document.parseResult.value;
+        grammar = (await helper(content)).parseResult.value;
         parser = parserFromGrammar(grammar);
     });
 
@@ -96,7 +96,7 @@ describe('One name for terminal and non-terminal rules', () => {
     `;
 
     beforeAll(async () => {
-        grammar = (await helper(content)).document.parseResult.value;
+        grammar = (await helper(content)).parseResult.value;
     });
 
     test('Should work without Parser Definition Errors', () => {

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -23,7 +23,7 @@ describe('tokenBuilder', () => {
         terminal fragment Frag: 'B';
         terminal AB: 'A' Frag;
         `;
-        const grammar = (await helper(text)).document.parseResult.value;
+        const grammar = (await helper(text)).parseResult.value;
         tokens = tokenBuilder.buildTokens(grammar);
     });
 
@@ -47,7 +47,7 @@ describe('tokenBuilder#longerAlts', () => {
         Main: {Main} 'A' 'AB' 'ABC';
         terminal AB: /ABD?/;
         `;
-        const grammar = (await helper(text)).document.parseResult.value;
+        const grammar = (await helper(text)).parseResult.value;
         const tokens = tokenBuilder.buildTokens(grammar);
         aToken = tokens[2];
         abToken = tokens[1];
@@ -95,7 +95,7 @@ describe('tokenBuilder#caseInsensitivePattern', () => {
         terminal BOOLEAN returns boolean: /true|false/;
         terminal AB: /ABD?/;
         `;
-        const grammar = (await parseHelper<Grammar>(grammarServices)(text)).document.parseResult.value;
+        const grammar = (await parseHelper<Grammar>(grammarServices)(text)).parseResult.value;
         const tokens = tokenBuilder.buildTokens(grammar, { caseInsensitive: true });
         const patterns = tokens.map(token => token.PATTERN);
 

--- a/packages/langium/test/workspace/ast-node-locator.test.ts
+++ b/packages/langium/test/workspace/ast-node-locator.test.ts
@@ -13,7 +13,7 @@ describe('DefaultAstNodeLocator', () => {
     const parser = parseHelper<Grammar>(grammarServices);
 
     test('computes correct paths', async () => {
-        const { document } = await parser(`
+        const document = await parser(`
             grammar Foo
             entry A: B | C;
             B: 'b';
@@ -27,7 +27,7 @@ describe('DefaultAstNodeLocator', () => {
     });
 
     test('resolves paths correctly', async () => {
-        const { document } = await parser(`
+        const document = await parser(`
             grammar Foo
             entry A: B | C;
             B: 'b';


### PR DESCRIPTION
Set unlinked document to Parsed state to gather new linked nodes in index.

Alternatively we could update the reference information in index after linking is done. Doing so we need to split the `IndexManager.processDocuments` implementation and call reference description update separately. 
In general I still wonder if the current order of DocumentStates is the right one, or better to say, if we are missing some in-between steps like IndexReferences.
