### PR TITLE
Run converter before constructing data rule string

### DIFF
--- a/packages/langium/src/lsp/folding-range-provider.ts
+++ b/packages/langium/src/lsp/folding-range-provider.ts
@@ -5,9 +5,8 @@
  ******************************************************************************/
 
 import { CancellationToken, FoldingRange, FoldingRangeKind, FoldingRangeParams } from 'vscode-languageserver';
-import { LeafCstNodeImpl } from '../parser/cst-node-builder';
 import { LangiumServices } from '../services';
-import { AstNode, CstNode } from '../syntax-tree';
+import { AstNode, CstNode, isLeafCstNode } from '../syntax-tree';
 import { streamAllContents } from '../utils/ast-util';
 import { streamCst } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
@@ -101,7 +100,7 @@ export class DefaultFoldingRangeProvider implements FoldingRangeProvider {
         const cstNode = node.$cstNode;
         if (cstNode) {
             for (const node of streamCst(cstNode)) {
-                if (node instanceof LeafCstNodeImpl && this.commentNames.includes(node.tokenType.name)) {
+                if (isLeafCstNode(node) && this.commentNames.includes(node.tokenType.name)) {
                     const foldingRange = this.toFoldingRange(document, node, FoldingRangeKind.Comment);
                     if (foldingRange) {
                         acceptor(foldingRange);

--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -144,7 +144,7 @@ function buildRuleCall(ctx: RuleContext, ruleCall: RuleCall): Method {
     if (isParserRule(rule)) {
         const idx = ctx.subrule++;
         const predicate = ruleCall.arguments.length > 0 ? buildRuleCallPredicate(rule, ruleCall.arguments) : () => ({});
-        if (hasContainerOfType(ruleCall, isAssignment) || isDataTypeRule(rule)) {
+        if (hasContainerOfType(ruleCall, isAssignment)) {
             return (args) => ctx.parser.subrule(idx, getRule(ctx, rule.name), ruleCall, predicate(args));
         } else {
             return (args) => ctx.parser.unassignedSubrule(idx, getRule(ctx, rule.name), ruleCall, predicate(args));

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -134,9 +134,17 @@ export interface CompositeCstNode extends CstNode {
     children: CstNode[];
 }
 
+export function isCompositeCstNode(node: CstNode): node is CompositeCstNode {
+    return typeof node === 'object' && !!node && 'children' in node;
+}
+
 /**
  * A leaf CST node corresponds to a token in the input token stream.
  */
 export interface LeafCstNode extends CstNode {
     readonly tokenType: TokenType;
+}
+
+export function isLeafCstNode(node: CstNode): node is LeafCstNode {
+    return typeof node === 'object' && !!node && 'tokenType' in node;
 }


### PR DESCRIPTION
Closes #418 

Runs the value converter when calling the `construct` method of the parser, instead of waiting until the appropriate assignment is performed.