### PR TITLE
Fixed domainmodel example generator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -80,6 +80,26 @@
 			]
 		},
 		{
+			"name": "Generate Domainmodel",
+			"type": "pwa-node",
+			"request": "launch",
+			"runtimeExecutable": "node",
+			"runtimeArgs": [
+				"${workspaceFolder}/examples/domainmodel/out/cli/cli",
+				"generate",
+				"example/blog.dmodel"
+			],
+			"cwd": "${workspaceFolder}/examples/domainmodel",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/examples/domainmodel/out/**/*.js",
+				"${workspaceFolder}/packages/langium/lib/**/*.js"
+			]
+		},
+		{
 			"name": "Extension Tests",
 			"type": "extensionHost",
 			"request": "launch",

--- a/examples/domainmodel/src/cli/cli-util.ts
+++ b/examples/domainmodel/src/cli/cli-util.ts
@@ -44,14 +44,16 @@ export async function extractAstNode<T extends AstNode>(fileName: string, extens
 }
 
 export async function setRootFolder(fileName: string, services: LangiumServices, root?: string): Promise<void> {
-    const folders: WorkspaceFolder[] = [];
-    if(!root) {
+    if (!root) {
         root = path.dirname(fileName);
     }
-    folders.push({
+    if (!path.isAbsolute(root)) {
+        root = path.resolve(process.cwd(), root);
+    }
+    const folders: WorkspaceFolder[] = [{
         name: path.basename(root),
         uri: URI.file(root).toString()
-    });
+    }];
     await services.shared.workspace.WorkspaceManager.initializeWorkspace(folders);
 }
 

--- a/examples/domainmodel/src/cli/generator.ts
+++ b/examples/domainmodel/src/cli/generator.ts
@@ -15,11 +15,15 @@ import { createDomainModelServices } from '../language-server/domain-model-modul
 import { DomainModelLanguageMetaData } from '../language-server/generated/module';
 
 export const generateAction = async (fileName: string, opts: GenerateOptions): Promise<void> => {
-    const services = createDomainModelServices().domainmodel;
-    await setRootFolder(fileName, services, opts.root);
-    const domainmodel = await extractAstNode<Domainmodel>(fileName, DomainModelLanguageMetaData.fileExtensions, services);
-    const generatedDirPath = generateJava(domainmodel, fileName, opts.destination);
-    console.log(colors.green(`Java classes generated successfully: ${colors.yellow(generatedDirPath)}`));
+    try {
+        const services = createDomainModelServices().domainmodel;
+        await setRootFolder(fileName, services, opts.root);
+        const domainmodel = await extractAstNode<Domainmodel>(fileName, DomainModelLanguageMetaData.fileExtensions, services);
+        const generatedDirPath = generateJava(domainmodel, fileName, opts.destination);
+        console.log(colors.green(`Java classes generated successfully: ${colors.yellow(generatedDirPath)}`));
+    } catch (error) {
+        console.error(colors.red(String(error)));
+    }
 };
 
 export type GenerateOptions = {

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -28,7 +28,7 @@ export interface DocumentValidator {
     validateDocument(document: LangiumDocument, cancelToken?: CancellationToken): Promise<Diagnostic[]>;
 }
 
-export class DefaultDocumentValidator {
+export class DefaultDocumentValidator implements DocumentValidator {
     protected readonly validationRegistry: ValidationRegistry;
 
     constructor(services: LangiumServices) {


### PR DESCRIPTION
URI should always be absolute. Relative paths from the CLI have to be resolved before passing them as URI to any Langium service.