### PR TITLE
Add types declaration

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -14,8 +14,7 @@ Definition:
 DeclaredParameter:
 	name=ID;
 
-AbstractDefinition:
-	Definition | DeclaredParameter;
+type AbstractDefinition = Definition | DeclaredParameter;
 
 Evaluation:
 	expression=Expression ';';

--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -7,10 +7,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import { AstNode, AstReflection, Reference, isAstNode } from 'langium';
 
-export interface AbstractDefinition extends AstNode {
-    readonly $container: Definition | Module;
-    name: string
-}
+export type AbstractDefinition = Definition | DeclaredParameter;
 
 export const AbstractDefinition = 'AbstractDefinition';
 
@@ -49,7 +46,8 @@ export function isStatement(item: unknown): item is Statement {
     return reflection.isInstance(item, Statement);
 }
 
-export interface DeclaredParameter extends AbstractDefinition {
+export interface DeclaredParameter extends AstNode {
+    name: string
 }
 
 export const DeclaredParameter = 'DeclaredParameter';
@@ -58,9 +56,10 @@ export function isDeclaredParameter(item: unknown): item is DeclaredParameter {
     return reflection.isInstance(item, DeclaredParameter);
 }
 
-export interface Definition extends Statement, AbstractDefinition {
+export interface Definition extends Statement {
     args: Array<DeclaredParameter>
     expr: Expression
+    name: string
 }
 
 export const Definition = 'Definition';

--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -45,7 +45,7 @@ export function isBinaryExpression(item: unknown): item is BinaryExpression {
 }
 
 export interface DeclaredParameter extends AstNode {
-    readonly $container: Definition | Module;
+    readonly $container: Definition;
     name: string
 }
 
@@ -56,7 +56,7 @@ export function isDeclaredParameter(item: unknown): item is DeclaredParameter {
 }
 
 export interface Definition extends AstNode {
-    readonly $container: Definition | Module;
+    readonly $container: Module;
     args: Array<DeclaredParameter>
     expr: Expression
     name: string
@@ -69,7 +69,7 @@ export function isDefinition(item: unknown): item is Definition {
 }
 
 export interface Evaluation extends AstNode {
-    readonly $container: Definition | Module;
+    readonly $container: Module;
     expression: Expression
 }
 
@@ -132,16 +132,16 @@ export class ArithmeticsAstReflection implements AstReflection {
             return true;
         }
         switch (subtype) {
-            case BinaryExpression:
-            case FunctionCall:
-            case NumberLiteral: {
-                return this.isSubtype(Expression, supertype);
+            case Definition: {
+                return this.isSubtype(AbstractDefinition, supertype) || this.isSubtype(Statement, supertype);
             }
             case DeclaredParameter: {
                 return this.isSubtype(AbstractDefinition, supertype);
             }
-            case Definition: {
-                return this.isSubtype(Statement, supertype) || this.isSubtype(AbstractDefinition, supertype);
+            case BinaryExpression:
+            case NumberLiteral:
+            case FunctionCall: {
+                return this.isSubtype(Expression, supertype);
             }
             case Evaluation: {
                 return this.isSubtype(Statement, supertype);

--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -31,15 +31,17 @@ export function isStatement(item: unknown): item is Statement {
     return reflection.isInstance(item, Statement);
 }
 
-export interface Module extends AstNode {
-    name: string
-    statements: Array<Statement>
+export interface BinaryExpression extends AstNode {
+    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
+    left: Expression
+    operator: '*' | '+' | '-' | '/'
+    right: Expression
 }
 
-export const Module = 'Module';
+export const BinaryExpression = 'BinaryExpression';
 
-export function isModule(item: unknown): item is Module {
-    return reflection.isInstance(item, Module);
+export function isBinaryExpression(item: unknown): item is BinaryExpression {
+    return reflection.isInstance(item, BinaryExpression);
 }
 
 export interface DeclaredParameter extends AstNode {
@@ -66,17 +68,15 @@ export function isDefinition(item: unknown): item is Definition {
     return reflection.isInstance(item, Definition);
 }
 
-export interface BinaryExpression extends AstNode {
-    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
-    left: Expression
-    operator: '*' | '+' | '-' | '/'
-    right: Expression
+export interface Evaluation extends AstNode {
+    readonly $container: Definition | Module;
+    expression: Expression
 }
 
-export const BinaryExpression = 'BinaryExpression';
+export const Evaluation = 'Evaluation';
 
-export function isBinaryExpression(item: unknown): item is BinaryExpression {
-    return reflection.isInstance(item, BinaryExpression);
+export function isEvaluation(item: unknown): item is Evaluation {
+    return reflection.isInstance(item, Evaluation);
 }
 
 export interface FunctionCall extends AstNode {
@@ -91,6 +91,17 @@ export function isFunctionCall(item: unknown): item is FunctionCall {
     return reflection.isInstance(item, FunctionCall);
 }
 
+export interface Module extends AstNode {
+    name: string
+    statements: Array<Statement>
+}
+
+export const Module = 'Module';
+
+export function isModule(item: unknown): item is Module {
+    return reflection.isInstance(item, Module);
+}
+
 export interface NumberLiteral extends AstNode {
     readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     value: number
@@ -102,25 +113,14 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
     return reflection.isInstance(item, NumberLiteral);
 }
 
-export interface Evaluation extends AstNode {
-    readonly $container: Definition | Module;
-    expression: Expression
-}
-
-export const Evaluation = 'Evaluation';
-
-export function isEvaluation(item: unknown): item is Evaluation {
-    return reflection.isInstance(item, Evaluation);
-}
-
-export type ArithmeticsAstType = 'AbstractDefinition' | 'Expression' | 'Module' | 'Statement' | 'DeclaredParameter' | 'Definition' | 'BinaryExpression' | 'FunctionCall' | 'NumberLiteral' | 'Evaluation';
+export type ArithmeticsAstType = 'AbstractDefinition' | 'BinaryExpression' | 'DeclaredParameter' | 'Definition' | 'Evaluation' | 'Expression' | 'FunctionCall' | 'Module' | 'NumberLiteral' | 'Statement';
 
 export type ArithmeticsAstReference = 'FunctionCall:func';
 
 export class ArithmeticsAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractDefinition', 'Expression', 'Module', 'Statement', 'DeclaredParameter', 'Definition', 'BinaryExpression', 'FunctionCall', 'NumberLiteral', 'Evaluation'];
+        return ['AbstractDefinition', 'BinaryExpression', 'DeclaredParameter', 'Definition', 'Evaluation', 'Expression', 'FunctionCall', 'Module', 'NumberLiteral', 'Statement'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -132,16 +132,16 @@ export class ArithmeticsAstReflection implements AstReflection {
             return true;
         }
         switch (subtype) {
+            case BinaryExpression:
+            case FunctionCall:
+            case NumberLiteral: {
+                return this.isSubtype(Expression, supertype);
+            }
             case DeclaredParameter: {
                 return this.isSubtype(AbstractDefinition, supertype);
             }
             case Definition: {
                 return this.isSubtype(Statement, supertype) || this.isSubtype(AbstractDefinition, supertype);
-            }
-            case BinaryExpression:
-            case FunctionCall:
-            case NumberLiteral: {
-                return this.isSubtype(Expression, supertype);
             }
             case Evaluation: {
                 return this.isSubtype(Statement, supertype);

--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -132,16 +132,16 @@ export class ArithmeticsAstReflection implements AstReflection {
             return true;
         }
         switch (subtype) {
-            case Definition: {
-                return this.isSubtype(AbstractDefinition, supertype) || this.isSubtype(Statement, supertype);
+            case BinaryExpression:
+            case FunctionCall:
+            case NumberLiteral: {
+                return this.isSubtype(Expression, supertype);
             }
             case DeclaredParameter: {
                 return this.isSubtype(AbstractDefinition, supertype);
             }
-            case BinaryExpression:
-            case NumberLiteral:
-            case FunctionCall: {
-                return this.isSubtype(Expression, supertype);
+            case Definition: {
+                return this.isSubtype(Statement, supertype) || this.isSubtype(AbstractDefinition, supertype);
             }
             case Evaluation: {
                 return this.isSubtype(Statement, supertype);

--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -15,14 +15,20 @@ export function isAbstractDefinition(item: unknown): item is AbstractDefinition 
     return reflection.isInstance(item, AbstractDefinition);
 }
 
-export interface Expression extends AstNode {
-    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
-}
+export type Expression = BinaryExpression | NumberLiteral | FunctionCall;
 
 export const Expression = 'Expression';
 
 export function isExpression(item: unknown): item is Expression {
     return reflection.isInstance(item, Expression);
+}
+
+export type Statement = Definition | Evaluation;
+
+export const Statement = 'Statement';
+
+export function isStatement(item: unknown): item is Statement {
+    return reflection.isInstance(item, Statement);
 }
 
 export interface Module extends AstNode {
@@ -36,17 +42,8 @@ export function isModule(item: unknown): item is Module {
     return reflection.isInstance(item, Module);
 }
 
-export interface Statement extends AstNode {
-    readonly $container: Definition | Module;
-}
-
-export const Statement = 'Statement';
-
-export function isStatement(item: unknown): item is Statement {
-    return reflection.isInstance(item, Statement);
-}
-
 export interface DeclaredParameter extends AstNode {
+    readonly $container: Definition | Module;
     name: string
 }
 
@@ -56,7 +53,8 @@ export function isDeclaredParameter(item: unknown): item is DeclaredParameter {
     return reflection.isInstance(item, DeclaredParameter);
 }
 
-export interface Definition extends Statement {
+export interface Definition extends AstNode {
+    readonly $container: Definition | Module;
     args: Array<DeclaredParameter>
     expr: Expression
     name: string
@@ -68,7 +66,8 @@ export function isDefinition(item: unknown): item is Definition {
     return reflection.isInstance(item, Definition);
 }
 
-export interface BinaryExpression extends Expression {
+export interface BinaryExpression extends AstNode {
+    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     left: Expression
     operator: '*' | '+' | '-' | '/'
     right: Expression
@@ -80,7 +79,8 @@ export function isBinaryExpression(item: unknown): item is BinaryExpression {
     return reflection.isInstance(item, BinaryExpression);
 }
 
-export interface FunctionCall extends Expression {
+export interface FunctionCall extends AstNode {
+    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     args: Array<Expression>
     func: Reference<AbstractDefinition>
 }
@@ -91,7 +91,8 @@ export function isFunctionCall(item: unknown): item is FunctionCall {
     return reflection.isInstance(item, FunctionCall);
 }
 
-export interface NumberLiteral extends Expression {
+export interface NumberLiteral extends AstNode {
+    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     value: number
 }
 
@@ -101,7 +102,8 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
     return reflection.isInstance(item, NumberLiteral);
 }
 
-export interface Evaluation extends Statement {
+export interface Evaluation extends AstNode {
+    readonly $container: Definition | Module;
     expression: Expression
 }
 

--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -7,7 +7,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import { AstNode, AstReflection, Reference, isAstNode } from 'langium';
 
-export type AbstractDefinition = Definition | DeclaredParameter;
+export type AbstractDefinition = DeclaredParameter | Definition;
 
 export const AbstractDefinition = 'AbstractDefinition';
 
@@ -15,7 +15,7 @@ export function isAbstractDefinition(item: unknown): item is AbstractDefinition 
     return reflection.isInstance(item, AbstractDefinition);
 }
 
-export type Expression = BinaryExpression | NumberLiteral | FunctionCall;
+export type Expression = BinaryExpression | FunctionCall | NumberLiteral;
 
 export const Expression = 'Expression';
 

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -572,6 +572,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       }
     }
   ],
+  "types": [],
   "isDeclared": true,
   "name": "Arithmetics"
 }`));

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -273,7 +273,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "Addition",
       "hiddenTokens": [],
-      "type": "Expression",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Expression"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -337,7 +340,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "Multiplication",
       "hiddenTokens": [],
-      "type": "Expression",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Expression"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -401,7 +407,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "PrimaryExpression",
       "hiddenTokens": [],
-      "type": "Expression",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Expression"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -544,7 +553,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
     {
       "$type": "TerminalRule",
       "name": "NUMBER",
-      "type": "number",
+      "type": {
+        "$type": "ReturnType",
+        "name": "number"
+      },
       "terminal": {
         "$type": "RegexToken",
         "regex": "[0-9]+(\\\\.[0-9])?",

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -585,6 +585,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
     }
   ],
   "interfaces": [],
+  "types": [],
   "isDeclared": true,
   "name": "Arithmetics"
 }`));

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -584,7 +584,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       }
     }
   ],
-  "types": [],
+  "interfaces": [],
   "isDeclared": true,
   "name": "Arithmetics"
 }`));

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -202,33 +202,6 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
     {
       "$type": "ParserRule",
       "parameters": [],
-      "name": "AbstractDefinition",
-      "hiddenTokens": [],
-      "alternatives": {
-        "$type": "Alternatives",
-        "elements": [
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "Definition"
-            },
-            "elements": []
-          },
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "DeclaredParameter"
-            },
-            "elements": []
-          }
-        ]
-      }
-    },
-    {
-      "$type": "ParserRule",
-      "parameters": [],
       "name": "Evaluation",
       "hiddenTokens": [],
       "alternatives": {
@@ -585,7 +558,26 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
     }
   ],
   "interfaces": [],
-  "types": [],
+  "types": [
+    {
+      "$type": "Type",
+      "typeAlternatives": [
+        {
+          "$type": "AtomType",
+          "refType": {
+            "$refText": "Definition"
+          }
+        },
+        {
+          "$type": "AtomType",
+          "refType": {
+            "$refText": "DeclaredParameter"
+          }
+        }
+      ],
+      "name": "AbstractDefinition"
+    }
+  ],
   "isDeclared": true,
   "name": "Arithmetics"
 }`));

--- a/examples/domainmodel/src/language-server/domain-model.langium
+++ b/examples/domainmodel/src/language-server/domain-model.langium
@@ -23,7 +23,7 @@ Entity:
     '}';
 
 Feature:
-    (many?='many')? name=ID ':' type=[Type:QualifiedName];
+    (many?='many')? name=ID ':' ^type=[Type:QualifiedName];
 
 QualifiedName returns string:
     ID ('.' ID)*;

--- a/examples/domainmodel/src/language-server/domain-model.langium
+++ b/examples/domainmodel/src/language-server/domain-model.langium
@@ -23,7 +23,7 @@ Entity:
     '}';
 
 Feature:
-    (many?='many')? name=ID ':' ^type=[Type:QualifiedName];
+    (many?='many')? name=ID ':' type=[Type:QualifiedName];
 
 QualifiedName returns string:
     ID ('.' ID)*;

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -7,9 +7,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import { AstNode, AstReflection, Reference, isAstNode } from 'langium';
 
-export interface AbstractElement extends AstNode {
-    readonly $container: Domainmodel | PackageDeclaration;
-}
+export type AbstractElement = PackageDeclaration | Type;
 
 export const AbstractElement = 'AbstractElement';
 
@@ -40,7 +38,7 @@ export function isFeature(item: unknown): item is Feature {
     return reflection.isInstance(item, Feature);
 }
 
-export interface PackageDeclaration extends AbstractElement {
+export interface PackageDeclaration extends AstNode {
     elements: Array<AbstractElement>
     name: QualifiedName
 }
@@ -51,9 +49,7 @@ export function isPackageDeclaration(item: unknown): item is PackageDeclaration 
     return reflection.isInstance(item, PackageDeclaration);
 }
 
-export interface Type extends AbstractElement {
-    name: string
-}
+export type Type = DataType | Entity;
 
 export const Type = 'Type';
 
@@ -61,7 +57,8 @@ export function isType(item: unknown): item is Type {
     return reflection.isInstance(item, Type);
 }
 
-export interface DataType extends Type {
+export interface DataType extends AstNode {
+    name: string
 }
 
 export const DataType = 'DataType';
@@ -70,8 +67,9 @@ export function isDataType(item: unknown): item is DataType {
     return reflection.isInstance(item, DataType);
 }
 
-export interface Entity extends Type {
+export interface Entity extends AstNode {
     features: Array<Feature>
+    name: string
     superType?: Reference<Entity>
 }
 

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -15,6 +15,8 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
 }
 
+export type QualifiedName = string;
+
 export type Type = DataType | Entity;
 
 export const Type = 'Type';
@@ -22,8 +24,6 @@ export const Type = 'Type';
 export function isType(item: unknown): item is Type {
     return reflection.isInstance(item, Type);
 }
-
-export type QualifiedName = string;
 
 export interface DataType extends AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
@@ -103,13 +103,13 @@ export class DomainModelAstReflection implements AstReflection {
             return true;
         }
         switch (subtype) {
-            case DataType:
-            case Entity: {
-                return this.isSubtype(Type, supertype);
-            }
             case PackageDeclaration:
             case Type: {
                 return this.isSubtype(AbstractElement, supertype);
+            }
+            case DataType:
+            case Entity: {
+                return this.isSubtype(Type, supertype);
             }
             default: {
                 return false;

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -23,6 +23,8 @@ export function isType(item: unknown): item is Type {
     return reflection.isInstance(item, Type);
 }
 
+export type QualifiedName = string;
+
 export interface DataType extends AstNode {
     readonly $container: Domainmodel | PackageDeclaration;
     name: string
@@ -81,8 +83,6 @@ export const PackageDeclaration = 'PackageDeclaration';
 export function isPackageDeclaration(item: unknown): item is PackageDeclaration {
     return reflection.isInstance(item, PackageDeclaration);
 }
-
-export type QualifiedName = string
 
 export type DomainModelAstType = 'AbstractElement' | 'DataType' | 'Domainmodel' | 'Entity' | 'Feature' | 'PackageDeclaration' | 'Type';
 

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -15,6 +15,14 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
 }
 
+export type Type = DataType | Entity;
+
+export const Type = 'Type';
+
+export function isType(item: unknown): item is Type {
+    return reflection.isInstance(item, Type);
+}
+
 export interface Domainmodel extends AstNode {
     elements: Array<AbstractElement>
 }
@@ -39,6 +47,7 @@ export function isFeature(item: unknown): item is Feature {
 }
 
 export interface PackageDeclaration extends AstNode {
+    readonly $container: Domainmodel | PackageDeclaration;
     elements: Array<AbstractElement>
     name: QualifiedName
 }
@@ -49,15 +58,8 @@ export function isPackageDeclaration(item: unknown): item is PackageDeclaration 
     return reflection.isInstance(item, PackageDeclaration);
 }
 
-export type Type = DataType | Entity;
-
-export const Type = 'Type';
-
-export function isType(item: unknown): item is Type {
-    return reflection.isInstance(item, Type);
-}
-
 export interface DataType extends AstNode {
+    readonly $container: Domainmodel | PackageDeclaration;
     name: string
 }
 
@@ -68,6 +70,7 @@ export function isDataType(item: unknown): item is DataType {
 }
 
 export interface Entity extends AstNode {
+    readonly $container: Domainmodel | PackageDeclaration;
     features: Array<Feature>
     name: string
     superType?: Reference<Entity>

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -23,6 +23,17 @@ export function isType(item: unknown): item is Type {
     return reflection.isInstance(item, Type);
 }
 
+export interface DataType extends AstNode {
+    readonly $container: Domainmodel | PackageDeclaration;
+    name: string
+}
+
+export const DataType = 'DataType';
+
+export function isDataType(item: unknown): item is DataType {
+    return reflection.isInstance(item, DataType);
+}
+
 export interface Domainmodel extends AstNode {
     elements: Array<AbstractElement>
 }
@@ -31,6 +42,19 @@ export const Domainmodel = 'Domainmodel';
 
 export function isDomainmodel(item: unknown): item is Domainmodel {
     return reflection.isInstance(item, Domainmodel);
+}
+
+export interface Entity extends AstNode {
+    readonly $container: Domainmodel | PackageDeclaration;
+    features: Array<Feature>
+    name: string
+    superType?: Reference<Entity>
+}
+
+export const Entity = 'Entity';
+
+export function isEntity(item: unknown): item is Entity {
+    return reflection.isInstance(item, Entity);
 }
 
 export interface Feature extends AstNode {
@@ -58,40 +82,16 @@ export function isPackageDeclaration(item: unknown): item is PackageDeclaration 
     return reflection.isInstance(item, PackageDeclaration);
 }
 
-export interface DataType extends AstNode {
-    readonly $container: Domainmodel | PackageDeclaration;
-    name: string
-}
-
-export const DataType = 'DataType';
-
-export function isDataType(item: unknown): item is DataType {
-    return reflection.isInstance(item, DataType);
-}
-
-export interface Entity extends AstNode {
-    readonly $container: Domainmodel | PackageDeclaration;
-    features: Array<Feature>
-    name: string
-    superType?: Reference<Entity>
-}
-
-export const Entity = 'Entity';
-
-export function isEntity(item: unknown): item is Entity {
-    return reflection.isInstance(item, Entity);
-}
-
 export type QualifiedName = string
 
-export type DomainModelAstType = 'AbstractElement' | 'Domainmodel' | 'Feature' | 'PackageDeclaration' | 'Type' | 'DataType' | 'Entity';
+export type DomainModelAstType = 'AbstractElement' | 'DataType' | 'Domainmodel' | 'Entity' | 'Feature' | 'PackageDeclaration' | 'Type';
 
-export type DomainModelAstReference = 'Feature:type' | 'Entity:superType';
+export type DomainModelAstReference = 'Entity:superType' | 'Feature:type';
 
 export class DomainModelAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'Domainmodel', 'Feature', 'PackageDeclaration', 'Type', 'DataType', 'Entity'];
+        return ['AbstractElement', 'DataType', 'Domainmodel', 'Entity', 'Feature', 'PackageDeclaration', 'Type'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -103,13 +103,13 @@ export class DomainModelAstReflection implements AstReflection {
             return true;
         }
         switch (subtype) {
-            case PackageDeclaration:
-            case Type: {
-                return this.isSubtype(AbstractElement, supertype);
-            }
             case DataType:
             case Entity: {
                 return this.isSubtype(Type, supertype);
+            }
+            case PackageDeclaration:
+            case Type: {
+                return this.isSubtype(AbstractElement, supertype);
             }
             default: {
                 return false;
@@ -119,11 +119,11 @@ export class DomainModelAstReflection implements AstReflection {
 
     getReferenceType(referenceId: DomainModelAstReference): string {
         switch (referenceId) {
-            case 'Feature:type': {
-                return Type;
-            }
             case 'Entity:superType': {
                 return Entity;
+            }
+            case 'Feature:type': {
+                return Type;
             }
             default: {
                 throw new Error(`${referenceId} is not a valid reference id.`);

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -103,13 +103,13 @@ export class DomainModelAstReflection implements AstReflection {
             return true;
         }
         switch (subtype) {
-            case PackageDeclaration:
-            case Type: {
-                return this.isSubtype(AbstractElement, supertype);
-            }
             case DataType:
             case Entity: {
                 return this.isSubtype(Type, supertype);
+            }
+            case PackageDeclaration:
+            case Type: {
+                return this.isSubtype(AbstractElement, supertype);
             }
             default: {
                 return false;

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -305,7 +305,10 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
       "parameters": [],
       "name": "QualifiedName",
       "hiddenTokens": [],
-      "type": "string",
+      "type": {
+        "$type": "ReturnType",
+        "name": "string"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -360,7 +363,10 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
     {
       "$type": "TerminalRule",
       "name": "INT",
-      "type": "number",
+      "type": {
+        "$type": "ReturnType",
+        "name": "number"
+      },
       "terminal": {
         "$type": "RegexToken",
         "regex": "[0-9]+",

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -397,6 +397,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
       }
     }
   ],
+  "types": [],
   "isDeclared": true,
   "name": "DomainModel"
 }`));

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -404,6 +404,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
     }
   ],
   "interfaces": [],
+  "types": [],
   "isDeclared": true,
   "name": "DomainModel"
 }`));

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -403,7 +403,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
       }
     }
   ],
-  "types": [],
+  "interfaces": [],
   "isDeclared": true,
   "name": "DomainModel"
 }`));

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -291,7 +291,10 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
     {
       "$type": "TerminalRule",
       "name": "INT",
-      "type": "number",
+      "type": {
+        "$type": "ReturnType",
+        "name": "number"
+      },
       "terminal": {
         "$type": "RegexToken",
         "regex": "[0-9]+",

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -328,6 +328,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
       }
     }
   ],
+  "types": [],
   "isDeclared": true,
   "name": "Statemachine"
 }`));

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -332,6 +332,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
     }
   ],
   "interfaces": [],
+  "types": [],
   "isDeclared": true,
   "name": "Statemachine"
 }`));

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -331,7 +331,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
       }
     }
   ],
-  "types": [],
+  "interfaces": [],
   "isDeclared": true,
   "name": "Statemachine"
 }`));

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -47,7 +47,7 @@ function buildDatatype(rule: ParserRule): GeneratorNode {
     if (isAlternatives(rule.alternatives) && rule.alternatives.elements.every(e => isKeyword(e))) {
         return `export type ${rule.name} = ${stream(rule.alternatives.elements).filter(isKeyword).map(e => `'${e.value}'`).join(' | ')}`;
     } else {
-        return `export type ${rule.name} = ${rule.type ?? 'string'}`;
+        return `export type ${rule.name} = ${rule.type?.name ?? 'string'}`;
     }
 }
 

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -14,7 +14,7 @@ import { collectAst, Interface } from './type-collector';
 import { generatedHeader } from './util';
 
 export function generateAst(services: LangiumServices, grammars: Grammar[], config: LangiumConfig): string {
-    const types = collectAst(services.shared.workspace.LangiumDocuments, grammars);
+    const astSources = collectAst(services.shared.workspace.LangiumDocuments, grammars);
     const fileNode = new CompositeGeneratorNode();
     fileNode.append(
         generatedHeader,
@@ -31,14 +31,17 @@ export function generateAst(services: LangiumServices, grammars: Grammar[], conf
         fileNode.append(`import { AstNode, AstReflection${crossRef ? ', Reference' : ''}, isAstNode } from 'langium';`, NL, NL);
     }
 
-    for (const type of types) {
+    for (const type of astSources.types) {
         fileNode.append(type.toString(), NL);
+    }
+    for (const interfaceType of astSources.interfaces) {
+        fileNode.append(interfaceType.toString(), NL);
     }
     for (const primitiveRule of stream(grammars.flatMap(e => e.rules)).distinct().filter(isParserRule).filter(e => isDataTypeRule(e))) {
         fileNode.append(buildDatatype(primitiveRule), NL, NL);
     }
 
-    fileNode.append(generateAstReflection(config, types));
+    fileNode.append(generateAstReflection(config, astSources.sourceInterfaces));
 
     return processGeneratorNode(fileNode);
 }

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -5,9 +5,7 @@
  ******************************************************************************/
 
 import {
-    GeneratorNode, Grammar, IndentNode, CompositeGeneratorNode, NL, processGeneratorNode, stream,
-    isAlternatives, isKeyword, isParserRule, isDataTypeRule, ParserRule, streamAllContents,
-    isCrossReference, MultiMap, LangiumServices
+    GeneratorNode, Grammar, IndentNode, CompositeGeneratorNode, NL, processGeneratorNode, streamAllContents, isCrossReference, MultiMap, LangiumServices
 } from 'langium';
 import { LangiumConfig } from '../package';
 import { collectAst, Interface } from './type-collector';
@@ -37,21 +35,9 @@ export function generateAst(services: LangiumServices, grammars: Grammar[], conf
     for (const interfaceType of astSources.interfaces) {
         fileNode.append(interfaceType.toString(), NL);
     }
-    for (const primitiveRule of stream(grammars.flatMap(e => e.rules)).distinct().filter(isParserRule).filter(e => isDataTypeRule(e))) {
-        fileNode.append(buildDatatype(primitiveRule), NL, NL);
-    }
-
     fileNode.append(generateAstReflection(config, astSources.sourceInterfaces));
 
     return processGeneratorNode(fileNode);
-}
-
-function buildDatatype(rule: ParserRule): GeneratorNode {
-    if (isAlternatives(rule.alternatives) && rule.alternatives.elements.every(e => isKeyword(e))) {
-        return `export type ${rule.name} = ${stream(rule.alternatives.elements).filter(isKeyword).map(e => `'${e.value}'`).join(' | ')}`;
-    } else {
-        return `export type ${rule.name} = ${rule.type?.name ?? 'string'}`;
-    }
 }
 
 function hasCrossReferences(grammar: Grammar): boolean {

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -116,7 +116,7 @@ type CrossReferenceType = {
 function buildCrossReferenceTypes(astTypes: AstTypes): CrossReferenceType[] {
     const crossReferences: CrossReferenceType[] = [];
     for (const typeInterface of astTypes.interfaces) {
-        for (const field of typeInterface.fields.filter(e => e.type.reference)) {
+        for (const field of typeInterface.fields.filter(e => e.type.reference).sort((a, b) => a.name.localeCompare(b.name))) {
             crossReferences.push({
                 type: typeInterface.name,
                 feature: field.name,
@@ -124,7 +124,7 @@ function buildCrossReferenceTypes(astTypes: AstTypes): CrossReferenceType[] {
             });
         }
     }
-    return crossReferences;
+    return crossReferences.sort((a, b) => a.type.localeCompare(b.type));
 }
 
 function buildIsSubtypeMethod(astTypes: AstTypes): GeneratorNode {

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -8,11 +8,11 @@ import {
     GeneratorNode, Grammar, IndentNode, CompositeGeneratorNode, NL, processGeneratorNode, streamAllContents, isCrossReference, MultiMap, LangiumServices
 } from 'langium';
 import { LangiumConfig } from '../package';
-import { collectAst, Interface } from './type-collector';
+import { AstTypes, collectAst } from './type-collector';
 import { generatedHeader } from './util';
 
 export function generateAst(services: LangiumServices, grammars: Grammar[], config: LangiumConfig): string {
-    const astSources = collectAst(services.shared.workspace.LangiumDocuments, grammars);
+    const astTypes = collectAst(services.shared.workspace.LangiumDocuments, grammars);
     const fileNode = new CompositeGeneratorNode();
     fileNode.append(
         generatedHeader,
@@ -29,13 +29,15 @@ export function generateAst(services: LangiumServices, grammars: Grammar[], conf
         fileNode.append(`import { AstNode, AstReflection${crossRef ? ', Reference' : ''}, isAstNode } from 'langium';`, NL, NL);
     }
 
-    for (const type of astSources.types) {
+    for (const type of astTypes.types) {
         fileNode.append(type.toString(), NL);
     }
-    for (const interfaceType of astSources.interfaces) {
+    for (const interfaceType of astTypes.interfaces) {
         fileNode.append(interfaceType.toString(), NL);
     }
-    fileNode.append(generateAstReflection(config, astSources.sourceInterfaces));
+
+    astTypes.types =  astTypes.types.filter(e => e.reflection);
+    fileNode.append(generateAstReflection(config, astTypes));
 
     return processGeneratorNode(fileNode);
 }
@@ -50,24 +52,26 @@ type CrossReferenceType = {
     referenceType: string
 }
 
-function generateAstReflection(config: LangiumConfig, interfaces: Interface[]): GeneratorNode {
+function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): GeneratorNode {
     const reflectionNode = new CompositeGeneratorNode();
-    const crossReferenceTypes = buildCrossReferenceTypes(interfaces);
+    const typeNames: string[] = astTypes.interfaces.map(t => `'${t.name}'`)
+        .concat(astTypes.types.map(t => `'${t.name}'`)).sort();
+    const crossReferenceTypes = buildCrossReferenceTypes(astTypes);
 
     reflectionNode.append(
-        'export type ', config.projectName, 'AstType = ',
-        interfaces.map(t => `'${t.name}'`).join(' | '),
+        `export type ${config.projectName}AstType = `,
+        typeNames.join(' | '),
         ';', NL, NL,
-        'export type ', config.projectName, 'AstReference = ',
+        `export type ${config.projectName}AstReference = `,
         crossReferenceTypes.map(e => `'${e.type}:${e.feature}'`).join(' | ') || 'never',
         ';', NL, NL,
-        'export class ', config.projectName, 'AstReflection implements AstReflection {', NL, NL
+        `export class ${config.projectName}AstReflection implements AstReflection {`, NL, NL
     );
 
     reflectionNode.indent(classBody => {
         classBody.append('getAllTypes(): string[] {', NL);
         classBody.indent(allTypes => {
-            allTypes.append('return [', interfaces.map(t => `'${t.name}'`).join(', '), '];', NL);
+            allTypes.append(`return [${typeNames.join(', ')}];`, NL);
         });
         classBody.append('}', NL, NL, 'isInstance(node: unknown, type: string): boolean {', NL);
         classBody.indent(isInstance => {
@@ -76,22 +80,22 @@ function generateAstReflection(config: LangiumConfig, interfaces: Interface[]): 
         classBody.append(
             '}', NL, NL,
             'isSubtype(subtype: string, supertype: string): boolean {', NL,
-            buildIsSubtypeMethod(interfaces), '}', NL, NL,
-            'getReferenceType(referenceId: ', config.projectName, 'AstReference): string {', NL,
-            buildReferenceTypeMethod(interfaces), '}', NL,
+            buildIsSubtypeMethod(astTypes), '}', NL, NL,
+            `getReferenceType(referenceId: ${config.projectName}AstReference): string {`, NL,
+            buildReferenceTypeMethod(astTypes), '}', NL,
         );
     });
 
     reflectionNode.append(
         '}', NL, NL,
-        'export const reflection = new ', config.projectName, 'AstReflection();', NL
+        `export const reflection = new ${config.projectName}AstReflection();`, NL
     );
 
     return reflectionNode;
 }
 
-function buildReferenceTypeMethod(interfaces: Interface[]): GeneratorNode {
-    const crossReferenceTypes = buildCrossReferenceTypes(interfaces);
+function buildReferenceTypeMethod(astTypes: AstTypes): GeneratorNode {
+    const crossReferenceTypes = buildCrossReferenceTypes(astTypes);
     const typeSwitchNode = new IndentNode();
     typeSwitchNode.append('switch (referenceId) {', NL);
     typeSwitchNode.indent(caseNode => {
@@ -112,17 +116,18 @@ function buildReferenceTypeMethod(interfaces: Interface[]): GeneratorNode {
     return typeSwitchNode;
 }
 
-function buildCrossReferenceTypes(interfaces: Interface[]): CrossReferenceType[] {
+function buildCrossReferenceTypes(astTypes: AstTypes): CrossReferenceType[] {
     const crossReferences: CrossReferenceType[] = [];
-    for (const type of interfaces) {
-        for (const field of type.fields.filter(e => e.reference)) {
-            crossReferences.push({ type: type.name, feature: field.name, referenceType: field.types[0] });
+    for (const typeInterface of astTypes.interfaces) {
+        for (const field of typeInterface.fields.filter(e => e.type.reference)) {
+            const referenceType = Array.isArray(field.type.types) ? field.type.types[0] : field.type.types;
+            crossReferences.push({ type: typeInterface.name, feature: field.name, referenceType });
         }
     }
     return crossReferences;
 }
 
-function buildIsSubtypeMethod(interfaces: Interface[]): GeneratorNode {
+function buildIsSubtypeMethod(astTypes: AstTypes): GeneratorNode {
     const methodNode = new IndentNode();
     methodNode.append('if (subtype === supertype) {', NL);
     methodNode.indent(ifNode => {
@@ -133,17 +138,17 @@ function buildIsSubtypeMethod(interfaces: Interface[]): GeneratorNode {
         'switch (subtype) {', NL
     );
     methodNode.indent(switchNode => {
-        const groups = groupBySupertypes(interfaces.filter(e => e.superTypes.length > 0));
+        const groups = groupBySupertypes(astTypes);
 
         for (const superTypes of groups.keys()) {
             const typeGroup = groups.get(superTypes);
-            for (const typeItem of typeGroup) {
-                switchNode.append(`case ${typeItem.name}:`, NL);
+            for (const typeName of typeGroup) {
+                switchNode.append(`case ${typeName}:`, NL);
             }
             switchNode.contents.pop();
             switchNode.append(' {', NL);
             switchNode.indent(caseNode => {
-                caseNode.append('return ', superTypes.split(':').map(e => `this.isSubtype(${e}, supertype)`).join(' || '), ';');
+                caseNode.append(`return ${superTypes.split(':').map(e => `this.isSubtype(${e}, supertype)`).join(' || ')};`);
             });
             switchNode.append(NL, '}', NL);
         }
@@ -158,10 +163,21 @@ function buildIsSubtypeMethod(interfaces: Interface[]): GeneratorNode {
     return methodNode;
 }
 
-function groupBySupertypes(interfaces: Interface[]): MultiMap<string, Interface> {
-    const map = new MultiMap<string, Interface>();
-    for (const item of interfaces) {
-        map.add(item.superTypes.join(':'), item);
+function groupBySupertypes(astTypes: AstTypes): MultiMap<string, string> {
+    const superToChild = new MultiMap<string, string>();
+    for (const item of astTypes.interfaces.filter(e => e.superTypes.length > 0)) {
+        superToChild.add(item.superTypes.join(':'), item.name);
     }
-    return map;
+
+    const childToSuper = new MultiMap<string, string>();
+    for (const superType of astTypes.types) {
+        superType.alternatives.filter(e => !e.reference && !e.array).flatMap(e => e.types)
+            .forEach(child => childToSuper.add(child, superType.name));
+    }
+    for (const childType of childToSuper.keys()) {
+        const superTypes = childToSuper.get(childType);
+        superToChild.add(superTypes.join(':'), childType);
+    }
+
+    return superToChild;
 }

--- a/packages/langium-cli/src/generator/type-collector.ts
+++ b/packages/langium-cli/src/generator/type-collector.ts
@@ -380,7 +380,6 @@ function calculateAst(alternatives: TypeAlternative[]): Interface[] {
         type.superTypes = Array.from(new Set(type.superTypes));
     }
     removeInvalidSuperTypes(interfaces);
-    liftFields(interfaces);
     buildContainerTypes(interfaces);
 
     return sortTypes(interfaces);
@@ -462,31 +461,6 @@ function shareAndLiftContainerTypes(connectedComponents: Interface[][]): void {
                 type.containerTypes = [];
             } else {
                 type.containerTypes = containerTypes;
-            }
-        }
-    }
-}
-
-function liftFields(interfaces: Interface[]): void {
-    for (const interfaceType of interfaces) {
-        const subInterfaces = interfaces.filter(e => e.superTypes.includes(interfaceType.name));
-        const first = subInterfaces[0];
-        if (first) {
-            const removal: Field[] = [];
-            for (const field of first.fields) {
-                const fieldTypeSet = new Set(field.types);
-                if (subInterfaces.every(e => e.fields.some(f => f.name === field.name && _.isEqual(new Set(f.types), fieldTypeSet)))) {
-                    if (!interfaceType.fields.some(e => e.name === field.name)) {
-                        interfaceType.fields.push(field);
-                    }
-                    removal.push(field);
-                }
-            }
-            for (const remove of removal) {
-                for (const subInterface of subInterfaces) {
-                    const index = subInterface.fields.findIndex(e => e.name === remove.name);
-                    subInterface.fields.splice(index, 1);
-                }
             }
         }
     }

--- a/packages/langium-cli/src/generator/type-collector.ts
+++ b/packages/langium-cli/src/generator/type-collector.ts
@@ -367,13 +367,9 @@ function findTypes(terminal: langium.AbstractElement, types: TypeCollection): vo
     } else if (langium.isKeyword(terminal)) {
         types.types.push(`'${terminal.value}'`);
     } else if (langium.isRuleCall(terminal)) {
-        if (langium.isParserRule(terminal.rule.ref) && isDataTypeRule(terminal.rule.ref)) {
-            types.types.push(terminal.rule.ref.name);
-        } else {
-            types.types.push(getRuleType(terminal.rule.ref));
-        }
+        types.types.push(getRuleType(terminal.rule.ref));
     } else if (langium.isCrossReference(terminal)) {
-        types.types.push(getRuleType(terminal.type.ref));
+        types.types.push(getTypeName(terminal.type.ref));
         types.reference = true;
     }
 }

--- a/packages/langium-cli/src/generator/type-collector.ts
+++ b/packages/langium-cli/src/generator/type-collector.ts
@@ -6,7 +6,7 @@
 
 import _ from 'lodash';
 import * as langium from 'langium';
-import { CompositeGeneratorNode, distictAndSorted, getDocument, getRuleType, getTypeName, IndentNode, isDataTypeRule, isOptional, LangiumDocuments, MultiMap, NL, processGeneratorNode, resolveImport, stream } from 'langium';
+import { CompositeGeneratorNode, getDocument, getRuleType, getTypeName, IndentNode, isDataTypeRule, isOptional, LangiumDocuments, MultiMap, NL, processGeneratorNode, resolveImport, stream } from 'langium';
 import { URI } from 'vscode-uri';
 
 type TypeAlternative = {
@@ -102,6 +102,10 @@ export class Interface {
         pushReflectionInfo(this.name, interfaceNode);
         return processGeneratorNode(interfaceNode);
     }
+}
+
+function distictAndSorted<T>(list: T[], compareFn?: (a: T, b: T) => number): T[] {
+    return Array.from(new Set(list)).sort(compareFn);
 }
 
 function typeFieldToString(fieldType: FieldType): string {

--- a/packages/langium-vscode/data/langium.tmLanguage.json
+++ b/packages/langium-vscode/data/langium.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.langium",
-            "match": "\\b(grammar|terminal|entry|fragment|hidden|with|import|returns|current)\\b"
+            "match": "\\b(grammar|terminal|entry|fragment|hidden|with|import|returns|current|interface|extends)\\b"
         },
         {
             "name": "constant.language.langium",

--- a/packages/langium-vscode/data/langium.tmLanguage.json
+++ b/packages/langium-vscode/data/langium.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.langium",
-            "match": "\\b(grammar|terminal|entry|fragment|hidden|with|import|returns|current|interface|extends)\\b"
+            "match": "\\b(grammar|terminal|entry|fragment|hidden|with|import|returns|current|type|interface|extends)\\b"
         },
         {
             "name": "constant.language.langium",

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -23,7 +23,7 @@ export interface AbstractRule extends AstNode {
     readonly $container: Grammar;
     fragment: boolean
     name: string
-    type: string
+    type: ReturnType
 }
 
 export const AbstractRule = 'AbstractRule';
@@ -382,6 +382,8 @@ export const Interface = 'Interface';
 export function isInterface(item: unknown): item is Interface {
     return reflection.isInstance(item, Interface);
 }
+
+export type ReturnType = string
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'TypeAttribute' | 'TypeDeclaration' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference' | 'Interface';
 

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -116,7 +116,7 @@ export function isReturnType(item: unknown): item is ReturnType {
 }
 
 export interface TypeAttribute extends AstNode {
-    readonly $container: TypeDeclaration;
+    readonly $container: Interface;
     isOptional: boolean
     name: string
     primitiveType: PrimitiveType
@@ -131,9 +131,7 @@ export function isTypeAttribute(item: unknown): item is TypeAttribute {
 
 export interface TypeDeclaration extends AstNode {
     readonly $container: Grammar;
-    attributes: Array<TypeAttribute>
     name: string
-    superTypes: Array<string>
 }
 
 export const TypeDeclaration = 'TypeDeclaration';
@@ -345,6 +343,8 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
 }
 
 export interface Interface extends TypeDeclaration, AbstractType {
+    attributes: Array<TypeAttribute>
+    superTypes: Array<Reference<AbstractType>>
 }
 
 export const Interface = 'Interface';
@@ -405,16 +405,25 @@ export function isParameterReference(item: unknown): item is ParameterReference 
     return reflection.isInstance(item, ParameterReference);
 }
 
+export interface X extends TypeDeclaration {
+}
+
+export const X = 'X';
+
+export function isX(item: unknown): item is X {
+    return reflection.isInstance(item, X);
+}
+
 export type PrimitiveType = 'string' | 'number' | 'boolean' | 'date'
 
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'TypeDeclaration' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
+export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'TypeDeclaration' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference' | 'X';
 
-export type LangiumGrammarAstReference = 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'NamedArgument:parameter' | 'TypeAttribute:type' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'ParameterReference:parameter';
+export type LangiumGrammarAstReference = 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'NamedArgument:parameter' | 'TypeAttribute:type' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'Interface:superTypes' | 'ParameterReference:parameter';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'TypeDeclaration', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'TypeDeclaration', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference', 'X'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -460,6 +469,9 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case ParameterReference: {
                 return this.isSubtype(Condition, supertype);
             }
+            case X: {
+                return this.isSubtype(TypeDeclaration, supertype);
+            }
             default: {
                 return false;
             }
@@ -491,6 +503,9 @@ export class LangiumGrammarAstReflection implements AstReflection {
             }
             case 'ParserRule:hiddenTokens': {
                 return AbstractRule;
+            }
+            case 'Interface:superTypes': {
+                return AbstractType;
             }
             case 'ParameterReference:parameter': {
                 return Parameter;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -104,6 +104,17 @@ export function isParameter(item: unknown): item is Parameter {
     return reflection.isInstance(item, Parameter);
 }
 
+export interface ReturnType extends AstNode {
+    readonly $container: AbstractRule;
+    name: PrimitiveType | string
+}
+
+export const ReturnType = 'ReturnType';
+
+export function isReturnType(item: unknown): item is ReturnType {
+    return reflection.isInstance(item, ReturnType);
+}
+
 export interface TypeAttribute extends AstNode {
     readonly $container: TypeDeclaration;
     isOptional: boolean
@@ -396,16 +407,14 @@ export function isParameterReference(item: unknown): item is ParameterReference 
 
 export type PrimitiveType = 'string' | 'number' | 'boolean' | 'date'
 
-export type ReturnType = string
-
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'TypeAttribute' | 'TypeDeclaration' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
+export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'TypeDeclaration' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
 
 export type LangiumGrammarAstReference = 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'NamedArgument:parameter' | 'TypeAttribute:type' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'ParameterReference:parameter';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'TypeAttribute', 'TypeDeclaration', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'TypeDeclaration', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
     }
 
     isInstance(node: unknown, type: string): boolean {

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -19,12 +19,7 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
 }
 
-export interface AbstractRule extends AstNode {
-    readonly $container: Grammar;
-    fragment: boolean
-    name: string
-    type: ReturnType
-}
+export type AbstractRule = TerminalRule | ParserRule;
 
 export const AbstractRule = 'AbstractRule';
 
@@ -32,9 +27,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
     return reflection.isInstance(item, AbstractRule);
 }
 
-export interface AbstractType extends AstNode {
-    readonly $container: Grammar;
-}
+export type AbstractType = Interface | ParserRule;
 
 export const AbstractType = 'AbstractType';
 
@@ -56,10 +49,10 @@ export interface Grammar extends AstNode {
     definesHiddenTokens: boolean
     hiddenTokens: Array<Reference<AbstractRule>>
     imports: Array<GrammarImport>
+    interfaces: Array<Interface>
     isDeclared: boolean
     name: string
     rules: Array<AbstractRule>
-    types: Array<TypeDeclaration>
     usedGrammars: Array<Reference<Grammar>>
 }
 
@@ -105,7 +98,7 @@ export function isParameter(item: unknown): item is Parameter {
 }
 
 export interface ReturnType extends AstNode {
-    readonly $container: AbstractRule;
+    readonly $container: ParserRule | TerminalRule;
     name: PrimitiveType | string
 }
 
@@ -127,17 +120,6 @@ export const TypeAttribute = 'TypeAttribute';
 
 export function isTypeAttribute(item: unknown): item is TypeAttribute {
     return reflection.isInstance(item, TypeAttribute);
-}
-
-export interface TypeDeclaration extends AstNode {
-    readonly $container: Grammar;
-    name: string
-}
-
-export const TypeDeclaration = 'TypeDeclaration';
-
-export function isTypeDeclaration(item: unknown): item is TypeDeclaration {
-    return reflection.isInstance(item, TypeDeclaration);
 }
 
 export interface Action extends AbstractElement {
@@ -316,12 +298,15 @@ export function isWildcard(item: unknown): item is Wildcard {
     return reflection.isInstance(item, Wildcard);
 }
 
-export interface ParserRule extends AbstractType, AbstractRule {
+export interface ParserRule extends AstNode {
     alternatives: AbstractElement
     definesHiddenTokens: boolean
     entry: boolean
+    fragment: boolean
     hiddenTokens: Array<Reference<AbstractRule>>
+    name: string
     parameters: Array<Parameter>
+    type: ReturnType
     wildcard: boolean
 }
 
@@ -331,9 +316,12 @@ export function isParserRule(item: unknown): item is ParserRule {
     return reflection.isInstance(item, ParserRule);
 }
 
-export interface TerminalRule extends AbstractRule {
+export interface TerminalRule extends AstNode {
+    fragment: boolean
     hidden: boolean
+    name: string
     terminal: AbstractElement
+    type: ReturnType
 }
 
 export const TerminalRule = 'TerminalRule';
@@ -342,8 +330,9 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
     return reflection.isInstance(item, TerminalRule);
 }
 
-export interface Interface extends TypeDeclaration, AbstractType {
+export interface Interface extends AstNode {
     attributes: Array<TypeAttribute>
+    name: string
     superTypes: Array<Reference<AbstractType>>
 }
 
@@ -405,25 +394,16 @@ export function isParameterReference(item: unknown): item is ParameterReference 
     return reflection.isInstance(item, ParameterReference);
 }
 
-export interface X extends TypeDeclaration {
-}
-
-export const X = 'X';
-
-export function isX(item: unknown): item is X {
-    return reflection.isInstance(item, X);
-}
-
 export type PrimitiveType = 'string' | 'number' | 'boolean' | 'date'
 
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'TypeDeclaration' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference' | 'X';
+export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
 
 export type LangiumGrammarAstReference = 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'NamedArgument:parameter' | 'TypeAttribute:type' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'Interface:superTypes' | 'ParameterReference:parameter';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'TypeDeclaration', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference', 'X'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -460,7 +440,7 @@ export class LangiumGrammarAstReflection implements AstReflection {
                 return this.isSubtype(AbstractRule, supertype);
             }
             case Interface: {
-                return this.isSubtype(TypeDeclaration, supertype) || this.isSubtype(AbstractType, supertype);
+                return this.isSubtype(AbstractType, supertype);
             }
             case Conjunction:
             case Disjunction:
@@ -468,9 +448,6 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case Negation:
             case ParameterReference: {
                 return this.isSubtype(Condition, supertype);
-            }
-            case X: {
-                return this.isSubtype(TypeDeclaration, supertype);
             }
             default: {
                 return false;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -49,6 +49,7 @@ export interface Grammar extends AstNode {
     isDeclared: boolean
     name: string
     rules: Array<AbstractRule>
+    types: Array<TypeDeclaration>
     usedGrammars: Array<Reference<Grammar>>
 }
 
@@ -91,6 +92,32 @@ export const Parameter = 'Parameter';
 
 export function isParameter(item: unknown): item is Parameter {
     return reflection.isInstance(item, Parameter);
+}
+
+export interface TypeAttribute extends AstNode {
+    readonly $container: TypeDeclaration;
+    isOptional: boolean
+    name: string
+    type: string
+}
+
+export const TypeAttribute = 'TypeAttribute';
+
+export function isTypeAttribute(item: unknown): item is TypeAttribute {
+    return reflection.isInstance(item, TypeAttribute);
+}
+
+export interface TypeDeclaration extends AstNode {
+    readonly $container: Grammar;
+    attributes: Array<TypeAttribute>
+    name: string
+    superTypes: Array<string>
+}
+
+export const TypeDeclaration = 'TypeDeclaration';
+
+export function isTypeDeclaration(item: unknown): item is TypeDeclaration {
+    return reflection.isInstance(item, TypeDeclaration);
 }
 
 export interface Action extends AbstractElement {
@@ -347,14 +374,23 @@ export function isParameterReference(item: unknown): item is ParameterReference 
     return reflection.isInstance(item, ParameterReference);
 }
 
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
+export interface Interface extends TypeDeclaration {
+}
+
+export const Interface = 'Interface';
+
+export function isInterface(item: unknown): item is Interface {
+    return reflection.isInstance(item, Interface);
+}
+
+export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'TypeAttribute' | 'TypeDeclaration' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference' | 'Interface';
 
 export type LangiumGrammarAstReference = 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'NamedArgument:parameter' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'ParameterReference:parameter';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
+        return ['AbstractElement', 'AbstractRule', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'TypeAttribute', 'TypeDeclaration', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference', 'Interface'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -394,6 +430,9 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case Negation:
             case ParameterReference: {
                 return this.isSubtype(Condition, supertype);
+            }
+            case Interface: {
+                return this.isSubtype(TypeDeclaration, supertype);
             }
             default: {
                 return false;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -447,7 +447,7 @@ export function isWildcard(item: unknown): item is Wildcard {
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 
-export type LangiumGrammarAstReference = 'AtomType:refType' | 'CrossReference:type' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
+export type LangiumGrammarAstReference = 'AtomType:refType' | 'CrossReference:type' | 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
@@ -513,11 +513,11 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case 'CrossReference:type': {
                 return AbstractType;
             }
-            case 'Grammar:usedGrammars': {
-                return Grammar;
-            }
             case 'Grammar:hiddenTokens': {
                 return AbstractRule;
+            }
+            case 'Grammar:usedGrammars': {
+                return Grammar;
             }
             case 'Interface:superTypes': {
                 return AbstractType;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -482,22 +482,22 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case Wildcard: {
                 return this.isSubtype(AbstractElement, supertype);
             }
-            case Conjunction:
-            case Disjunction:
-            case LiteralCondition:
-            case Negation:
-            case ParameterReference: {
-                return this.isSubtype(Condition, supertype);
+            case ParserRule: {
+                return this.isSubtype(AbstractRule, supertype) || this.isSubtype(AbstractType, supertype);
+            }
+            case TerminalRule: {
+                return this.isSubtype(AbstractRule, supertype);
             }
             case Interface:
             case Type: {
                 return this.isSubtype(AbstractType, supertype);
             }
-            case ParserRule: {
-                return this.isSubtype(AbstractType, supertype) || this.isSubtype(AbstractRule, supertype);
-            }
-            case TerminalRule: {
-                return this.isSubtype(AbstractRule, supertype);
+            case LiteralCondition:
+            case Disjunction:
+            case Conjunction:
+            case Negation:
+            case ParameterReference: {
+                return this.isSubtype(Condition, supertype);
             }
             default: {
                 return false;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -16,7 +16,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
     return reflection.isInstance(item, AbstractRule);
 }
 
-export type AbstractType = Interface | ParserRule;
+export type AbstractType = Interface | Type | ParserRule;
 
 export const AbstractType = 'AbstractType';
 
@@ -33,7 +33,7 @@ export function isCondition(item: unknown): item is Condition {
 }
 
 export interface AbstractElement extends AstNode {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     cardinality: '*' | '+' | '?'
 }
 
@@ -41,6 +41,18 @@ export const AbstractElement = 'AbstractElement';
 
 export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
+}
+
+export interface AtomType extends AstNode {
+    readonly $container: Type | TypeAttribute;
+    primitiveType: Keyword | PrimitiveType
+    referenceType: Reference<AbstractType>
+}
+
+export const AtomType = 'AtomType';
+
+export function isAtomType(item: unknown): item is AtomType {
+    return reflection.isInstance(item, AtomType);
 }
 
 export interface Grammar extends AstNode {
@@ -51,6 +63,7 @@ export interface Grammar extends AstNode {
     isDeclared: boolean
     name: string
     rules: Array<AbstractRule>
+    types: Array<Type>
     usedGrammars: Array<Reference<Grammar>>
 }
 
@@ -110,8 +123,7 @@ export interface TypeAttribute extends AstNode {
     readonly $container: Interface;
     isOptional: boolean
     name: string
-    primitiveType: PrimitiveType
-    type: Reference<AbstractType>
+    type: AtomType
 }
 
 export const TypeAttribute = 'TypeAttribute';
@@ -121,7 +133,7 @@ export function isTypeAttribute(item: unknown): item is TypeAttribute {
 }
 
 export interface Action extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     feature: string
     operator: '+=' | '='
     type: string
@@ -134,7 +146,7 @@ export function isAction(item: unknown): item is Action {
 }
 
 export interface Alternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -145,7 +157,7 @@ export function isAlternatives(item: unknown): item is Alternatives {
 }
 
 export interface Assignment extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     feature: string
     firstSetPredicated: boolean
     operator: '+=' | '=' | '?='
@@ -160,7 +172,7 @@ export function isAssignment(item: unknown): item is Assignment {
 }
 
 export interface CharacterRange extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     left: Keyword
     right: Keyword
 }
@@ -172,7 +184,7 @@ export function isCharacterRange(item: unknown): item is CharacterRange {
 }
 
 export interface CrossReference extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     deprecatedSyntax: boolean
     terminal: AbstractElement
     type: Reference<ParserRule>
@@ -185,7 +197,7 @@ export function isCrossReference(item: unknown): item is CrossReference {
 }
 
 export interface Group extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
     firstSetPredicated: boolean
     guardCondition: Condition
@@ -199,7 +211,7 @@ export function isGroup(item: unknown): item is Group {
 }
 
 export interface Keyword extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     firstSetPredicated: boolean
     predicated: boolean
     value: string
@@ -212,7 +224,7 @@ export function isKeyword(item: unknown): item is Keyword {
 }
 
 export interface NegatedToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     terminal: AbstractElement
 }
 
@@ -223,7 +235,7 @@ export function isNegatedToken(item: unknown): item is NegatedToken {
 }
 
 export interface RegexToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     regex: string
 }
 
@@ -234,7 +246,7 @@ export function isRegexToken(item: unknown): item is RegexToken {
 }
 
 export interface RuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     arguments: Array<NamedArgument>
     firstSetPredicated: boolean
     predicated: boolean
@@ -248,7 +260,7 @@ export function isRuleCall(item: unknown): item is RuleCall {
 }
 
 export interface TerminalAlternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -259,7 +271,7 @@ export function isTerminalAlternatives(item: unknown): item is TerminalAlternati
 }
 
 export interface TerminalGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -270,7 +282,7 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
 }
 
 export interface TerminalRuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     rule: Reference<TerminalRule>
 }
 
@@ -281,7 +293,7 @@ export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
 }
 
 export interface UnorderedGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -292,7 +304,7 @@ export function isUnorderedGroup(item: unknown): item is UnorderedGroup {
 }
 
 export interface UntilToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     terminal: AbstractElement
 }
 
@@ -303,7 +315,7 @@ export function isUntilToken(item: unknown): item is UntilToken {
 }
 
 export interface Wildcard extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
 }
 
 export const Wildcard = 'Wildcard';
@@ -357,6 +369,18 @@ export const Interface = 'Interface';
 
 export function isInterface(item: unknown): item is Interface {
     return reflection.isInstance(item, Interface);
+}
+
+export interface Type extends AstNode {
+    readonly $container: Grammar;
+    name: string
+    typeAlternatives: Array<AtomType>
+}
+
+export const Type = 'Type';
+
+export function isType(item: unknown): item is Type {
+    return reflection.isInstance(item, Type);
 }
 
 export interface Conjunction extends AstNode {
@@ -418,14 +442,14 @@ export function isParameterReference(item: unknown): item is ParameterReference 
 
 export type PrimitiveType = 'string' | 'number' | 'boolean' | 'date'
 
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
+export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'AtomType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Type' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
 
-export type LangiumGrammarAstReference = 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'NamedArgument:parameter' | 'TypeAttribute:type' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'Interface:superTypes' | 'ParameterReference:parameter';
+export type LangiumGrammarAstReference = 'AtomType:referenceType' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'NamedArgument:parameter' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'Interface:superTypes' | 'ParameterReference:parameter';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'AtomType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Type', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -461,7 +485,8 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case TerminalRule: {
                 return this.isSubtype(AbstractRule, supertype);
             }
-            case Interface: {
+            case Interface:
+            case Type: {
                 return this.isSubtype(AbstractType, supertype);
             }
             case Conjunction:
@@ -479,6 +504,9 @@ export class LangiumGrammarAstReflection implements AstReflection {
 
     getReferenceType(referenceId: LangiumGrammarAstReference): string {
         switch (referenceId) {
+            case 'AtomType:referenceType': {
+                return AbstractType;
+            }
             case 'Grammar:usedGrammars': {
                 return Grammar;
             }
@@ -487,9 +515,6 @@ export class LangiumGrammarAstReflection implements AstReflection {
             }
             case 'NamedArgument:parameter': {
                 return Parameter;
-            }
-            case 'TypeAttribute:type': {
-                return AbstractType;
             }
             case 'CrossReference:type': {
                 return ParserRule;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -88,8 +88,9 @@ export interface AtomType extends AstNode {
     readonly $container: Type | TypeAttribute;
     isArray: boolean
     isRef: boolean
-    refValue: Reference<AbstractType>
-    value: Keyword | PrimitiveType
+    keywordType: Keyword
+    primitiveType: PrimitiveType
+    refType: Reference<AbstractType>
 }
 
 export const AtomType = 'AtomType';
@@ -446,7 +447,7 @@ export function isWildcard(item: unknown): item is Wildcard {
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 
-export type LangiumGrammarAstReference = 'AtomType:refValue' | 'CrossReference:type' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
+export type LangiumGrammarAstReference = 'AtomType:refType' | 'CrossReference:type' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
@@ -506,7 +507,7 @@ export class LangiumGrammarAstReflection implements AstReflection {
 
     getReferenceType(referenceId: LangiumGrammarAstReference): string {
         switch (referenceId) {
-            case 'AtomType:refValue': {
+            case 'AtomType:refType': {
                 return AbstractType;
             }
             case 'CrossReference:type': {

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -16,7 +16,7 @@ export function isAbstractRule(item: unknown): item is AbstractRule {
     return reflection.isInstance(item, AbstractRule);
 }
 
-export type AbstractType = Interface | Type | ParserRule;
+export type AbstractType = Interface | ParserRule | Type;
 
 export const AbstractType = 'AbstractType';
 
@@ -24,7 +24,7 @@ export function isAbstractType(item: unknown): item is AbstractType {
     return reflection.isInstance(item, AbstractType);
 }
 
-export type Condition = LiteralCondition | Disjunction | Conjunction | Negation | ParameterReference;
+export type Condition = Conjunction | Disjunction | LiteralCondition | Negation | ParameterReference;
 
 export const Condition = 'Condition';
 

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -86,8 +86,10 @@ export function isAssignment(item: unknown): item is Assignment {
 
 export interface AtomType extends AstNode {
     readonly $container: Type | TypeAttribute;
-    primitiveType: Keyword | PrimitiveType
-    referenceType: Reference<AbstractType>
+    isArray: boolean
+    isRef: boolean
+    refValue: Reference<AbstractType>
+    value: Keyword | PrimitiveType
 }
 
 export const AtomType = 'AtomType';
@@ -444,7 +446,7 @@ export function isWildcard(item: unknown): item is Wildcard {
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 
-export type LangiumGrammarAstReference = 'AtomType:referenceType' | 'CrossReference:type' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
+export type LangiumGrammarAstReference = 'AtomType:refValue' | 'CrossReference:type' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
@@ -504,7 +506,7 @@ export class LangiumGrammarAstReflection implements AstReflection {
 
     getReferenceType(referenceId: LangiumGrammarAstReference): string {
         switch (referenceId) {
-            case 'AtomType:referenceType': {
+            case 'AtomType:refValue': {
                 return AbstractType;
             }
             case 'CrossReference:type': {

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -43,95 +43,6 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
 }
 
-export interface AtomType extends AstNode {
-    readonly $container: Type | TypeAttribute;
-    primitiveType: Keyword | PrimitiveType
-    referenceType: Reference<AbstractType>
-}
-
-export const AtomType = 'AtomType';
-
-export function isAtomType(item: unknown): item is AtomType {
-    return reflection.isInstance(item, AtomType);
-}
-
-export interface Grammar extends AstNode {
-    definesHiddenTokens: boolean
-    hiddenTokens: Array<Reference<AbstractRule>>
-    imports: Array<GrammarImport>
-    interfaces: Array<Interface>
-    isDeclared: boolean
-    name: string
-    rules: Array<AbstractRule>
-    types: Array<Type>
-    usedGrammars: Array<Reference<Grammar>>
-}
-
-export const Grammar = 'Grammar';
-
-export function isGrammar(item: unknown): item is Grammar {
-    return reflection.isInstance(item, Grammar);
-}
-
-export interface GrammarImport extends AstNode {
-    readonly $container: Grammar;
-    path: string
-}
-
-export const GrammarImport = 'GrammarImport';
-
-export function isGrammarImport(item: unknown): item is GrammarImport {
-    return reflection.isInstance(item, GrammarImport);
-}
-
-export interface NamedArgument extends AstNode {
-    readonly $container: RuleCall;
-    calledByName: boolean
-    parameter?: Reference<Parameter>
-    value: Condition
-}
-
-export const NamedArgument = 'NamedArgument';
-
-export function isNamedArgument(item: unknown): item is NamedArgument {
-    return reflection.isInstance(item, NamedArgument);
-}
-
-export interface Parameter extends AstNode {
-    readonly $container: ParserRule;
-    name: string
-}
-
-export const Parameter = 'Parameter';
-
-export function isParameter(item: unknown): item is Parameter {
-    return reflection.isInstance(item, Parameter);
-}
-
-export interface ReturnType extends AstNode {
-    readonly $container: ParserRule | TerminalRule;
-    name: PrimitiveType | string
-}
-
-export const ReturnType = 'ReturnType';
-
-export function isReturnType(item: unknown): item is ReturnType {
-    return reflection.isInstance(item, ReturnType);
-}
-
-export interface TypeAttribute extends AstNode {
-    readonly $container: Interface;
-    isOptional: boolean
-    name: string
-    type: AtomType
-}
-
-export const TypeAttribute = 'TypeAttribute';
-
-export function isTypeAttribute(item: unknown): item is TypeAttribute {
-    return reflection.isInstance(item, TypeAttribute);
-}
-
 export interface Action extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     feature: string
@@ -171,6 +82,18 @@ export function isAssignment(item: unknown): item is Assignment {
     return reflection.isInstance(item, Assignment);
 }
 
+export interface AtomType extends AstNode {
+    readonly $container: Type | TypeAttribute;
+    primitiveType: Keyword | PrimitiveType
+    referenceType: Reference<AbstractType>
+}
+
+export const AtomType = 'AtomType';
+
+export function isAtomType(item: unknown): item is AtomType {
+    return reflection.isInstance(item, AtomType);
+}
+
 export interface CharacterRange extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     left: Keyword
@@ -181,6 +104,18 @@ export const CharacterRange = 'CharacterRange';
 
 export function isCharacterRange(item: unknown): item is CharacterRange {
     return reflection.isInstance(item, CharacterRange);
+}
+
+export interface Conjunction extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
+    left: Condition
+    right: Condition
+}
+
+export const Conjunction = 'Conjunction';
+
+export function isConjunction(item: unknown): item is Conjunction {
+    return reflection.isInstance(item, Conjunction);
 }
 
 export interface CrossReference extends AbstractElement {
@@ -194,6 +129,47 @@ export const CrossReference = 'CrossReference';
 
 export function isCrossReference(item: unknown): item is CrossReference {
     return reflection.isInstance(item, CrossReference);
+}
+
+export interface Disjunction extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
+    left: Condition
+    right: Condition
+}
+
+export const Disjunction = 'Disjunction';
+
+export function isDisjunction(item: unknown): item is Disjunction {
+    return reflection.isInstance(item, Disjunction);
+}
+
+export interface Grammar extends AstNode {
+    definesHiddenTokens: boolean
+    hiddenTokens: Array<Reference<AbstractRule>>
+    imports: Array<GrammarImport>
+    interfaces: Array<Interface>
+    isDeclared: boolean
+    name: string
+    rules: Array<AbstractRule>
+    types: Array<Type>
+    usedGrammars: Array<Reference<Grammar>>
+}
+
+export const Grammar = 'Grammar';
+
+export function isGrammar(item: unknown): item is Grammar {
+    return reflection.isInstance(item, Grammar);
+}
+
+export interface GrammarImport extends AstNode {
+    readonly $container: Grammar;
+    path: string
+}
+
+export const GrammarImport = 'GrammarImport';
+
+export function isGrammarImport(item: unknown): item is GrammarImport {
+    return reflection.isInstance(item, GrammarImport);
 }
 
 export interface Group extends AbstractElement {
@@ -210,6 +186,19 @@ export function isGroup(item: unknown): item is Group {
     return reflection.isInstance(item, Group);
 }
 
+export interface Interface extends AstNode {
+    readonly $container: Grammar;
+    attributes: Array<TypeAttribute>
+    name: string
+    superTypes: Array<Reference<AbstractType>>
+}
+
+export const Interface = 'Interface';
+
+export function isInterface(item: unknown): item is Interface {
+    return reflection.isInstance(item, Interface);
+}
+
 export interface Keyword extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     firstSetPredicated: boolean
@@ -223,6 +212,30 @@ export function isKeyword(item: unknown): item is Keyword {
     return reflection.isInstance(item, Keyword);
 }
 
+export interface LiteralCondition extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
+    true: boolean
+}
+
+export const LiteralCondition = 'LiteralCondition';
+
+export function isLiteralCondition(item: unknown): item is LiteralCondition {
+    return reflection.isInstance(item, LiteralCondition);
+}
+
+export interface NamedArgument extends AstNode {
+    readonly $container: RuleCall;
+    calledByName: boolean
+    parameter?: Reference<Parameter>
+    value: Condition
+}
+
+export const NamedArgument = 'NamedArgument';
+
+export function isNamedArgument(item: unknown): item is NamedArgument {
+    return reflection.isInstance(item, NamedArgument);
+}
+
 export interface NegatedToken extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     terminal: AbstractElement
@@ -234,6 +247,58 @@ export function isNegatedToken(item: unknown): item is NegatedToken {
     return reflection.isInstance(item, NegatedToken);
 }
 
+export interface Negation extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
+    value: Condition
+}
+
+export const Negation = 'Negation';
+
+export function isNegation(item: unknown): item is Negation {
+    return reflection.isInstance(item, Negation);
+}
+
+export interface Parameter extends AstNode {
+    readonly $container: ParserRule;
+    name: string
+}
+
+export const Parameter = 'Parameter';
+
+export function isParameter(item: unknown): item is Parameter {
+    return reflection.isInstance(item, Parameter);
+}
+
+export interface ParameterReference extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
+    parameter: Reference<Parameter>
+}
+
+export const ParameterReference = 'ParameterReference';
+
+export function isParameterReference(item: unknown): item is ParameterReference {
+    return reflection.isInstance(item, ParameterReference);
+}
+
+export interface ParserRule extends AstNode {
+    readonly $container: Grammar;
+    alternatives: AbstractElement
+    definesHiddenTokens: boolean
+    entry: boolean
+    fragment: boolean
+    hiddenTokens: Array<Reference<AbstractRule>>
+    name: string
+    parameters: Array<Parameter>
+    type: ReturnType
+    wildcard: boolean
+}
+
+export const ParserRule = 'ParserRule';
+
+export function isParserRule(item: unknown): item is ParserRule {
+    return reflection.isInstance(item, ParserRule);
+}
+
 export interface RegexToken extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     regex: string
@@ -243,6 +308,17 @@ export const RegexToken = 'RegexToken';
 
 export function isRegexToken(item: unknown): item is RegexToken {
     return reflection.isInstance(item, RegexToken);
+}
+
+export interface ReturnType extends AstNode {
+    readonly $container: ParserRule | TerminalRule;
+    name: PrimitiveType | string
+}
+
+export const ReturnType = 'ReturnType';
+
+export function isReturnType(item: unknown): item is ReturnType {
+    return reflection.isInstance(item, ReturnType);
 }
 
 export interface RuleCall extends AbstractElement {
@@ -281,6 +357,21 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
     return reflection.isInstance(item, TerminalGroup);
 }
 
+export interface TerminalRule extends AstNode {
+    readonly $container: Grammar;
+    fragment: boolean
+    hidden: boolean
+    name: string
+    terminal: AbstractElement
+    type: ReturnType
+}
+
+export const TerminalRule = 'TerminalRule';
+
+export function isTerminalRule(item: unknown): item is TerminalRule {
+    return reflection.isInstance(item, TerminalRule);
+}
+
 export interface TerminalRuleCall extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     rule: Reference<TerminalRule>
@@ -290,6 +381,31 @@ export const TerminalRuleCall = 'TerminalRuleCall';
 
 export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
     return reflection.isInstance(item, TerminalRuleCall);
+}
+
+export interface Type extends AstNode {
+    readonly $container: Grammar;
+    name: string
+    typeAlternatives: Array<AtomType>
+}
+
+export const Type = 'Type';
+
+export function isType(item: unknown): item is Type {
+    return reflection.isInstance(item, Type);
+}
+
+export interface TypeAttribute extends AstNode {
+    readonly $container: Interface;
+    isOptional: boolean
+    name: string
+    type: AtomType
+}
+
+export const TypeAttribute = 'TypeAttribute';
+
+export function isTypeAttribute(item: unknown): item is TypeAttribute {
+    return reflection.isInstance(item, TypeAttribute);
 }
 
 export interface UnorderedGroup extends AbstractElement {
@@ -324,132 +440,16 @@ export function isWildcard(item: unknown): item is Wildcard {
     return reflection.isInstance(item, Wildcard);
 }
 
-export interface ParserRule extends AstNode {
-    readonly $container: Grammar;
-    alternatives: AbstractElement
-    definesHiddenTokens: boolean
-    entry: boolean
-    fragment: boolean
-    hiddenTokens: Array<Reference<AbstractRule>>
-    name: string
-    parameters: Array<Parameter>
-    type: ReturnType
-    wildcard: boolean
-}
-
-export const ParserRule = 'ParserRule';
-
-export function isParserRule(item: unknown): item is ParserRule {
-    return reflection.isInstance(item, ParserRule);
-}
-
-export interface TerminalRule extends AstNode {
-    readonly $container: Grammar;
-    fragment: boolean
-    hidden: boolean
-    name: string
-    terminal: AbstractElement
-    type: ReturnType
-}
-
-export const TerminalRule = 'TerminalRule';
-
-export function isTerminalRule(item: unknown): item is TerminalRule {
-    return reflection.isInstance(item, TerminalRule);
-}
-
-export interface Interface extends AstNode {
-    readonly $container: Grammar;
-    attributes: Array<TypeAttribute>
-    name: string
-    superTypes: Array<Reference<AbstractType>>
-}
-
-export const Interface = 'Interface';
-
-export function isInterface(item: unknown): item is Interface {
-    return reflection.isInstance(item, Interface);
-}
-
-export interface Type extends AstNode {
-    readonly $container: Grammar;
-    name: string
-    typeAlternatives: Array<AtomType>
-}
-
-export const Type = 'Type';
-
-export function isType(item: unknown): item is Type {
-    return reflection.isInstance(item, Type);
-}
-
-export interface Conjunction extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
-    left: Condition
-    right: Condition
-}
-
-export const Conjunction = 'Conjunction';
-
-export function isConjunction(item: unknown): item is Conjunction {
-    return reflection.isInstance(item, Conjunction);
-}
-
-export interface Disjunction extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
-    left: Condition
-    right: Condition
-}
-
-export const Disjunction = 'Disjunction';
-
-export function isDisjunction(item: unknown): item is Disjunction {
-    return reflection.isInstance(item, Disjunction);
-}
-
-export interface LiteralCondition extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
-    true: boolean
-}
-
-export const LiteralCondition = 'LiteralCondition';
-
-export function isLiteralCondition(item: unknown): item is LiteralCondition {
-    return reflection.isInstance(item, LiteralCondition);
-}
-
-export interface Negation extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
-    value: Condition
-}
-
-export const Negation = 'Negation';
-
-export function isNegation(item: unknown): item is Negation {
-    return reflection.isInstance(item, Negation);
-}
-
-export interface ParameterReference extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
-    parameter: Reference<Parameter>
-}
-
-export const ParameterReference = 'ParameterReference';
-
-export function isParameterReference(item: unknown): item is ParameterReference {
-    return reflection.isInstance(item, ParameterReference);
-}
-
 export type PrimitiveType = 'string' | 'number' | 'boolean' | 'date'
 
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'AtomType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Type' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
+export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 
-export type LangiumGrammarAstReference = 'AtomType:referenceType' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'NamedArgument:parameter' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'Interface:superTypes' | 'ParameterReference:parameter';
+export type LangiumGrammarAstReference = 'AtomType:referenceType' | 'CrossReference:type' | 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'AtomType', 'Condition', 'Grammar', 'GrammarImport', 'NamedArgument', 'Parameter', 'ReturnType', 'TypeAttribute', 'Action', 'Alternatives', 'Assignment', 'CharacterRange', 'CrossReference', 'Group', 'Keyword', 'NegatedToken', 'RegexToken', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRuleCall', 'UnorderedGroup', 'UntilToken', 'Wildcard', 'ParserRule', 'TerminalRule', 'Interface', 'Type', 'Conjunction', 'Disjunction', 'LiteralCondition', 'Negation', 'ParameterReference'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'Assignment', 'AtomType', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'Grammar', 'GrammarImport', 'Group', 'Interface', 'Keyword', 'LiteralCondition', 'NamedArgument', 'NegatedToken', 'Negation', 'Parameter', 'ParameterReference', 'ParserRule', 'RegexToken', 'ReturnType', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'UnorderedGroup', 'UntilToken', 'Wildcard'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -479,22 +479,22 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case Wildcard: {
                 return this.isSubtype(AbstractElement, supertype);
             }
-            case ParserRule: {
-                return this.isSubtype(AbstractType, supertype) || this.isSubtype(AbstractRule, supertype);
-            }
-            case TerminalRule: {
-                return this.isSubtype(AbstractRule, supertype);
-            }
-            case Interface:
-            case Type: {
-                return this.isSubtype(AbstractType, supertype);
-            }
             case Conjunction:
             case Disjunction:
             case LiteralCondition:
             case Negation:
             case ParameterReference: {
                 return this.isSubtype(Condition, supertype);
+            }
+            case Interface:
+            case Type: {
+                return this.isSubtype(AbstractType, supertype);
+            }
+            case ParserRule: {
+                return this.isSubtype(AbstractType, supertype) || this.isSubtype(AbstractRule, supertype);
+            }
+            case TerminalRule: {
+                return this.isSubtype(AbstractRule, supertype);
             }
             default: {
                 return false;
@@ -507,32 +507,32 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case 'AtomType:referenceType': {
                 return AbstractType;
             }
+            case 'CrossReference:type': {
+                return ParserRule;
+            }
             case 'Grammar:usedGrammars': {
                 return Grammar;
             }
             case 'Grammar:hiddenTokens': {
                 return AbstractRule;
             }
+            case 'Interface:superTypes': {
+                return AbstractType;
+            }
             case 'NamedArgument:parameter': {
                 return Parameter;
             }
-            case 'CrossReference:type': {
-                return ParserRule;
+            case 'ParameterReference:parameter': {
+                return Parameter;
+            }
+            case 'ParserRule:hiddenTokens': {
+                return AbstractRule;
             }
             case 'RuleCall:rule': {
                 return AbstractRule;
             }
             case 'TerminalRuleCall:rule': {
                 return TerminalRule;
-            }
-            case 'ParserRule:hiddenTokens': {
-                return AbstractRule;
-            }
-            case 'Interface:superTypes': {
-                return AbstractType;
-            }
-            case 'ParameterReference:parameter': {
-                return Parameter;
             }
             default: {
                 throw new Error(`${referenceId} is not a valid reference id.`);

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -482,22 +482,22 @@ export class LangiumGrammarAstReflection implements AstReflection {
             case Wildcard: {
                 return this.isSubtype(AbstractElement, supertype);
             }
-            case ParserRule: {
-                return this.isSubtype(AbstractRule, supertype) || this.isSubtype(AbstractType, supertype);
-            }
-            case TerminalRule: {
-                return this.isSubtype(AbstractRule, supertype);
+            case Conjunction:
+            case Disjunction:
+            case LiteralCondition:
+            case Negation:
+            case ParameterReference: {
+                return this.isSubtype(Condition, supertype);
             }
             case Interface:
             case Type: {
                 return this.isSubtype(AbstractType, supertype);
             }
-            case LiteralCondition:
-            case Disjunction:
-            case Conjunction:
-            case Negation:
-            case ParameterReference: {
-                return this.isSubtype(Condition, supertype);
+            case ParserRule: {
+                return this.isSubtype(AbstractRule, supertype) || this.isSubtype(AbstractType, supertype);
+            }
+            case TerminalRule: {
+                return this.isSubtype(AbstractRule, supertype);
             }
             default: {
                 return false;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -8,18 +8,7 @@
 import { AstNode, AstReflection, Reference } from '../../syntax-tree';
 import { isAstNode } from '../../utils/ast-util';
 
-export interface AbstractElement extends AstNode {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
-    cardinality: '*' | '+' | '?'
-}
-
-export const AbstractElement = 'AbstractElement';
-
-export function isAbstractElement(item: unknown): item is AbstractElement {
-    return reflection.isInstance(item, AbstractElement);
-}
-
-export type AbstractRule = TerminalRule | ParserRule;
+export type AbstractRule = ParserRule | TerminalRule;
 
 export const AbstractRule = 'AbstractRule';
 
@@ -35,14 +24,23 @@ export function isAbstractType(item: unknown): item is AbstractType {
     return reflection.isInstance(item, AbstractType);
 }
 
-export interface Condition extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
-}
+export type Condition = LiteralCondition | Disjunction | Conjunction | Negation | ParameterReference;
 
 export const Condition = 'Condition';
 
 export function isCondition(item: unknown): item is Condition {
     return reflection.isInstance(item, Condition);
+}
+
+export interface AbstractElement extends AstNode {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    cardinality: '*' | '+' | '?'
+}
+
+export const AbstractElement = 'AbstractElement';
+
+export function isAbstractElement(item: unknown): item is AbstractElement {
+    return reflection.isInstance(item, AbstractElement);
 }
 
 export interface Grammar extends AstNode {
@@ -123,6 +121,7 @@ export function isTypeAttribute(item: unknown): item is TypeAttribute {
 }
 
 export interface Action extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     feature: string
     operator: '+=' | '='
     type: string
@@ -135,6 +134,7 @@ export function isAction(item: unknown): item is Action {
 }
 
 export interface Alternatives extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -145,6 +145,7 @@ export function isAlternatives(item: unknown): item is Alternatives {
 }
 
 export interface Assignment extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     feature: string
     firstSetPredicated: boolean
     operator: '+=' | '=' | '?='
@@ -159,6 +160,7 @@ export function isAssignment(item: unknown): item is Assignment {
 }
 
 export interface CharacterRange extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     left: Keyword
     right: Keyword
 }
@@ -170,6 +172,7 @@ export function isCharacterRange(item: unknown): item is CharacterRange {
 }
 
 export interface CrossReference extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     deprecatedSyntax: boolean
     terminal: AbstractElement
     type: Reference<ParserRule>
@@ -182,6 +185,7 @@ export function isCrossReference(item: unknown): item is CrossReference {
 }
 
 export interface Group extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
     firstSetPredicated: boolean
     guardCondition: Condition
@@ -195,6 +199,7 @@ export function isGroup(item: unknown): item is Group {
 }
 
 export interface Keyword extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     firstSetPredicated: boolean
     predicated: boolean
     value: string
@@ -207,6 +212,7 @@ export function isKeyword(item: unknown): item is Keyword {
 }
 
 export interface NegatedToken extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     terminal: AbstractElement
 }
 
@@ -217,6 +223,7 @@ export function isNegatedToken(item: unknown): item is NegatedToken {
 }
 
 export interface RegexToken extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     regex: string
 }
 
@@ -227,6 +234,7 @@ export function isRegexToken(item: unknown): item is RegexToken {
 }
 
 export interface RuleCall extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     arguments: Array<NamedArgument>
     firstSetPredicated: boolean
     predicated: boolean
@@ -240,6 +248,7 @@ export function isRuleCall(item: unknown): item is RuleCall {
 }
 
 export interface TerminalAlternatives extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -250,6 +259,7 @@ export function isTerminalAlternatives(item: unknown): item is TerminalAlternati
 }
 
 export interface TerminalGroup extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -260,6 +270,7 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
 }
 
 export interface TerminalRuleCall extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     rule: Reference<TerminalRule>
 }
 
@@ -270,6 +281,7 @@ export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
 }
 
 export interface UnorderedGroup extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     elements: Array<AbstractElement>
 }
 
@@ -280,6 +292,7 @@ export function isUnorderedGroup(item: unknown): item is UnorderedGroup {
 }
 
 export interface UntilToken extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     terminal: AbstractElement
 }
 
@@ -290,6 +303,7 @@ export function isUntilToken(item: unknown): item is UntilToken {
 }
 
 export interface Wildcard extends AbstractElement {
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
 }
 
 export const Wildcard = 'Wildcard';
@@ -299,6 +313,7 @@ export function isWildcard(item: unknown): item is Wildcard {
 }
 
 export interface ParserRule extends AstNode {
+    readonly $container: Grammar;
     alternatives: AbstractElement
     definesHiddenTokens: boolean
     entry: boolean
@@ -317,6 +332,7 @@ export function isParserRule(item: unknown): item is ParserRule {
 }
 
 export interface TerminalRule extends AstNode {
+    readonly $container: Grammar;
     fragment: boolean
     hidden: boolean
     name: string
@@ -331,6 +347,7 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
 }
 
 export interface Interface extends AstNode {
+    readonly $container: Grammar;
     attributes: Array<TypeAttribute>
     name: string
     superTypes: Array<Reference<AbstractType>>
@@ -342,7 +359,8 @@ export function isInterface(item: unknown): item is Interface {
     return reflection.isInstance(item, Interface);
 }
 
-export interface Conjunction extends Condition {
+export interface Conjunction extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     left: Condition
     right: Condition
 }
@@ -353,7 +371,8 @@ export function isConjunction(item: unknown): item is Conjunction {
     return reflection.isInstance(item, Conjunction);
 }
 
-export interface Disjunction extends Condition {
+export interface Disjunction extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     left: Condition
     right: Condition
 }
@@ -364,7 +383,8 @@ export function isDisjunction(item: unknown): item is Disjunction {
     return reflection.isInstance(item, Disjunction);
 }
 
-export interface LiteralCondition extends Condition {
+export interface LiteralCondition extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     true: boolean
 }
 
@@ -374,7 +394,8 @@ export function isLiteralCondition(item: unknown): item is LiteralCondition {
     return reflection.isInstance(item, LiteralCondition);
 }
 
-export interface Negation extends Condition {
+export interface Negation extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     value: Condition
 }
 
@@ -384,7 +405,8 @@ export function isNegation(item: unknown): item is Negation {
     return reflection.isInstance(item, Negation);
 }
 
-export interface ParameterReference extends Condition {
+export interface ParameterReference extends AstNode {
+    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     parameter: Reference<Parameter>
 }
 
@@ -398,7 +420,7 @@ export type PrimitiveType = 'string' | 'number' | 'boolean' | 'date'
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Condition' | 'Grammar' | 'GrammarImport' | 'NamedArgument' | 'Parameter' | 'ReturnType' | 'TypeAttribute' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard' | 'ParserRule' | 'TerminalRule' | 'Interface' | 'Conjunction' | 'Disjunction' | 'LiteralCondition' | 'Negation' | 'ParameterReference';
 
-export type LangiumGrammarAstReference = 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'NamedArgument:parameter' | 'TypeAttribute:type' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'Interface:superTypes' | 'ParameterReference:parameter';
+export type LangiumGrammarAstReference = 'Grammar:usedGrammars' | 'Grammar:hiddenTokens' | 'NamedArgument:parameter' | 'TypeAttribute:type' | 'CrossReference:type' | 'RuleCall:rule' | 'TerminalRuleCall:rule' | 'ParserRule:hiddenTokens' | 'Interface:superTypes' | 'ParameterReference:parameter';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
@@ -457,11 +479,11 @@ export class LangiumGrammarAstReflection implements AstReflection {
 
     getReferenceType(referenceId: LangiumGrammarAstReference): string {
         switch (referenceId) {
-            case 'Grammar:hiddenTokens': {
-                return AbstractRule;
-            }
             case 'Grammar:usedGrammars': {
                 return Grammar;
+            }
+            case 'Grammar:hiddenTokens': {
+                return AbstractRule;
             }
             case 'NamedArgument:parameter': {
                 return Parameter;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -127,7 +127,7 @@ export interface CrossReference extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     deprecatedSyntax: boolean
     terminal: AbstractElement
-    type: Reference<ParserRule>
+    type: Reference<AbstractType>
 }
 
 export const CrossReference = 'CrossReference';
@@ -511,7 +511,7 @@ export class LangiumGrammarAstReflection implements AstReflection {
                 return AbstractType;
             }
             case 'CrossReference:type': {
-                return ParserRule;
+                return AbstractType;
             }
             case 'Grammar:usedGrammars': {
                 return Grammar;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -32,6 +32,8 @@ export function isCondition(item: unknown): item is Condition {
     return reflection.isInstance(item, Condition);
 }
 
+export type PrimitiveType = 'boolean' | 'date' | 'number' | 'string';
+
 export interface AbstractElement extends AstNode {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     cardinality: '*' | '+' | '?'
@@ -439,8 +441,6 @@ export const Wildcard = 'Wildcard';
 export function isWildcard(item: unknown): item is Wildcard {
     return reflection.isInstance(item, Wildcard);
 }
-
-export type PrimitiveType = 'string' | 'number' | 'boolean' | 'date'
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -32,6 +32,8 @@ export function isCondition(item: unknown): item is Condition {
     return reflection.isInstance(item, Condition);
 }
 
+export type FeatureName = string;
+
 export type PrimitiveType = 'boolean' | 'date' | 'number' | 'string';
 
 export interface AbstractElement extends AstNode {
@@ -47,7 +49,7 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
 
 export interface Action extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
-    feature: string
+    feature: FeatureName
     operator: '+=' | '='
     type: string
 }
@@ -71,7 +73,7 @@ export function isAlternatives(item: unknown): item is Alternatives {
 
 export interface Assignment extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
-    feature: string
+    feature: FeatureName
     firstSetPredicated: boolean
     operator: '+=' | '=' | '?='
     predicated: boolean

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -405,16 +405,41 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "value": ":"
           },
           {
-            "$type": "Assignment",
-            "feature": "type",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "arguments": [],
-              "rule": {
-                "$refText": "ID"
+            "$type": "Alternatives",
+            "elements": [
+              {
+                "$type": "Assignment",
+                "feature": "primitiveType",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "PrimitiveType"
+                  }
+                },
+                "elements": []
+              },
+              {
+                "$type": "Assignment",
+                "feature": "type",
+                "operator": "=",
+                "terminal": {
+                  "$type": "CrossReference",
+                  "type": {
+                    "$refText": "AbstractType"
+                  },
+                  "terminal": {
+                    "$type": "RuleCall",
+                    "arguments": [],
+                    "rule": {
+                      "$refText": "ID"
+                    }
+                  }
+                },
+                "elements": []
               }
-            }
+            ]
           },
           {
             "$type": "Keyword",
@@ -427,7 +452,34 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "parameters": [],
-      "name": "ReturnType",
+      "name": "AbstractType",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "Interface"
+            },
+            "elements": []
+          },
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "ParserRule"
+            },
+            "elements": []
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "PrimitiveType",
       "hiddenTokens": [],
       "type": "string",
       "alternatives": {
@@ -450,12 +502,27 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           },
           {
             "$type": "Keyword",
-            "value": "bigint",
+            "value": "date",
             "elements": []
-          },
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "ReturnType",
+      "hiddenTokens": [],
+      "type": "string",
+      "alternatives": {
+        "$type": "Alternatives",
+        "elements": [
           {
-            "$type": "Keyword",
-            "value": "Date",
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "PrimitiveType"
+            },
             "elements": []
           },
           {

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -240,12 +240,53 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "TypeDeclaration",
       "hiddenTokens": [],
       "alternatives": {
-        "$type": "RuleCall",
-        "arguments": [],
-        "rule": {
-          "$refText": "Interface"
-        },
-        "elements": []
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "Interface"
+            },
+            "elements": []
+          },
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "X"
+            },
+            "elements": []
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "X",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "x",
+            "elements": []
+          },
+          {
+            "$type": "Assignment",
+            "feature": "name",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            }
+          }
+        ]
       }
     },
     {
@@ -286,10 +327,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "feature": "superTypes",
                 "operator": "+=",
                 "terminal": {
-                  "$type": "RuleCall",
-                  "arguments": [],
-                  "rule": {
-                    "$refText": "ID"
+                  "$type": "CrossReference",
+                  "type": {
+                    "$refText": "AbstractType"
                   }
                 }
               },
@@ -306,10 +346,9 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "feature": "superTypes",
                     "operator": "+=",
                     "terminal": {
-                      "$type": "RuleCall",
-                      "arguments": [],
-                      "rule": {
-                        "$refText": "ID"
+                      "$type": "CrossReference",
+                      "type": {
+                        "$refText": "AbstractType"
                       }
                     }
                   }
@@ -428,13 +467,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "$type": "CrossReference",
                   "type": {
                     "$refText": "AbstractType"
-                  },
-                  "terminal": {
-                    "$type": "RuleCall",
-                    "arguments": [],
-                    "rule": {
-                      "$refText": "ID"
-                    }
                   }
                 },
                 "elements": []

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -427,6 +427,51 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "parameters": [],
+      "name": "ReturnType",
+      "hiddenTokens": [],
+      "type": "string",
+      "alternatives": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "string",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "number",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "boolean",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "bigint",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "Date",
+            "elements": []
+          },
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "ID"
+            },
+            "elements": []
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
       "name": "AbstractRule",
       "hiddenTokens": [],
       "alternatives": {
@@ -558,7 +603,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                               "$type": "RuleCall",
                               "arguments": [],
                               "rule": {
-                                "$refText": "ID"
+                                "$refText": "ReturnType"
                               }
                             }
                           }
@@ -596,7 +641,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "$type": "RuleCall",
                           "arguments": [],
                           "rule": {
-                            "$refText": "ID"
+                            "$refText": "ReturnType"
                           }
                         }
                       }
@@ -2326,7 +2371,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "$type": "RuleCall",
                           "arguments": [],
                           "rule": {
-                            "$refText": "ID"
+                            "$refText": "ReturnType"
                           }
                         }
                       }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -481,7 +481,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PrimitiveType",
       "hiddenTokens": [],
-      "type": "string",
+      "type": {
+        "$type": "ReturnType",
+        "name": "string"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -513,27 +516,31 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ReturnType",
       "hiddenTokens": [],
-      "type": "string",
       "alternatives": {
-        "$type": "Alternatives",
-        "elements": [
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "PrimitiveType"
+        "$type": "Assignment",
+        "feature": "name",
+        "operator": "=",
+        "terminal": {
+          "$type": "Alternatives",
+          "elements": [
+            {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "PrimitiveType"
+              },
+              "elements": []
             },
-            "elements": []
-          },
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "ID"
-            },
-            "elements": []
-          }
-        ]
+            {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            }
+          ]
+        },
+        "elements": []
       }
     },
     {
@@ -926,7 +933,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Alternatives",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -982,7 +992,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ConditionalBranch",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -1046,7 +1059,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "UnorderedGroup",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1102,7 +1118,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Group",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1148,7 +1167,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AbstractToken",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -1176,7 +1198,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AbstractTokenWithCardinality",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1233,7 +1258,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Action",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1316,7 +1344,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AbstractTerminal",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -1559,7 +1590,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Disjunction",
       "hiddenTokens": [],
-      "type": "Condition",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Condition"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1608,7 +1642,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Conjunction",
       "hiddenTokens": [],
-      "type": "Condition",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Condition"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1657,7 +1694,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Negation",
       "hiddenTokens": [],
-      "type": "Condition",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Condition"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -1703,7 +1743,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Atom",
       "hiddenTokens": [],
-      "type": "Condition",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Condition"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -1739,7 +1782,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedCondition",
       "hiddenTokens": [],
-      "type": "Condition",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Condition"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1792,7 +1838,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PredicatedKeyword",
       "hiddenTokens": [],
-      "type": "Keyword",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Keyword"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1841,7 +1890,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PredicatedRuleCall",
       "hiddenTokens": [],
-      "type": "RuleCall",
+      "type": {
+        "$type": "ReturnType",
+        "name": "RuleCall"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -1946,7 +1998,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Assignment",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2036,7 +2091,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AssignableTerminal",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -2080,7 +2138,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedAssignableElement",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2108,7 +2169,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AssignableAlternatives",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2164,7 +2228,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "CrossReference",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2245,7 +2312,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "CrossReferenceableTerminal",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -2273,7 +2343,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedElement",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2301,7 +2374,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PredicatedGroup",
       "hiddenTokens": [],
-      "type": "Group",
+      "type": {
+        "$type": "ReturnType",
+        "name": "Group"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2475,7 +2551,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "TerminalRule",
       "name": "RegexLiteral",
-      "type": "string",
+      "type": {
+        "$type": "ReturnType",
+        "name": "string"
+      },
       "terminal": {
         "$type": "RegexToken",
         "regex": "\\\\/(?![*+?])(?:[^\\\\r\\\\n\\\\[/\\\\\\\\]|\\\\\\\\.|\\\\[(?:[^\\\\r\\\\n\\\\]\\\\\\\\]|\\\\\\\\.)*\\\\])+\\\\/",
@@ -2487,7 +2566,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalAlternatives",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2536,7 +2618,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalGroup",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2582,7 +2667,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalToken",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2626,7 +2714,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalTokenElement",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -2694,7 +2785,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedTerminalElement",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2722,7 +2816,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalRuleCall",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2757,7 +2854,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "NegatedToken",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2790,7 +2890,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "UntilToken",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2823,7 +2926,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "RegexToken",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2852,7 +2958,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Wildcard",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [
@@ -2873,7 +2982,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "CharacterRange",
       "hiddenTokens": [],
-      "type": "AbstractElement",
+      "type": {
+        "$type": "ReturnType",
+        "name": "AbstractElement"
+      },
       "alternatives": {
         "$type": "Group",
         "elements": [

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -217,74 +217,19 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               },
               {
                 "$type": "Assignment",
-                "feature": "types",
+                "feature": "interfaces",
                 "operator": "+=",
                 "terminal": {
                   "$type": "RuleCall",
                   "arguments": [],
                   "rule": {
-                    "$refText": "TypeDeclaration"
+                    "$refText": "Interface"
                   }
                 },
                 "elements": []
               }
             ],
             "cardinality": "+"
-          }
-        ]
-      }
-    },
-    {
-      "$type": "ParserRule",
-      "parameters": [],
-      "name": "TypeDeclaration",
-      "hiddenTokens": [],
-      "alternatives": {
-        "$type": "Alternatives",
-        "elements": [
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "Interface"
-            },
-            "elements": []
-          },
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "X"
-            },
-            "elements": []
-          }
-        ]
-      }
-    },
-    {
-      "$type": "ParserRule",
-      "parameters": [],
-      "name": "X",
-      "hiddenTokens": [],
-      "alternatives": {
-        "$type": "Group",
-        "elements": [
-          {
-            "$type": "Keyword",
-            "value": "x",
-            "elements": []
-          },
-          {
-            "$type": "Assignment",
-            "feature": "name",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "arguments": [],
-              "rule": {
-                "$refText": "ID"
-              }
-            }
           }
         ]
       }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -200,18 +200,226 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "cardinality": "*"
           },
           {
+            "$type": "Alternatives",
+            "elements": [
+              {
+                "$type": "Assignment",
+                "feature": "rules",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "AbstractRule"
+                  }
+                },
+                "elements": []
+              },
+              {
+                "$type": "Assignment",
+                "feature": "types",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "TypeDeclaration"
+                  }
+                },
+                "elements": []
+              }
+            ],
+            "cardinality": "+"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "TypeDeclaration",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "RuleCall",
+        "arguments": [],
+        "rule": {
+          "$refText": "Interface"
+        },
+        "elements": []
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "Interface",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "interface",
+            "elements": []
+          },
+          {
             "$type": "Assignment",
-            "feature": "rules",
+            "feature": "name",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            }
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "extends",
+                "elements": []
+              },
+              {
+                "$type": "Assignment",
+                "feature": "superTypes",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "ID"
+                  }
+                }
+              },
+              {
+                "$type": "Group",
+                "elements": [
+                  {
+                    "$type": "Keyword",
+                    "value": ",",
+                    "elements": []
+                  },
+                  {
+                    "$type": "Assignment",
+                    "feature": "superTypes",
+                    "operator": "+=",
+                    "terminal": {
+                      "$type": "RuleCall",
+                      "arguments": [],
+                      "rule": {
+                        "$refText": "ID"
+                      }
+                    }
+                  }
+                ],
+                "cardinality": "*"
+              }
+            ],
+            "cardinality": "?"
+          },
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "SchemaType"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "SchemaType",
+      "hiddenTokens": [],
+      "fragment": true,
+      "alternatives": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "{",
+            "elements": []
+          },
+          {
+            "$type": "Assignment",
+            "feature": "attributes",
             "operator": "+=",
             "terminal": {
               "$type": "RuleCall",
               "arguments": [],
               "rule": {
-                "$refText": "AbstractRule"
+                "$refText": "TypeAttribute"
               }
             },
+            "cardinality": "*"
+          },
+          {
+            "$type": "Keyword",
+            "value": "}"
+          },
+          {
+            "$type": "Keyword",
+            "value": ";",
+            "cardinality": "?"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "TypeAttribute",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Assignment",
+            "feature": "name",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            },
+            "elements": []
+          },
+          {
+            "$type": "Assignment",
+            "feature": "isOptional",
+            "operator": "?=",
+            "terminal": {
+              "$type": "Keyword",
+              "value": "?"
+            },
             "elements": [],
-            "cardinality": "+"
+            "cardinality": "?"
+          },
+          {
+            "$type": "Keyword",
+            "value": ":"
+          },
+          {
+            "$type": "Assignment",
+            "feature": "type",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            }
+          },
+          {
+            "$type": "Keyword",
+            "value": ";",
+            "cardinality": "?"
           }
         ]
       }
@@ -2649,6 +2857,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       }
     }
   ],
+  "types": [],
   "isDeclared": true,
   "name": "LangiumGrammar"
 }`));

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -580,41 +580,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     {
       "$type": "ParserRule",
       "parameters": [],
-      "name": "AbstractType",
-      "hiddenTokens": [],
-      "alternatives": {
-        "$type": "Alternatives",
-        "elements": [
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "Interface"
-            },
-            "elements": []
-          },
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "Type"
-            },
-            "elements": []
-          },
-          {
-            "$type": "RuleCall",
-            "arguments": [],
-            "rule": {
-              "$refText": "ParserRule"
-            },
-            "elements": []
-          }
-        ]
-      }
-    },
-    {
-      "$type": "ParserRule",
-      "parameters": [],
       "name": "PrimitiveType",
       "hiddenTokens": [],
       "type": {
@@ -3211,7 +3176,32 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     }
   ],
   "interfaces": [],
-  "types": [],
+  "types": [
+    {
+      "$type": "Type",
+      "typeAlternatives": [
+        {
+          "$type": "AtomType",
+          "refType": {
+            "$refText": "Interface"
+          }
+        },
+        {
+          "$type": "AtomType",
+          "refType": {
+            "$refText": "Type"
+          }
+        },
+        {
+          "$type": "AtomType",
+          "refType": {
+            "$refText": "ParserRule"
+          }
+        }
+      ],
+      "name": "AbstractType"
+    }
+  ],
   "isDeclared": true,
   "name": "LangiumGrammar"
 }`));

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -499,45 +499,71 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "AtomType",
       "hiddenTokens": [],
       "alternatives": {
-        "$type": "Alternatives",
+        "$type": "Group",
         "elements": [
           {
             "$type": "Assignment",
-            "feature": "primitiveType",
-            "operator": "=",
+            "feature": "isRef",
+            "operator": "?=",
             "terminal": {
-              "$type": "Alternatives",
-              "elements": [
-                {
-                  "$type": "RuleCall",
-                  "arguments": [],
-                  "rule": {
-                    "$refText": "PrimitiveType"
-                  },
-                  "elements": []
-                },
-                {
-                  "$type": "RuleCall",
-                  "arguments": [],
-                  "rule": {
-                    "$refText": "Keyword"
-                  }
-                }
-              ]
+              "$type": "Keyword",
+              "value": "@"
             },
+            "cardinality": "?",
             "elements": []
           },
           {
-            "$type": "Assignment",
-            "feature": "referenceType",
-            "operator": "=",
-            "terminal": {
-              "$type": "CrossReference",
-              "type": {
-                "$refText": "AbstractType"
+            "$type": "Alternatives",
+            "elements": [
+              {
+                "$type": "Assignment",
+                "feature": "value",
+                "operator": "=",
+                "terminal": {
+                  "$type": "Alternatives",
+                  "elements": [
+                    {
+                      "$type": "RuleCall",
+                      "arguments": [],
+                      "rule": {
+                        "$refText": "PrimitiveType"
+                      },
+                      "elements": []
+                    },
+                    {
+                      "$type": "RuleCall",
+                      "arguments": [],
+                      "rule": {
+                        "$refText": "Keyword"
+                      }
+                    }
+                  ]
+                },
+                "elements": []
+              },
+              {
+                "$type": "Assignment",
+                "feature": "refValue",
+                "operator": "=",
+                "terminal": {
+                  "$type": "CrossReference",
+                  "type": {
+                    "$refText": "AbstractType"
+                  }
+                },
+                "elements": []
               }
+            ]
+          },
+          {
+            "$type": "Assignment",
+            "feature": "isArray",
+            "operator": "?=",
+            "terminal": {
+              "$type": "Keyword",
+              "value": "[]"
             },
-            "elements": []
+            "cardinality": "?"
           }
         ]
       }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3058,7 +3058,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       }
     }
   ],
-  "types": [],
+  "interfaces": [],
   "isDeclared": true,
   "name": "LangiumGrammar"
 }`));

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -1403,7 +1403,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "$type": "RuleCall",
                   "arguments": [],
                   "rule": {
-                    "$refText": "ID"
+                    "$refText": "FeatureName"
                   }
                 }
               },
@@ -2145,7 +2145,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               "$type": "RuleCall",
               "arguments": [],
               "rule": {
-                "$refText": "ID"
+                "$refText": "FeatureName"
               }
             }
           },
@@ -3122,6 +3122,107 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               }
             ],
             "cardinality": "?"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "FeatureName",
+      "hiddenTokens": [],
+      "type": {
+        "$type": "ReturnType",
+        "name": "string"
+      },
+      "alternatives": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "current",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "entry",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "extends",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "false",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "fragment",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "grammar",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "hidden",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "import",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "interface",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "returns",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "terminal",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "true",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "type",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "with",
+            "elements": []
+          },
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "PrimitiveType"
+            },
+            "elements": []
+          },
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "ID"
+            },
+            "elements": []
           }
         ]
       }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -2387,14 +2387,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "ParserRule"
-              },
-              "terminal": {
-                "$type": "RuleCall",
-                "arguments": [],
-                "rule": {
-                  "$refText": "ID"
-                }
+                "$refText": "AbstractType"
               }
             }
           },

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -499,71 +499,80 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "AtomType",
       "hiddenTokens": [],
       "alternatives": {
-        "$type": "Group",
+        "$type": "Alternatives",
         "elements": [
           {
-            "$type": "Assignment",
-            "feature": "isRef",
-            "operator": "?=",
-            "terminal": {
-              "$type": "Keyword",
-              "value": "@"
-            },
-            "cardinality": "?",
-            "elements": []
-          },
-          {
-            "$type": "Alternatives",
+            "$type": "Group",
             "elements": [
               {
-                "$type": "Assignment",
-                "feature": "value",
-                "operator": "=",
-                "terminal": {
-                  "$type": "Alternatives",
-                  "elements": [
-                    {
+                "$type": "Alternatives",
+                "elements": [
+                  {
+                    "$type": "Assignment",
+                    "feature": "primitiveType",
+                    "operator": "=",
+                    "terminal": {
                       "$type": "RuleCall",
                       "arguments": [],
                       "rule": {
                         "$refText": "PrimitiveType"
-                      },
-                      "elements": []
-                    },
-                    {
-                      "$type": "RuleCall",
-                      "arguments": [],
-                      "rule": {
-                        "$refText": "Keyword"
                       }
-                    }
-                  ]
-                },
-                "elements": []
+                    },
+                    "elements": []
+                  },
+                  {
+                    "$type": "Group",
+                    "elements": [
+                      {
+                        "$type": "Assignment",
+                        "feature": "isRef",
+                        "operator": "?=",
+                        "terminal": {
+                          "$type": "Keyword",
+                          "value": "@"
+                        },
+                        "cardinality": "?",
+                        "elements": []
+                      },
+                      {
+                        "$type": "Assignment",
+                        "feature": "refType",
+                        "operator": "=",
+                        "terminal": {
+                          "$type": "CrossReference",
+                          "type": {
+                            "$refText": "AbstractType"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "$type": "Assignment",
-                "feature": "refValue",
-                "operator": "=",
+                "feature": "isArray",
+                "operator": "?=",
                 "terminal": {
-                  "$type": "CrossReference",
-                  "type": {
-                    "$refText": "AbstractType"
-                  }
+                  "$type": "Keyword",
+                  "value": "[]"
                 },
-                "elements": []
+                "cardinality": "?"
               }
             ]
           },
           {
             "$type": "Assignment",
-            "feature": "isArray",
-            "operator": "?=",
+            "feature": "keywordType",
+            "operator": "=",
             "terminal": {
-              "$type": "Keyword",
-              "value": "[]"
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "Keyword"
+              }
             },
-            "cardinality": "?"
+            "elements": []
           }
         ]
       }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -227,6 +227,19 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   }
                 },
                 "elements": []
+              },
+              {
+                "$type": "Assignment",
+                "feature": "types",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "Type"
+                  }
+                },
+                "elements": []
               }
             ],
             "cardinality": "+"
@@ -389,39 +402,142 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "value": ":"
           },
           {
-            "$type": "Alternatives",
-            "elements": [
-              {
-                "$type": "Assignment",
-                "feature": "primitiveType",
-                "operator": "=",
-                "terminal": {
-                  "$type": "RuleCall",
-                  "arguments": [],
-                  "rule": {
-                    "$refText": "PrimitiveType"
-                  }
-                },
-                "elements": []
-              },
-              {
-                "$type": "Assignment",
-                "feature": "type",
-                "operator": "=",
-                "terminal": {
-                  "$type": "CrossReference",
-                  "type": {
-                    "$refText": "AbstractType"
-                  }
-                },
-                "elements": []
+            "$type": "Assignment",
+            "feature": "type",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "AtomType"
               }
-            ]
+            }
           },
           {
             "$type": "Keyword",
             "value": ";",
             "cardinality": "?"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "Type",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "type",
+            "elements": []
+          },
+          {
+            "$type": "Assignment",
+            "feature": "name",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            }
+          },
+          {
+            "$type": "Keyword",
+            "value": "="
+          },
+          {
+            "$type": "Assignment",
+            "feature": "typeAlternatives",
+            "operator": "+=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "AtomType"
+              }
+            }
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "|",
+                "elements": []
+              },
+              {
+                "$type": "Assignment",
+                "feature": "typeAlternatives",
+                "operator": "+=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "AtomType"
+                  }
+                }
+              }
+            ],
+            "cardinality": "*"
+          },
+          {
+            "$type": "Keyword",
+            "value": ";",
+            "cardinality": "?"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "AtomType",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "Assignment",
+            "feature": "primitiveType",
+            "operator": "=",
+            "terminal": {
+              "$type": "Alternatives",
+              "elements": [
+                {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "PrimitiveType"
+                  },
+                  "elements": []
+                },
+                {
+                  "$type": "RuleCall",
+                  "arguments": [],
+                  "rule": {
+                    "$refText": "Keyword"
+                  }
+                }
+              ]
+            },
+            "elements": []
+          },
+          {
+            "$type": "Assignment",
+            "feature": "referenceType",
+            "operator": "=",
+            "terminal": {
+              "$type": "CrossReference",
+              "type": {
+                "$refText": "AbstractType"
+              }
+            },
+            "elements": []
           }
         ]
       }
@@ -439,6 +555,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "arguments": [],
             "rule": {
               "$refText": "Interface"
+            },
+            "elements": []
+          },
+          {
+            "$type": "RuleCall",
+            "arguments": [],
+            "rule": {
+              "$refText": "Type"
             },
             "elements": []
           },
@@ -3059,6 +3183,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     }
   ],
   "interfaces": [],
+  "types": [],
   "isDeclared": true,
   "name": "LangiumGrammar"
 }`));

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -260,7 +260,7 @@ function withCardinality(regex: string, cardinality?: string, wrap = false): str
 
 export function getTypeName(rule: ast.AbstractRule | undefined): string {
     if (rule) {
-        return rule.type ?? rule.name;
+        return rule.type?.name ?? rule.name;
     } else {
         throw new Error('Unknown rule type');
     }
@@ -268,7 +268,7 @@ export function getTypeName(rule: ast.AbstractRule | undefined): string {
 
 export function getRuleType(rule: ast.AbstractRule | undefined): string {
     if (ast.isParserRule(rule) && isDataTypeRule(rule) || ast.isTerminalRule(rule)) {
-        return rule.type ?? 'string';
+        return rule.type?.name ?? 'string';
     }
     return getTypeName(rule);
 }
@@ -375,9 +375,9 @@ export function processNodeWithNodeLocator(astNodeLocator: AstNodeLocator): (nod
             scopes.add(container, {
                 node,
                 type: 'Interface',
-                name: node.type ?? node.name,
+                name: node.type?.name ?? node.name,
                 documentUri: document.uri,
-                path: astNodeLocator.getAstNodePath(node)
+                path: astNodeLocator.getAstNodePath(node.type ?? node)
             });
         }
     };

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -14,6 +14,7 @@ import { getContainerOfType, getDocument, Mutable, streamAllContents } from '../
 import { MultiMap } from '../utils/collections';
 import { streamCst } from '../utils/cst-util';
 import { escapeRegExp } from '../utils/regex-util';
+import { stream } from '../utils/stream';
 import { AstNodeLocator } from '../workspace/ast-node-locator';
 import { documentFromText, LangiumDocument, LangiumDocuments, PrecomputedScopes } from '../workspace/documents';
 import { createLangiumGrammarServices } from './langium-grammar-module';
@@ -79,6 +80,10 @@ function findNameAssignmentInternal(node: AstNode, refType: ast.AbstractType): a
         }
     }
     return undefined;
