### PR TITLE
Refactored validation in document builder

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,10 @@ tasks:
   - before: npm install -g npm@^7.7.0
     init: npm install
 
+ports:
+  - port: 6000-6999
+    onOpen: ignore
+
 vscode:
   extensions:
     - langium.langium-vscode

--- a/examples/arithmetics/src/cli/cli-util.ts
+++ b/examples/arithmetics/src/cli/cli-util.ts
@@ -22,7 +22,7 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    await services.shared.workspace.DocumentBuilder.build([document]);
+    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {

--- a/examples/arithmetics/src/language-server/arithmetics-scope-provider.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-scope-provider.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstNodeDescription, DefaultScopeProvider, Scope, SimpleScope, Stream } from 'langium';
+import { AstNodeDescription, DefaultScopeProvider, Scope, Stream, StreamScope } from 'langium';
 
 /**
  * Special scope provider that matches symbol names regardless of lowercase or uppercase.
@@ -12,11 +12,11 @@ import { AstNodeDescription, DefaultScopeProvider, Scope, SimpleScope, Stream } 
 export class ArithmeticsScopeProvider extends DefaultScopeProvider {
 
     protected createScope(elements: Stream<AstNodeDescription>, outerScope: Scope): Scope {
-        return new SimpleScope(elements, outerScope, { caseInsensitive: true });
+        return new StreamScope(elements, outerScope, { caseInsensitive: true });
     }
 
     protected getGlobalScope(referenceType: string): Scope {
-        return new SimpleScope(this.indexManager.allElements(referenceType), undefined, { caseInsensitive: true });
+        return new StreamScope(this.indexManager.allElements(referenceType), undefined, { caseInsensitive: true });
     }
 
 }

--- a/examples/domainmodel/example/qualified-names.dmodel
+++ b/examples/domainmodel/example/qualified-names.dmodel
@@ -1,5 +1,3 @@
-datatype String
-
 entity E1 {
     name: String
 }

--- a/examples/domainmodel/src/cli/cli-util.ts
+++ b/examples/domainmodel/src/cli/cli-util.ts
@@ -23,9 +23,9 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    await services.shared.workspace.DocumentBuilder.build([document]);
+    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
 
-    const validationErrors = (document.diagnostics??[]).filter(e => e.severity === 1);
+    const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         console.error(colors.red('There are validation errors:'));
         for (const validationError of validationErrors) {

--- a/examples/statemachine/src/cli/cli-util.ts
+++ b/examples/statemachine/src/cli/cli-util.ts
@@ -22,7 +22,7 @@ export async function extractDocument(fileName: string, extensions: string[], se
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    await services.shared.workspace.DocumentBuilder.build([document]);
+    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {

--- a/packages/generator-langium/langium-template/src/cli/cli-util.ts
+++ b/packages/generator-langium/langium-template/src/cli/cli-util.ts
@@ -17,9 +17,9 @@ export async function extractDocument(fileName: string, services: LangiumService
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    const buildResult = await services.shared.workspace.DocumentBuilder.build(document);
+    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
 
-    const validationErrors = buildResult.diagnostics.filter(e => e.severity === 1);
+    const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         console.error(colors.red('There are validation errors:'));
         for (const validationError of validationErrors) {

--- a/packages/langium/src/references/scope.ts
+++ b/packages/langium/src/references/scope.ts
@@ -16,12 +16,32 @@ import { LangiumDocument, PrecomputedScopes } from '../workspace/documents';
 import { IndexManager } from '../workspace/index-manager';
 import { NameProvider } from './naming';
 
+/**
+ * A scope describes what target elements are visible from a specific cross-reference context.
+ */
 export interface Scope {
+    /**
+     * Find a target element matching the given name. If no element is found, `undefined` is returned.
+     * If multiple matching elements are present, the selection of the returned element should be done
+     * according to the semantics of your language. Usually it is the element that is most closely defined.
+     *
+     * @param name Name of the cross-reference target as it appears in the source text.
+     */
     getElement(name: string): AstNodeDescription | undefined
+
+    /**
+     * Create a stream of all elements in the scope. This is used to compute completion proposals to be
+     * shown in the editor.
+     */
     getAllElements(): Stream<AstNodeDescription>
 }
 
