### PR TITLE
Order semantic tokens

### DIFF
--- a/packages/langium/src/grammar/langium-grammar-semantic-token-provider.ts
+++ b/packages/langium/src/grammar/langium-grammar-semantic-token-provider.ts
@@ -7,7 +7,7 @@
 import { SemanticTokenTypes } from 'vscode-languageserver';
 import { AbstractSemanticTokenProvider, SemanticTokenAcceptor } from '../lsp/semantic-token-provider';
 import { AstNode } from '../syntax-tree';
-import { isAction, isAssignment, isParameter, isParameterReference, isReturnType } from './generated/ast';
+import { isAction, isAssignment, isAtomType, isParameter, isParameterReference, isReturnType } from './generated/ast';
 
 export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenProvider {
 
@@ -30,6 +30,12 @@ export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenPr
             acceptor({
                 node,
                 feature: 'name',
+                type: SemanticTokenTypes.type
+            });
+        } else if (isAtomType(node)) {
+            acceptor({
+                node,
+                feature: 'primitiveType',
                 type: SemanticTokenTypes.type
             });
         } else if (isParameter(node)) {


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/420

Implements an extension of the `SemanticTokensBuilder` provided by the language-server library, which sorts tokens before building the final array.

#### How to test

Open a grammar file and add `interface Test { x: string }` before the first rule. Also include a rule which returns `string`, `number`, etc. The `string` of the `Test` interface should be highlighted correctly.