### PR TITLE
Support for backticks in grammars

### DIFF
--- a/packages/langium-cli/src/generator/grammar-serializer.ts
+++ b/packages/langium-cli/src/generator/grammar-serializer.ts
@@ -26,7 +26,7 @@ export function serializeGrammar(services: LangiumServices, grammars: Grammar[],
         const grammar = grammars[i];
         // The json serializer returns strings with \n line delimiter by default
         // We need to translate these line endings to the OS specific line ending
-        const json = services.serializer.JsonSerializer.serialize(grammar, 2).replace(/\\/g, '\\\\').split('\n').join(EOL);
+        const json = services.serializer.JsonSerializer.serialize(grammar, 2).replace(/\\/g, '\\\\').replace(/`/g, '\\`').split('\n').join(EOL);
         node.append(
             'let loaded', grammar.name, 'Grammar: Grammar | undefined;', NL,
             'export const ', grammar.name, 'Grammar = (): Grammar => loaded', grammar.name, 'Grammar ||' ,'(loaded', grammar.name, 'Grammar = loadGrammar(`', json, '`));', NL


### PR DESCRIPTION
As the grammar is stored inside a template string delimited by backticks, if a grammar contains backticks the generated `grammar.ts` contains invalid syntax. Escaping the backticks solves the issue.

I couldn't find tests for this package, if they exist let me know to add a check for this situation.