-export class SimpleScope implements Scope {
+/**
+ * The default scope implementation is based on a `Stream`. It has an optional _outer scope_ describing
+ * the next level of elements, which are queried when a target element is not found in the stream provided
+ * to this scope.
+ */
+export class StreamScope implements Scope {
     readonly elements: Stream<AstNodeDescription>;
     readonly outerScope?: Scope;
     readonly caseInsensitive?: boolean;
@@ -63,7 +83,18 @@ export const EMPTY_SCOPE: Scope = {
     }
 };
 
+/**
+ * Determines the scope of target elements visible in a specific cross-reference context.
+ */
 export interface ScopeProvider {
+    /**
+     * Return a scope describing what elements are visible for the given AST node and cross-reference
+     * identifier.
+     *
+     * @param node The AST node holding the cross-reference.
+     * @param referenceId Identifier of the cross-reference in the form `Type:property` (see
+     *     `getReferenceId` utility function).
+     */
     getScope(node: AstNode, referenceId: string): Scope;
 }
 
@@ -104,27 +135,43 @@ export class DefaultScopeProvider implements ScopeProvider {
      * Create a scope for the given precomputed stream of elements.
      */
     protected createScope(elements: Stream<AstNodeDescription>, outerScope: Scope): Scope {
-        return new SimpleScope(elements, outerScope);
+        return new StreamScope(elements, outerScope);
     }
 
     /**
      * Create a global scope filtered for the given reference type.
      */
     protected getGlobalScope(referenceType: string): Scope {
-        return new SimpleScope(this.indexManager.allElements(referenceType));
+        return new StreamScope(this.indexManager.allElements(referenceType));
     }
 }
 
+/**
+ * This service is executed as part of the _preprocessing_ phase in the `DocumentBuilder`.
+ */
 export interface ScopeComputation {
     /**
-     * Computes the scope for a document
-     * @param document specified document for scope computation
-     * @param cancelToken allows to cancel the current operation
+     * Precomputes the scopes for a document. The result is a multimap assigning a set of AST node
+     * descriptions to every level of the AST. These data are used by the `ScopeProvider` service
+     * to determine which target nodes are visible in the context of a specific cross-reference.
+     *
+     * _Note:_ You should not resolve any cross-references in this service method. Cross-reference
+     * resolution depends on the preprocessing phase to be completed.
+     *
+     * @param document The document in which to compute scopes.
+     * @param cancelToken Indicates when to cancel the current operation.
      * @throws `OperationCanceled` if a user action occurs during execution
      */
     computeScope(document: LangiumDocument, cancelToken?: CancellationToken): Promise<PrecomputedScopes>;
 }
 
+/**
+ * The default scope computation gathers all AST nodes that have a name (according to the `NameProvider`
+ * service) and makes them available in their container node. As a result, from every cross-reference in
+ * the AST, target elements from the same level and further up towards the root are visible. Elements that
+ * are nested inside lower levels are not visible by default, but that can be changed by customizing this
+ * service.
+ */
 export class DefaultScopeComputation implements ScopeComputation {
     protected readonly nameProvider: NameProvider;
     protected readonly descriptions: AstNodeDescriptionProvider;

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -36,15 +36,19 @@ export type Properties<N extends AstNode> = keyof Omit<N, keyof AstNode | number
  * A cross-reference in the AST. Cross-references may or may not be successfully resolved.
  */
 export interface Reference<T extends AstNode = AstNode> {
-    /** The target AST node of this reference. In case the reference cannot be resolved, the value is `undefined`. */
+    /**
+     * The target AST node of this reference. Accessing this property may trigger cross-reference
+     * resolution by the `Linker` in case it has not been done yet. If the reference cannot be resolved,
+     * the value is `undefined`.
+     */
     readonly ref?: T;
+
     /** If any problem occurred while resolving the reference, it is described by this property. */
     readonly error?: LinkingError;
     /** The CST node from which the reference was parsed */
     readonly $refNode: CstNode;
     /** The actual text used to look up in the surrounding scope */
     readonly $refText: string;
-
     /** The node description for the AstNode returned by `ref`  */
     readonly $nodeDescription?: AstNodeDescription;
 }


### PR DESCRIPTION
I refactored the validation process in `DocumentBuilder`:

 * Added `BuildOptions` type. Later we can extend this to support partial validation, for example when there are checks that shall be executed only when a document is saved to disk. With the new options, you have full control over which validations to run in a CLI, for example.
 * The `DocumentBuilder` no longer reports diagnostics to the client. This is now done with a build phase listener that is invoked at the end of every rebuild.
 * `IndexManager` methods accept a single document so they fit better in the general phase scheme of `DocumentBuilder`.
 * Renamed `SimpleScope` to `StreamScope`.
 * Added more code comments in the scoping / references area.