+}
+
+export function distictAndSorted<T>(list: T[], compareFn?: (a: T, b: T) => number): T[] {
+    return stream(list).distinct().toArray().sort(compareFn);
 }
 
 export function isCommentTerminal(terminalRule: ast.TerminalRule): boolean {

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -14,7 +14,6 @@ import { getContainerOfType, getDocument, Mutable, streamAllContents } from '../
 import { MultiMap } from '../utils/collections';
 import { streamCst } from '../utils/cst-util';
 import { escapeRegExp } from '../utils/regex-util';
-import { stream } from '../utils/stream';
 import { AstNodeLocator } from '../workspace/ast-node-locator';
 import { documentFromText, LangiumDocument, LangiumDocuments, PrecomputedScopes } from '../workspace/documents';
 import { createLangiumGrammarServices } from './langium-grammar-module';
@@ -86,10 +85,6 @@ function findNameAssignmentInternal(type: ast.AbstractType, cashed: Map<ast.Abst
         }
     }
     return undefined;
-}
-
-export function distictAndSorted<T>(list: T[], compareFn?: (a: T, b: T) => number): T[] {
-    return stream(list).distinct().toArray().sort(compareFn);
 }
 
 export function isCommentTerminal(terminalRule: ast.TerminalRule): boolean {

--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -9,6 +9,7 @@ import { inject, Module } from '../dependency-injection';
 import { LangiumServices, LangiumSharedServices, PartialLangiumServices } from '../services';
 import { LangiumGrammarGeneratedModule, LangiumGrammarGeneratedSharedModule } from './generated/module';
 import { LangiumGrammarCodeActionProvider } from './langium-grammar-code-actions';
+import { LangiumGrammarScopeComputation } from './langium-grammar-scope';
 import { LangiumGrammarSemanticTokenProvider } from './langium-grammar-semantic-token-provider';
 import { LangiumGrammarValidationRegistry, LangiumGrammarValidator } from './langium-grammar-validator';
 import { LangiumGrammarFoldingRangeProvider } from './lsp/langium-grammar-folding-range-provider';
@@ -30,6 +31,9 @@ export const LangiumGrammarModule: Module<LangiumGrammarServices, PartialLangium
         FoldingRangeProvider: (services) => new LangiumGrammarFoldingRangeProvider(services),
         CodeActionProvider: () => new LangiumGrammarCodeActionProvider(),
         SemanticTokenProvider: () => new LangiumGrammarSemanticTokenProvider()
+    },
+    references: {
+        ScopeComputation: (services) => new LangiumGrammarScopeComputation(services),
     }
 };
 

