### PR TITLE
Optional semicolon for imports

### DIFF
--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -249,11 +249,6 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
       "parameters": [],
       "name": "Feature",
       "hiddenTokens": [],
-      "infer": true,
-      "type": {
-        "$type": "ReturnType",
-        "name": "Feature"
-      },
       "alternatives": {
         "$type": "Group",
         "elements": [

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -698,7 +698,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           },
           {
             "$type": "Keyword",
-            "value": ";"
+            "value": ";",
+            "cardinality": "?"
           }
         ]
       }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -44,7 +44,7 @@ ReturnType:
 AbstractRule : ParserRule | TerminalRule;
 
 GrammarImport:
-	'import' path=STRING ';';
+	'import' path=STRING ';'?;
 
 ParserRule:
 	(entry?='entry' | fragment?='fragment')? RuleNameAndParams (wildcard?='*' | 'returns' type=ReturnType | infer?='infer' type=ReturnType)?


### PR DESCRIPTION
Also contains a change inside of the `grammar.ts` of the domain-model example, since I forgot to regenerate that one.