### PR TITLE
Add ability to return a multi-mode lexer

### DIFF
--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { IOrAlt, TokenType, TokenVocabulary } from 'chevrotain';
+import { IOrAlt, TokenType, TokenTypeDictionary, TokenVocabulary } from 'chevrotain';
 import { AbstractElement, Action, Alternatives, Condition, CrossReference, Grammar, Group, isAction, isAlternatives, isAssignment, isConjunction, isCrossReference, isDisjunction, isGroup, isKeyword, isLiteralCondition, isNegation, isParameterReference, isParserRule, isRuleCall, isTerminalRule, isUnorderedGroup, Keyword, NamedArgument, ParserRule, RuleCall, UnorderedGroup } from '../grammar/generated/ast';
 import { Cardinality, findNameAssignment, getTypeName, isArrayOperator, isDataTypeRule } from '../grammar/grammar-util';
 import { LangiumServices } from '../services';
@@ -22,7 +22,7 @@ type RuleContext = {
 
 type ParserContext = {
     parser: LangiumParser
-    tokens: Map<string, TokenType>
+    tokens: TokenTypeDictionary
     rules: Map<string, Rule>
 }
 
@@ -50,9 +50,8 @@ export function createLangiumParser(services: LangiumServices): LangiumParser {
  */
 export function prepareLangiumParser(services: LangiumServices): LangiumParser {
     const grammar = services.Grammar;
-    const tokens = new Map<string, TokenType>();
     const buildTokens = services.parser.TokenBuilder.buildTokens(grammar, { caseInsensitive: services.LanguageMetaData.caseInsensitive });
-    toTokenTypeArray(buildTokens).forEach(e => tokens.set(e.name, e));
+    const tokens = toTokenTypeDictionary(buildTokens);
 
     const rules = new Map<string, Rule>();
     const parser = new LangiumParser(services, buildTokens);
@@ -65,10 +64,12 @@ export function prepareLangiumParser(services: LangiumServices): LangiumParser {
     return parser;
 }
 
-function toTokenTypeArray(buildTokens: TokenVocabulary): TokenType[] {
-    if (isTokenTypeDictionary(buildTokens)) return Object.values(buildTokens);
-    if (isIMultiModeLexerDefinition(buildTokens)) return Object.values(buildTokens.modes).flat();
-    return buildTokens;
+function toTokenTypeDictionary(buildTokens: TokenVocabulary): TokenTypeDictionary {
+    if (isTokenTypeDictionary(buildTokens)) return buildTokens;
+    const tokens = isIMultiModeLexerDefinition(buildTokens) ? Object.values(buildTokens.modes).flat() : buildTokens;
+    const res: TokenTypeDictionary = {};
+    tokens.forEach(token => res[token.name] = token);
+    return res;
 }
 
 function getRule(ctx: ParserContext, name: string): Rule {
@@ -78,7 +79,7 @@ function getRule(ctx: ParserContext, name: string): Rule {
 }
 
 function getToken(ctx: ParserContext, name: string): TokenType {
-    const token = ctx.tokens.get(name);
+    const token = ctx.tokens[name];
     if (!token) throw new Error(`Token "${name}" not found."`);
     return token;
 }
@@ -280,7 +281,7 @@ const withKeywordSuffix = (name: string): string => name.endsWith(':KW') ? name 
 
 function buildKeyword(ctx: RuleContext, keyword: Keyword): Method {
     const idx = ctx.consume++;
-    const token = ctx.tokens.get(keyword.value);
+    const token = ctx.tokens[keyword.value];
     if (!token) {
         throw new Error('Could not find token for keyword: ' + keyword.value);
     }

--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -8,9 +8,9 @@ import { IOrAlt, TokenType, TokenTypeDictionary, TokenVocabulary } from 'chevrot
 import { AbstractElement, Action, Alternatives, Condition, CrossReference, Grammar, Group, isAction, isAlternatives, isAssignment, isConjunction, isCrossReference, isDisjunction, isGroup, isKeyword, isLiteralCondition, isNegation, isParameterReference, isParserRule, isRuleCall, isTerminalRule, isUnorderedGroup, Keyword, NamedArgument, ParserRule, RuleCall, UnorderedGroup } from '../grammar/generated/ast';
 import { Cardinality, findNameAssignment, getTypeName, isArrayOperator, isDataTypeRule } from '../grammar/grammar-util';
 import { LangiumServices } from '../services';
-import { hasContainerOfType, isIMultiModeLexerDefinition, isTokenTypeDictionary, streamAllContents } from '../utils/ast-util';
+import { hasContainerOfType, streamAllContents } from '../utils/ast-util';
 import { stream } from '../utils/stream';
-import { DatatypeSymbol, LangiumParser } from './langium-parser';
+import { DatatypeSymbol, isIMultiModeLexerDefinition, isTokenTypeDictionary, LangiumParser } from './langium-parser';
 
 type RuleContext = {
     optional: number,

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -5,12 +5,12 @@
  ******************************************************************************/
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { defaultParserErrorProvider, EmbeddedActionsParser, ILexingError, IOrAlt, IParserErrorMessageProvider, IRecognitionException, IToken, Lexer, TokenType, TokenVocabulary } from 'chevrotain';
+import { defaultParserErrorProvider, EmbeddedActionsParser, ILexingError, IMultiModeLexerDefinition, IOrAlt, IParserErrorMessageProvider, IRecognitionException, IToken, Lexer, TokenType, TokenTypeDictionary, TokenVocabulary } from 'chevrotain';
 import { AbstractElement, Action, Assignment, isAssignment, isCrossReference } from '../grammar/generated/ast';
 import { Linker } from '../references/linker';
 import { LangiumServices } from '../services';
 import { AstNode, CompositeCstNode, CstNode, LeafCstNode } from '../syntax-tree';
-import { getContainerOfType, isTokenTypeDictionary, linkContentToContainer } from '../utils/ast-util';
+import { getContainerOfType, linkContentToContainer } from '../utils/ast-util';
 import { tokenToRange } from '../utils/cst-util';
 import { CompositeCstNodeImpl, CstNodeBuilder, LeafCstNodeImpl, RootCstNodeImpl } from './cst-node-builder';
 import { IParserConfig } from './parser-config';
@@ -424,4 +424,25 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
     wrapAtLeastOne(idx: number, callback: () => void): void {
         this.atLeastOne(idx, callback);
     }
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is TokenType array
+ */
+export function isTokenTypeArray(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenType[] {
+    return Array.isArray(tokenVocabulary) && (tokenVocabulary.length === 0 || 'name' in tokenVocabulary[0]);
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is IMultiModeLexerDefinition
+ */
+export function isIMultiModeLexerDefinition(tokenVocabulary: TokenVocabulary): tokenVocabulary is IMultiModeLexerDefinition {
+    return tokenVocabulary && 'modes' in tokenVocabulary && 'defaultMode' in tokenVocabulary;
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is TokenTypeDictionary
+ */
+export function isTokenTypeDictionary(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenTypeDictionary {
+    return !isTokenTypeArray(tokenVocabulary) && !isIMultiModeLexerDefinition(tokenVocabulary);
 }

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -5,12 +5,12 @@
  ******************************************************************************/
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { defaultParserErrorProvider, EmbeddedActionsParser, ILexingError, IOrAlt, IParserErrorMessageProvider, IRecognitionException, IToken, Lexer, TokenType } from 'chevrotain';
+import { defaultParserErrorProvider, EmbeddedActionsParser, ILexingError, IOrAlt, IParserErrorMessageProvider, IRecognitionException, IToken, Lexer, TokenType, TokenVocabulary } from 'chevrotain';
 import { AbstractElement, Action, Assignment, isAssignment, isCrossReference } from '../grammar/generated/ast';
 import { Linker } from '../references/linker';
 import { LangiumServices } from '../services';
 import { AstNode, CompositeCstNode, CstNode, LeafCstNode } from '../syntax-tree';
-import { getContainerOfType, linkContentToContainer } from '../utils/ast-util';
+import { getContainerOfType, isTokenTypeDictionary, linkContentToContainer } from '../utils/ast-util';
 import { tokenToRange } from '../utils/cst-util';
 import { CompositeCstNodeImpl, CstNodeBuilder, LeafCstNodeImpl, RootCstNodeImpl } from './cst-node-builder';
 import { IParserConfig } from './parser-config';
@@ -51,11 +51,11 @@ export class LangiumParser {
         return this.stack[this.stack.length - 1];
     }
 
-    constructor(services: LangiumServices, tokens: TokenType[]) {
+    constructor(services: LangiumServices, tokens: TokenVocabulary) {
         this.wrapper = new ChevrotainWrapper(tokens, services.parser.ParserConfig);
         this.linker = services.references.Linker;
         this.converter = services.parser.ValueConverter;
-        this.lexer = new Lexer(tokens);
+        this.lexer = new Lexer(isTokenTypeDictionary(tokens) ? Object.values(tokens) : tokens);
     }
 
     MAIN_RULE(
@@ -380,7 +380,7 @@ class ChevrotainWrapper extends EmbeddedActionsParser {
     // This array is set in the base implementation of Chevrotain.
     definitionErrors: IParserDefinitionError[];
 
-    constructor(tokens: TokenType[], config?: IParserConfig) {
+    constructor(tokens: TokenVocabulary, config?: IParserConfig) {
         super(tokens, {
             ...defaultConfig,
             ...config

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -17,43 +17,22 @@ export interface TokenBuilder {
 
 export class DefaultTokenBuilder implements TokenBuilder {
 
-    // We need suffixes for terminals and keywords which have the same name
-    protected readonly KEYWORD_SUFFIX = '_KEYWORD';
-    protected readonly TERMINAL_SUFFIX = '_TERMINAL';
-
     buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenVocabulary {
-        const tokenMap = new Map<string, TokenType>();
-        const terminalsTokens: TokenType[] = [];
-        const terminals = Array.from(stream(grammar.rules).filter(isTerminalRule)).filter(e => !e.fragment);
-        for (const terminal of terminals) {
-            const token = this.buildTerminalToken(terminal);
-            terminalsTokens.push(token);
-            tokenMap.set(terminal.name + this.TERMINAL_SUFFIX, token);
-        }
+        const terminalTokens: TokenType[] = this.buildTerminalTokens(grammar);
+        const tokens: TokenType[] = this.buildKeywordTokens(grammar, terminalTokens, options);
 
-        const tokens: TokenType[] = [];
-        // We filter by parser rules, since keywords in terminal rules get transformed into regex and are not actual tokens
-        const parserRuleKeywords = grammar.rules.filter(isParserRule).flatMap(rule => streamAllContents(rule).filter(isKeyword).toArray());
-        const keywords = stream(parserRuleKeywords).distinct(e => e.value).toArray()
-            // Sort keywords by descending length
-            .sort((a, b) => b.value.length - a.value.length);
-
-        for (const keyword of keywords) {
-            const keywordToken = this.buildKeywordToken(keyword, keywords, terminals, tokenMap, !!options?.caseInsensitive);
-            tokens.push(keywordToken);
-            tokenMap.set(keyword.value + this.KEYWORD_SUFFIX, keywordToken);
-        }
-
-        for (const terminalToken of terminalsTokens) {
+        terminalTokens.forEach(terminalToken => {
             const pattern = terminalToken.PATTERN;
-            if (typeof pattern === 'object' && pattern && 'test' in pattern && pattern.test(' ')) {
-                tokens.unshift(terminalToken);
-            } else {
+            (typeof pattern === 'object' && pattern && 'test' in pattern && pattern.test(' ')) ?
+                tokens.unshift(terminalToken) :
                 tokens.push(terminalToken);
-            }
-        }
-
+        });
         return tokens;
+    }
+
+    protected buildTerminalTokens(grammar: Grammar): TokenType[] {
+        return Array.from(stream(grammar.rules).filter(isTerminalRule)).filter(e => !e.fragment)
+            .map(terminal => this.buildTerminalToken(terminal));
     }
 
     protected buildTerminalToken(terminal: TerminalRule): TokenType {
@@ -76,8 +55,21 @@ export class DefaultTokenBuilder implements TokenBuilder {
         return token;
     }
 
-    protected buildKeywordToken(keyword: Keyword, keywords: Keyword[], terminals: TerminalRule[], tokenMap: Map<string, TokenType>, caseInsensitive: boolean): TokenType {
-        const longerAlt = this.findLongerAlt(keyword, keywords, terminals, tokenMap);
+    protected buildKeywordTokens(grammar: Grammar, terminalTokens: TokenType[], options?: { caseInsensitive?: boolean }): TokenType[] {
+        // We filter by parser rules, since keywords in terminal rules get transformed into regex and are not actual tokens
+        const parserRuleKeywords = grammar.rules.filter(isParserRule).flatMap(rule => streamAllContents(rule).filter(isKeyword).toArray());
+        return stream(parserRuleKeywords).distinct(e => e.value).toArray()
+            // Sort keywords by descending length
+            .sort((a, b) => b.value.length - a.value.length)
+            .reduce(
+                (keywordTokens: TokenType[], keyword: Keyword) => {
+                    keywordTokens.push(this.buildKeywordToken(keyword, keywordTokens, terminalTokens, !!options?.caseInsensitive));
+                    return keywordTokens;
+                }, []);
+    }
+
+    protected buildKeywordToken(keyword: Keyword, keywordTokens: TokenType[], terminalTokens: TokenType[], caseInsensitive: boolean): TokenType {
+        const longerAlt = this.findLongerAlt(keyword, keywordTokens, terminalTokens);
         return { name: keyword.value, PATTERN: this.buildKeywordPattern(keyword, caseInsensitive), LONGER_ALT: longerAlt };
     }
 
@@ -87,20 +79,19 @@ export class DefaultTokenBuilder implements TokenBuilder {
             keyword.value;
     }
 
-    protected findLongerAlt(keyword: Keyword, keywords: Keyword[], terminals: TerminalRule[], tokenMap: Map<string, TokenType>): TokenType[] {
+    protected findLongerAlt(keyword: Keyword, keywordTokens: TokenType[], terminalTokens: TokenType[]): TokenType[] {
         const longerAlts: TokenType[] = [];
-        for (const otherKeyword of keywords) {
-            const tokenType = tokenMap.get(otherKeyword.value + this.KEYWORD_SUFFIX);
-            if (tokenType && otherKeyword.value.length > keyword.value.length && otherKeyword.value.startsWith(keyword.value)) {
-                longerAlts.push(tokenType);
+        keywordTokens.forEach(token => {
+            if (token.name.length > keyword.value.length && token.name.startsWith(keyword.value)) {
+                longerAlts.push(token);
             }
-        }
-        for (const terminal of terminals) {
-            const tokenType = tokenMap.get(terminal.name + this.TERMINAL_SUFFIX);
-            if (tokenType && partialMatches('^' + terminalRegex(terminal) + '$', keyword.value)) {
-                longerAlts.push(tokenType);
+        });
+        terminalTokens.forEach(token => {
+            const pattern = token?.PATTERN as RegExp;
+            if (pattern?.source && partialMatches('^' + pattern.source + '$', keyword.value)) {
+                longerAlts.push(token);
             }
-        }
+        });
         return longerAlts;
     }
 }

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { Lexer, TokenPattern, TokenType } from 'chevrotain';
+import { Lexer, TokenPattern, TokenType, TokenVocabulary } from 'chevrotain';
 import { Grammar, isKeyword, isParserRule, isTerminalRule, Keyword, TerminalRule } from '../grammar/generated/ast';
 import { terminalRegex } from '../grammar/grammar-util';
 import { streamAllContents } from '../utils/ast-util';
@@ -12,7 +12,7 @@ import { getCaseInsensitivePattern, partialMatches } from '../utils/regex-util';
 import { stream } from '../utils/stream';
 
 export interface TokenBuilder {
-    buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenType[];
+    buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenVocabulary;
 }
 
 export class DefaultTokenBuilder implements TokenBuilder {
@@ -21,7 +21,7 @@ export class DefaultTokenBuilder implements TokenBuilder {
     protected readonly KEYWORD_SUFFIX = '_KEYWORD';
     protected readonly TERMINAL_SUFFIX = '_TERMINAL';
 
-    buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenType[] {
+    buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenVocabulary {
         const tokenMap = new Map<string, TokenType>();
         const terminalsTokens: TokenType[] = [];
         const terminals = Array.from(stream(grammar.rules).filter(isTerminalRule)).filter(e => !e.fragment);

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { IMultiModeLexerDefinition, TokenType, TokenTypeDictionary, TokenVocabulary } from 'chevrotain';
 import { AstNode, AstNodeDescription, LinkingError, Reference, ReferenceInfo } from '../syntax-tree';
 import { DONE_RESULT, Stream, stream, StreamImpl, TreeStream, TreeStreamImpl } from '../utils/stream';
 import { LangiumDocument } from '../workspace/documents';
@@ -202,4 +203,25 @@ export function findLocalReferences(targetNode: AstNode, lookup = getDocument(ta
     process(lookup);
     streamAllContents(lookup).forEach(node => process(node));
     return stream(refs);
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is TokenType array
+ */
+export function isTokenTypeArray(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenType[] {
+    return Array.isArray(tokenVocabulary) && (tokenVocabulary.length === 0 || 'name' in tokenVocabulary[0]);
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is IMultiModeLexerDefinition
+ */
+export function isIMultiModeLexerDefinition(tokenVocabulary: TokenVocabulary): tokenVocabulary is IMultiModeLexerDefinition {
+    return tokenVocabulary && 'modes' in tokenVocabulary && 'defaultMode' in tokenVocabulary;
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is TokenTypeDictionary
+ */
+export function isTokenTypeDictionary(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenTypeDictionary {
+    return !isTokenTypeArray(tokenVocabulary) && !isIMultiModeLexerDefinition(tokenVocabulary);
 }

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -4,7 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { IMultiModeLexerDefinition, TokenType, TokenTypeDictionary, TokenVocabulary } from 'chevrotain';
 import { AstNode, AstNodeDescription, LinkingError, Reference, ReferenceInfo } from '../syntax-tree';
 import { DONE_RESULT, Stream, stream, StreamImpl, TreeStream, TreeStreamImpl } from '../utils/stream';
 import { LangiumDocument } from '../workspace/documents';
@@ -203,25 +202,4 @@ export function findLocalReferences(targetNode: AstNode, lookup = getDocument(ta
     process(lookup);
     streamAllContents(lookup).forEach(node => process(node));
     return stream(refs);
-}
-
-/**
- * Returns a check whether the given TokenVocabulary is TokenType array
- */
-export function isTokenTypeArray(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenType[] {
-    return Array.isArray(tokenVocabulary) && (tokenVocabulary.length === 0 || 'name' in tokenVocabulary[0]);
-}
-
-/**
- * Returns a check whether the given TokenVocabulary is IMultiModeLexerDefinition
- */
-export function isIMultiModeLexerDefinition(tokenVocabulary: TokenVocabulary): tokenVocabulary is IMultiModeLexerDefinition {
-    return tokenVocabulary && 'modes' in tokenVocabulary && 'defaultMode' in tokenVocabulary;
-}
-
-/**
- * Returns a check whether the given TokenVocabulary is TokenTypeDictionary
- */
-export function isTokenTypeDictionary(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenTypeDictionary {
-    return !isTokenTypeArray(tokenVocabulary) && !isIMultiModeLexerDefinition(tokenVocabulary);
 }

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -24,7 +24,7 @@ describe('tokenBuilder', () => {
         terminal AB: 'A' Frag;
         `;
         const grammar = (await helper(text)).parseResult.value;
-        tokens = tokenBuilder.buildTokens(grammar);
+        tokens = tokenBuilder.buildTokens(grammar) as TokenType[];
     });
 
     test('should only create non-fragment terminals', () => {
@@ -48,7 +48,7 @@ describe('tokenBuilder#longerAlts', () => {
         terminal AB: /ABD?/;
         `;
         const grammar = (await helper(text)).parseResult.value;
-        const tokens = tokenBuilder.buildTokens(grammar);
+        const tokens = tokenBuilder.buildTokens(grammar) as TokenType[];
         aToken = tokens[2];
         abToken = tokens[1];
         abcToken = tokens[0];
@@ -96,7 +96,7 @@ describe('tokenBuilder#caseInsensitivePattern', () => {
         terminal AB: /ABD?/;
         `;
         const grammar = (await parseHelper<Grammar>(grammarServices)(text)).parseResult.value;
-        const tokens = tokenBuilder.buildTokens(grammar, { caseInsensitive: true });
+        const tokens = tokenBuilder.buildTokens(grammar, { caseInsensitive: true }) as TokenType[];
         const patterns = tokens.map(token => token.PATTERN);
 
         implementPattern = patterns[0];

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -58,13 +58,13 @@ describe('tokenBuilder#longerAlts', () => {
     test('should create longer alts for keywords # 1', () => {
         expect(Array.isArray(aToken.LONGER_ALT)).toBeTruthy();
         const longerAlts = aToken.LONGER_ALT as TokenType[];
-        expect(longerAlts).toEqual([abcToken, abToken, abTerminalToken]);
+        expect(longerAlts).toEqual([abTerminalToken]);
     });
 
     test('should create longer alts for keywords # 2', () => {
         expect(Array.isArray(abToken.LONGER_ALT)).toBeTruthy();
         const longerAlts = abToken.LONGER_ALT as TokenType[];
-        expect(longerAlts).toEqual([abcToken, abTerminalToken]);
+        expect(longerAlts).toEqual([abTerminalToken]);
     });
 
     test('should create no longer alts for longest keyword', () => {


### PR DESCRIPTION
Closes [#320](https://github.com/langium/langium/issues/320).
* Adds ability to return a multi-mode lexer by modification of `TokenBuilder` API (`buildTokens` returns `TokenVocabulary` instead of just `TokenType[]`)
* Refactors `DefaultTokenBuilder` to make it more modular