--- a/packages/langium/src/grammar/langium-grammar-scope.ts
+++ b/packages/langium/src/grammar/langium-grammar-scope.ts
@@ -1,0 +1,26 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { DefaultScopeComputation } from '../references/scope';
+import { LangiumServices } from '../services';
+import { AstNode } from '../syntax-tree';
+import { AstNodeLocator } from '../workspace/ast-node-locator';
+import { LangiumDocument, PrecomputedScopes } from '../workspace/documents';
+import { processNodeWithNodeLocator } from './grammar-util';
+
+export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
+    protected readonly astNodeLocator: AstNodeLocator;
+
+    constructor(services: LangiumServices) {
+        super(services);
+        this.astNodeLocator = services.index.AstNodeLocator;
+    }
+
+    protected processNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
+        processNodeWithNodeLocator(this.astNodeLocator)(node, document, scopes);
+        super.processNode(node, document, scopes);
+    }
+}

--- a/packages/langium/src/grammar/langium-grammar-scope.ts
+++ b/packages/langium/src/grammar/langium-grammar-scope.ts
@@ -9,7 +9,8 @@ import { LangiumServices } from '../services';
 import { AstNode } from '../syntax-tree';
 import { AstNodeLocator } from '../workspace/ast-node-locator';
 import { LangiumDocument, PrecomputedScopes } from '../workspace/documents';
-import { processNodeWithNodeLocator } from './grammar-util';
+import { isReturnType } from './generated/ast';
+import { processTypeNodeWithNodeLocator } from './grammar-util';
 
 export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
     protected readonly astNodeLocator: AstNodeLocator;
@@ -20,7 +21,8 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
     }
 
     protected processNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
-        processNodeWithNodeLocator(this.astNodeLocator)(node, document, scopes);
+        if (isReturnType(node)) return;
+        processTypeNodeWithNodeLocator(this.astNodeLocator)(node, document, scopes);
         super.processNode(node, document, scopes);
     }
 }

--- a/packages/langium/src/grammar/langium-grammar-scope.ts
+++ b/packages/langium/src/grammar/langium-grammar-scope.ts
@@ -14,15 +14,16 @@ import { processTypeNodeWithNodeLocator } from './grammar-util';
 
 export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
     protected readonly astNodeLocator: AstNodeLocator;
+    protected readonly processTypeNode: (node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes) => void;
 
     constructor(services: LangiumServices) {
         super(services);
-        this.astNodeLocator = services.index.AstNodeLocator;
+        this.processTypeNode = processTypeNodeWithNodeLocator(services.index.AstNodeLocator);
     }
 
     protected processNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
         if (isReturnType(node)) return;
-        processTypeNodeWithNodeLocator(this.astNodeLocator)(node, document, scopes);
+        this.processTypeNode(node, document, scopes);
         super.processNode(node, document, scopes);
     }
 }

--- a/packages/langium/src/grammar/langium-grammar-semantic-token-provider.ts
+++ b/packages/langium/src/grammar/langium-grammar-semantic-token-provider.ts
@@ -7,8 +7,7 @@
 import { SemanticTokenTypes } from 'vscode-languageserver';
 import { AbstractSemanticTokenProvider, SemanticTokenAcceptor } from '../lsp/semantic-token-provider';
 import { AstNode } from '../syntax-tree';
-import { isAction, isAssignment, isParameter, isParameterReference, isParserRule, isTerminalRule } from './generated/ast';
-import { isDataTypeRule } from './grammar-util';
+import { isAction, isAssignment, isParameter, isParameterReference, isReturnType } from './generated/ast';
 
 export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenProvider {
 
@@ -27,10 +26,10 @@ export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenPr
                     type: SemanticTokenTypes.property
                 });
             }
-        } else if ((isParserRule(node) && isDataTypeRule(node) || isTerminalRule(node)) && node.type) {
+        } else if (isReturnType(node)) {
             acceptor({
                 node,
-                feature: 'type',
+                feature: 'name',
                 type: SemanticTokenTypes.type
             });
         } else if (isParameter(node)) {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -399,7 +399,7 @@ export class LangiumGrammarValidator {
     }
 
     checkParserRuleDataType(rule: ast.ParserRule, accept: ValidationAcceptor): void {
-        const hasDatatypeReturnType = rule.type && isPrimitiveType(rule.type);
+        const hasDatatypeReturnType = rule.type?.name && isPrimitiveType(rule.type.name);
         const isDataType = isDataTypeRule(rule);
         if (!hasDatatypeReturnType && isDataType) {
             accept('error', 'This parser rule does not create an object. Add a primitive return type or an action to the start of the rule to force object instantiation.', { node: rule, property: 'name' });
@@ -409,7 +409,7 @@ export class LangiumGrammarValidator {
     }
 
     checkTerminalRuleReturnType(rule: ast.TerminalRule, accept: ValidationAcceptor): void {
-        if (rule.type && !isPrimitiveType(rule.type)) {
+        if (rule.type?.name && !isPrimitiveType(rule.type.name)) {
             accept('error', "Terminal rules can only return primitive types like 'string', 'boolean', 'number' or 'date'.", { node: rule, property: 'type' });
         }
     }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -16,12 +16,15 @@ entry Grammar:
 ///////////////////////////////////////////////////////////////////////////////
 
 TypeDeclaration:
-	Interface;
+	Interface | X;
+
+X:
+	'x' name=ID;
 
 Interface:
 	'interface' name=ID
 	// superType: [Interface, ParserRule, ReturnType (only ID)]
-	('extends' superTypes+=ID (',' superTypes+=ID)*)?
+	('extends' superTypes+=[AbstractType] (',' superTypes+=[AbstractType])*)?
 	SchemaType;
 
 fragment SchemaType:
@@ -29,7 +32,7 @@ fragment SchemaType:
 
 TypeAttribute:
 	// primitiveType/type: [Interface, ParserRule, ReturnType (primitive + ID)]
-	name=ID (isOptional?='?')? ':' (primitiveType=PrimitiveType | type=[AbstractType:ID]) ';'?;
+	name=ID (isOptional?='?')? ':' (primitiveType=PrimitiveType | type=[AbstractType]) ';'?;
 
 AbstractType:
 	Interface | ParserRule;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -20,7 +20,7 @@ TypeDeclaration:
 
 Interface:
 	'interface' name=ID
-	// superType can be Interface, not primitive return type or ParserRule without return name
+	// superType: [Interface, ParserRule, ReturnType (only ID)]
 	('extends' superTypes+=ID (',' superTypes+=ID)*)?
 	SchemaType;
 
@@ -28,11 +28,14 @@ fragment SchemaType:
 	'{' attributes+=TypeAttribute* '}' ';'?;
 
 TypeAttribute:
-	// type can be a primitive type, Interface, not primitive return type or ParserRule without return name 
+	// type: [Interface, ParserRule, ReturnType (primitive + ID)]
 	name=ID (isOptional?='?')? ':' type=ID ';'?;
 
-// return type for terminals and datatype rules can be a primitive type
-// return type for parser rules can be Interface, ParserRule or any ID (what is condidered as type definition)
+// return type for terminals and datatype rules: [primitive]
+// return type for parser rules: [Interface, ID]
+
+ReturnType returns string:
+	'string' | 'number' | 'boolean' | 'bigint' | 'Date' | ID;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -43,8 +46,8 @@ GrammarImport:
 
 ParserRule :
 	(
-	  (^entry?='entry' | ^fragment?='fragment') RuleNameAndParams (wildcard?='*' | ('returns' type=ID)?)
-	| RuleNameAndParams ('returns' type=ID)?
+	  (^entry?='entry' | ^fragment?='fragment') RuleNameAndParams (wildcard?='*' | ('returns' type=ReturnType)?)
+	| RuleNameAndParams ('returns' type=ReturnType)?
 	)
 	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
 		alternatives=Alternatives
@@ -150,7 +153,7 @@ PredicatedGroup returns Group:
 	(predicated?='=>' | firstSetPredicated?='->') '(' elements+=Alternatives ')';
 
 TerminalRule:
-	^hidden?='hidden'? 'terminal' (^fragment?='fragment' name=ID | name=ID ('returns' type=ID)?) ':'
+	^hidden?='hidden'? 'terminal' (^fragment?='fragment' name=ID | name=ID ('returns' type=ReturnType)?) ':'
 		^terminal=TerminalAlternatives
 	';';
 

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -11,7 +11,30 @@ entry Grammar:
         (definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')?
     )?
 	imports+=GrammarImport*
-	(rules+=AbstractRule)+;
+	(rules+=AbstractRule | types+=TypeDeclaration)+;
+
+///////////////////////////////////////////////////////////////////////////////
+
+TypeDeclaration:
+	Interface;
+
+Interface:
+	'interface' name=ID
+	// superType can be Interface, not primitive return type or ParserRule without return name
+	('extends' superTypes+=ID (',' superTypes+=ID)*)?
+	SchemaType;
+
+fragment SchemaType:
+	'{' attributes+=TypeAttribute* '}' ';'?;
+
+TypeAttribute:
+	// type can be a primitive type, Interface, not primitive return type or ParserRule without return name 
+	name=ID (isOptional?='?')? ':' type=ID ';'?;
+
+// return type for terminals and datatype rules can be a primitive type
+// return type for parser rules can be Interface, ParserRule or any ID (what is condidered as type definition)
+
+///////////////////////////////////////////////////////////////////////////////
 
 AbstractRule : ParserRule | TerminalRule;
 

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -28,14 +28,20 @@ fragment SchemaType:
 	'{' attributes+=TypeAttribute* '}' ';'?;
 
 TypeAttribute:
-	// type: [Interface, ParserRule, ReturnType (primitive + ID)]
-	name=ID (isOptional?='?')? ':' type=ID ';'?;
+	// primitiveType/type: [Interface, ParserRule, ReturnType (primitive + ID)]
+	name=ID (isOptional?='?')? ':' (primitiveType=PrimitiveType | type=[AbstractType:ID]) ';'?;
+
+AbstractType:
+	Interface | ParserRule;
+
+PrimitiveType returns string:
+	'string' | 'number' | 'boolean' | 'date';
 
 // return type for terminals and datatype rules: [primitive]
 // return type for parser rules: [Interface, ID]
 
 ReturnType returns string:
-	'string' | 'number' | 'boolean' | 'bigint' | 'Date' | ID;
+	PrimitiveType | ID;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -11,15 +11,9 @@ entry Grammar:
         (definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')?
     )?
 	imports+=GrammarImport*
-	(rules+=AbstractRule | types+=TypeDeclaration)+;
+	(rules+=AbstractRule | interfaces+=Interface)+;
 
 ///////////////////////////////////////////////////////////////////////////////
-
-TypeDeclaration:
-	Interface | X;
-
-X:
-	'x' name=ID;
 
 Interface:
 	'interface' name=ID

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -40,8 +40,8 @@ PrimitiveType returns string:
 // return type for terminals and datatype rules: [primitive]
 // return type for parser rules: [Interface, ID]
 
-ReturnType returns string:
-	PrimitiveType | ID;
+ReturnType:
+	name=(PrimitiveType | ID);
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -33,10 +33,10 @@ Type:
 
 // atom ////////////
 AtomType:
-	isRef?='@'? (
-		value=(PrimitiveType | Keyword)
-	| 	 refValue=[AbstractType]
-	) isArray?='[]'?;
+		(	primitiveType=PrimitiveType
+		| 	isRef?='@'? refType=[AbstractType]
+		) isArray?='[]'?
+	|	keywordType=Keyword;
 
 AbstractType:
 	Interface | Type | ParserRule;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -13,9 +13,6 @@ entry Grammar:
 	imports+=GrammarImport*
 	(rules+=AbstractRule | interfaces+=Interface | types+=Type)+;
 
-///////////////////////////////////////////////////////////////////////////////
-
-// interface ///////
 Interface:
 	'interface' name=ID
 	('extends' superTypes+=[AbstractType] (',' superTypes+=[AbstractType])*)?
@@ -27,11 +24,9 @@ fragment SchemaType:
 TypeAttribute:
 	name=ID (isOptional?='?')? ':' ^type=AtomType ';'?;
 
-// type ////////////
 Type:
 	'type' name=ID '=' typeAlternatives+=AtomType ('|' typeAlternatives+=AtomType)* ';'?;
 
-// atom ////////////
 AtomType:
 		(	primitiveType=PrimitiveType
 		| 	isRef?='@'? refType=[AbstractType]
@@ -43,11 +38,8 @@ type AbstractType = Interface | Type | ParserRule;
 PrimitiveType returns string:
 	'string' | 'number' | 'boolean' | 'date';
 
-// return type /////
 ReturnType:
 	name=(PrimitiveType | ID);
-
-///////////////////////////////////////////////////////////////////////////////
 
 AbstractRule : ParserRule | TerminalRule;
 

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -33,8 +33,10 @@ Type:
 
 // atom ////////////
 AtomType:
-		primitiveType=(PrimitiveType | Keyword)
-	| 	referenceType=[AbstractType];
+	isRef?='@'? (
+		value=(PrimitiveType | Keyword)
+	| 	 refValue=[AbstractType]
+	) isArray?='[]'?;
 
 AbstractType:
 	Interface | Type | ParserRule;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -38,8 +38,7 @@ AtomType:
 		) isArray?='[]'?
 	|	keywordType=Keyword;
 
-AbstractType:
-	Interface | Type | ParserRule;
+type AbstractType = Interface | Type | ParserRule;
 
 PrimitiveType returns string:
 	'string' | 'number' | 'boolean' | 'date';
@@ -152,7 +151,7 @@ AssignableAlternatives returns AbstractElement:
 	AssignableTerminal ({Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
 CrossReference returns AbstractElement:
-	{CrossReference} '[' ^type=[ParserRule:ID] ((deprecatedSyntax?='|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
+	{CrossReference} '[' ^type=[AbstractType] ((deprecatedSyntax?='|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
 
 CrossReferenceableTerminal returns AbstractElement:
 	Keyword | RuleCall;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -22,7 +22,7 @@ fragment SchemaType:
 	'{' attributes+=TypeAttribute* '}' ';'?;
 
 TypeAttribute:
-	name=ID (isOptional?='?')? ':' ^type=AtomType ';'?;
+	name=ID (isOptional?='?')? ':' type=AtomType ';'?;
 
 Type:
 	'type' name=ID '=' typeAlternatives+=AtomType ('|' typeAlternatives+=AtomType)* ';'?;
@@ -48,8 +48,8 @@ GrammarImport:
 
 ParserRule :
 	(
-	  (^entry?='entry' | ^fragment?='fragment') RuleNameAndParams (wildcard?='*' | ('returns' ^type=ReturnType)?)
-	| RuleNameAndParams ('returns' ^type=ReturnType)?
+	  (entry?='entry' | fragment?='fragment') RuleNameAndParams (wildcard?='*' | ('returns' type=ReturnType)?)
+	| RuleNameAndParams ('returns' type=ReturnType)?
 	)
 	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
 		alternatives=Alternatives
@@ -83,7 +83,7 @@ AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | AbstractTerminal) cardinality=('?'|'*'|'+')?;
 
 Action returns AbstractElement:
-	{Action} '{' ^type=ID ('.' feature=ID operator=('='|'+=') 'current')? '}';
+	{Action} '{' type=ID ('.' feature=FeatureName operator=('='|'+=') 'current')? '}';
 
 AbstractTerminal returns AbstractElement:
 	Keyword |
@@ -104,7 +104,7 @@ NamedArgument:
 	( value=Disjunction );
 
 LiteralCondition:
-	^true?='true' | 'false';
+	true?='true' | 'false';
 
 Disjunction returns Condition:
 	Conjunction ({Disjunction.left=current} '|' right=Conjunction)*;
@@ -131,7 +131,7 @@ PredicatedRuleCall returns RuleCall:
 	(predicated?='=>' | firstSetPredicated?='->') rule=[AbstractRule:ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
 
 Assignment returns AbstractElement:
-	{Assignment} (predicated?='=>' | firstSetPredicated?='->')? feature=ID operator=('+='|'='|'?=') ^terminal=AssignableTerminal;
+	{Assignment} (predicated?='=>' | firstSetPredicated?='->')? feature=FeatureName operator=('+='|'='|'?=') terminal=AssignableTerminal;
 
 AssignableTerminal returns AbstractElement:
 	Keyword | RuleCall | ParenthesizedAssignableElement | CrossReference;
@@ -143,7 +143,7 @@ AssignableAlternatives returns AbstractElement:
 	AssignableTerminal ({Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
 CrossReference returns AbstractElement:
-	{CrossReference} '[' ^type=[AbstractType] ((deprecatedSyntax?='|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
+	{CrossReference} '[' type=[AbstractType] ((deprecatedSyntax?='|' | ':') terminal=CrossReferenceableTerminal )? ']';
 
 CrossReferenceableTerminal returns AbstractElement:
 	Keyword | RuleCall;
@@ -155,8 +155,8 @@ PredicatedGroup returns Group:
 	(predicated?='=>' | firstSetPredicated?='->') '(' elements+=Alternatives ')';
 
 TerminalRule:
-	^hidden?='hidden'? 'terminal' (^fragment?='fragment' name=ID | name=ID ('returns' ^type=ReturnType)?) ':'
-		^terminal=TerminalAlternatives
+	hidden?='hidden'? 'terminal' (fragment?='fragment' name=ID | name=ID ('returns' type=ReturnType)?) ':'
+		terminal=TerminalAlternatives
 	';';
 
 terminal RegexLiteral returns string: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\//;
@@ -180,10 +180,10 @@ TerminalRuleCall returns AbstractElement:
 	{TerminalRuleCall} rule=[TerminalRule:ID];
 
 NegatedToken returns AbstractElement:
-	{NegatedToken} '!' ^terminal=TerminalTokenElement;
+	{NegatedToken} '!' terminal=TerminalTokenElement;
 
 UntilToken returns AbstractElement:
-	{UntilToken} '->' ^terminal=TerminalTokenElement;
+	{UntilToken} '->' terminal=TerminalTokenElement;
 
 RegexToken returns AbstractElement:
 	{RegexToken} regex=RegexLiteral;
@@ -193,6 +193,9 @@ Wildcard returns AbstractElement:
 
 CharacterRange returns AbstractElement:
 	{CharacterRange} left=Keyword ('..' right=Keyword)?;
+
+FeatureName returns string:
+	'current' | 'entry' | 'extends' | 'false' | 'fragment' | 'grammar' | 'hidden' | 'import' | 'interface' | 'returns' | 'terminal' | 'true' | 'type' | 'with' | PrimitiveType | ID;
 
 terminal ID: /\^?[_a-zA-Z][\w_]*/;
 terminal STRING: /"[^"]*"|'[^']*'/;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -11,13 +11,13 @@ entry Grammar:
         (definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')?
     )?
 	imports+=GrammarImport*
-	(rules+=AbstractRule | interfaces+=Interface)+;
+	(rules+=AbstractRule | interfaces+=Interface | types+=Type)+;
 
 ///////////////////////////////////////////////////////////////////////////////
 
+// interface ///////
 Interface:
 	'interface' name=ID
-	// superType: [Interface, ParserRule, ReturnType (only ID)]
 	('extends' superTypes+=[AbstractType] (',' superTypes+=[AbstractType])*)?
 	SchemaType;
 
@@ -25,18 +25,24 @@ fragment SchemaType:
 	'{' attributes+=TypeAttribute* '}' ';'?;
 
 TypeAttribute:
-	// primitiveType/type: [Interface, ParserRule, ReturnType (primitive + ID)]
-	name=ID (isOptional?='?')? ':' (primitiveType=PrimitiveType | type=[AbstractType]) ';'?;
+	name=ID (isOptional?='?')? ':' ^type=AtomType ';'?;
+
+// type ////////////
+Type:
+	'type' name=ID '=' typeAlternatives+=AtomType ('|' typeAlternatives+=AtomType)* ';'?;
+
+// atom ////////////
+AtomType:
+		primitiveType=(PrimitiveType | Keyword)
+	| 	referenceType=[AbstractType];
 
 AbstractType:
-	Interface | ParserRule;
+	Interface | Type | ParserRule;
 
 PrimitiveType returns string:
 	'string' | 'number' | 'boolean' | 'date';
 
-// return type for terminals and datatype rules: [primitive]
-// return type for parser rules: [Interface, ID]
-
+// return type /////
 ReturnType:
 	name=(PrimitiveType | ID);
 
@@ -49,8 +55,8 @@ GrammarImport:
 
 ParserRule :
 	(
-	  (^entry?='entry' | ^fragment?='fragment') RuleNameAndParams (wildcard?='*' | ('returns' type=ReturnType)?)
-	| RuleNameAndParams ('returns' type=ReturnType)?
+	  (^entry?='entry' | ^fragment?='fragment') RuleNameAndParams (wildcard?='*' | ('returns' ^type=ReturnType)?)
+	| RuleNameAndParams ('returns' ^type=ReturnType)?
 	)
 	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
 		alternatives=Alternatives
@@ -84,7 +90,7 @@ AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | AbstractTerminal) cardinality=('?'|'*'|'+')?;
 
 Action returns AbstractElement:
-	{Action} '{' type=ID ('.' feature=ID operator=('='|'+=') 'current')? '}';
+	{Action} '{' ^type=ID ('.' feature=ID operator=('='|'+=') 'current')? '}';
 
 AbstractTerminal returns AbstractElement:
 	Keyword |
@@ -144,7 +150,7 @@ AssignableAlternatives returns AbstractElement:
 	AssignableTerminal ({Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
 CrossReference returns AbstractElement:
-	{CrossReference} '[' type=[ParserRule:ID] ((deprecatedSyntax?='|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
+	{CrossReference} '[' ^type=[ParserRule:ID] ((deprecatedSyntax?='|' | ':') ^terminal=CrossReferenceableTerminal )? ']';
 
 CrossReferenceableTerminal returns AbstractElement:
 	Keyword | RuleCall;
@@ -156,7 +162,7 @@ PredicatedGroup returns Group:
 	(predicated?='=>' | firstSetPredicated?='->') '(' elements+=Alternatives ')';
 
 TerminalRule:
-	^hidden?='hidden'? 'terminal' (^fragment?='fragment' name=ID | name=ID ('returns' type=ReturnType)?) ':'
+	^hidden?='hidden'? 'terminal' (^fragment?='fragment' name=ID | name=ID ('returns' ^type=ReturnType)?) ':'
 		^terminal=TerminalAlternatives
 	';';
 

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -44,7 +44,7 @@ export class DefaultValueConverter implements ValueConverter {
             case 'ID': return convertID(input);
             case 'REGEXLITERAL': return convertString(input);
         }
-        switch (rule.type.toLowerCase()) {
+        switch (rule.type?.name?.toLowerCase()) {
             case 'number': return convertNumber(input);
             case 'boolean': return convertBoolean(input);
             default: return input;


### PR DESCRIPTION
* Adds `interface` and `type` syntax
* Adds `ReturnType` & adds it to the scope for cross-references
* Removes properties lifting by replacement interfaces with types in the AST (closes [#408](https://github.com/langium/langium/issues/408))
* Adds references in types as `@` and arrays as `[]` (for example, `@MyType[]` means an array of references on `MyType`)
* Adds types in the AST reflection
* Sorts the AST: interfaces and types / fields / fields types / container types / cases in reflection