### PR TITLE
Change 'infer' to 'infers' for grammar rules

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -22,13 +22,13 @@ Evaluation:
 Expression:
 	Addition;
 
-Addition infer Expression:
+Addition infers Expression:
 	Multiplication ({infer BinaryExpression.left=current} operator=('+' | '-') right=Multiplication)*;
 
-Multiplication infer Expression:
+Multiplication infers Expression:
 	PrimaryExpression ({infer BinaryExpression.left=current} operator=('*' | '/') right=PrimaryExpression)*;
 
-PrimaryExpression infer Expression:
+PrimaryExpression infers Expression:
 	'(' Expression ')' |
 	{infer NumberLiteral} value=NUMBER |
 	{infer FunctionCall} func=[AbstractDefinition] ('(' args+=Expression (',' args+=Expression)* ')')?;

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -246,7 +246,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "Addition",
       "hiddenTokens": [],
-      "infer": true,
+      "infers": true,
       "type": {
         "$type": "ReturnType",
         "name": "Expression"
@@ -315,7 +315,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "Multiplication",
       "hiddenTokens": [],
-      "infer": true,
+      "infers": true,
       "type": {
         "$type": "ReturnType",
         "name": "Expression"
@@ -384,7 +384,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "PrimaryExpression",
       "hiddenTokens": [],
-      "infer": true,
+      "infers": true,
       "type": {
         "$type": "ReturnType",
         "name": "Expression"

--- a/packages/langium-vscode/data/langium.tmLanguage.json
+++ b/packages/langium-vscode/data/langium.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.langium",
-            "match": "\\b(grammar|terminal|entry|fragment|hidden|with|import|returns|current|type|interface|extends|infer)\\b"
+            "match": "\\b(current|entry|extends|fragment|grammar|hidden|import|infer|infers|interface|returns|terminal|type|with)\\b"
         },
         {
             "name": "constant.language.langium",

--- a/packages/langium/CHANGELOG.md
+++ b/packages/langium/CHANGELOG.md
@@ -30,7 +30,7 @@ type Symbol = Entity | PackageDeclaration | DataType | Feature
 ```
 The `interface` form describes the properties of an AST node type. The `@` character used at the `superType` property above denotes a cross-reference to a node of type `Entity`. The `type` form creates _union types_, i.e. an alternative of other declared or inferred types. These are transferred almost identically to TypeScript, where they have [their usual meaning](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html).
 
-Parser rules which use the `returns` directive to infer a new type should now use the `infer` keyword instead. Using `returns` is only valid for explicitly declared types. Actions also need to add the `infer` keyword in front of the type if it is not explicitly declared. ([#438](https://github.com/langium/langium/pull/438))
+Parser rules which use the `returns` directive to infer a new type should now use the `infers` keyword instead. Using `returns` is only valid for explicitly declared types ([#438](https://github.com/langium/langium/pull/438)). Actions need to add the `infer` keyword in front of the type if it is not explicitly declared.
 
 ### New Sprotty Integration
 

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -295,7 +295,7 @@ export interface ParserRule extends AstNode {
     entry: boolean
     fragment: boolean
     hiddenTokens: Array<Reference<AbstractRule>>
-    infer: boolean
+    infers: boolean
     name: string
     parameters: Array<Parameter>
     type: ReturnType

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -800,7 +800,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "elements": [
                   {
                     "$type": "Assignment",
-                    "feature": "infer",
+                    "feature": "infers",
                     "operator": "?=",
                     "terminal": {
                       "$type": "Keyword",

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -804,7 +804,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "operator": "?=",
                     "terminal": {
                       "$type": "Keyword",
-                      "value": "infer"
+                      "value": "infers"
                     },
                     "elements": []
                   },
@@ -3267,6 +3267,11 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "Keyword",
             "value": "infer",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "infers",
             "elements": []
           },
           {

--- a/packages/langium/src/grammar/langium-grammar-code-actions.ts
+++ b/packages/langium/src/grammar/langium-grammar-code-actions.ts
@@ -85,7 +85,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         const data = diagnostic.data as DocumentSegment;
         if (data) {
             return {
-                title: "Correct 'infers' usage",
+                title: "Correct 'infer' usage",
                 kind: CodeActionKind.QuickFix,
                 diagnostics: [diagnostic],
                 edit: {
@@ -108,7 +108,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         const data = diagnostic.data as DocumentSegment;
         if (data) {
             return {
-                title: "Correct 'infers' usage",
+                title: "Correct 'infer' usage",
                 kind: CodeActionKind.QuickFix,
                 diagnostics: [diagnostic],
                 edit: {

--- a/packages/langium/src/grammar/langium-grammar-code-actions.ts
+++ b/packages/langium/src/grammar/langium-grammar-code-actions.ts
@@ -48,9 +48,9 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
                 return this.fixMissingImport(diagnostic, document);
             case IssueCodes.UnnecessaryFileExtension:
                 return this.fixUnnecessaryFileExtension(diagnostic, document);
-            case IssueCodes.InvalidInfer:
+            case IssueCodes.InvalidInfers:
             case IssueCodes.InvalidReturns:
-                return this.fixInvalidReturnsInfer(diagnostic, document);
+                return this.fixInvalidReturnsInfers(diagnostic, document);
             case IssueCodes.MissingInfer:
                 return this.fixMissingInfer(diagnostic, document);
             case IssueCodes.SuperfluousInfer:
@@ -60,7 +60,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         }
     }
 
-    private fixInvalidReturnsInfer(diagnostic: Diagnostic, document: LangiumDocument): CodeAction | undefined {
+    private fixInvalidReturnsInfers(diagnostic: Diagnostic, document: LangiumDocument): CodeAction | undefined {
         const data = diagnostic.data as DocumentSegment;
         if (data) {
             const text = document.textDocument.getText(data.range);
@@ -72,7 +72,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
                     changes: {
                         [document.textDocument.uri]: [{
                             range: data.range,
-                            newText: text === 'infer' ? 'returns' : 'infer'
+                            newText: text === 'infers' ? 'returns' : 'infers'
                         }]
                     }
                 }
@@ -85,7 +85,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         const data = diagnostic.data as DocumentSegment;
         if (data) {
             return {
-                title: "Correct 'infer' usage",
+                title: "Correct 'infers' usage",
                 kind: CodeActionKind.QuickFix,
                 diagnostics: [diagnostic],
                 edit: {
@@ -108,7 +108,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         const data = diagnostic.data as DocumentSegment;
         if (data) {
             return {
-                title: "Correct 'infer' usage",
+                title: "Correct 'infers' usage",
                 kind: CodeActionKind.QuickFix,
                 diagnostics: [diagnostic],
                 edit: {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -248,19 +248,19 @@ export class LangiumGrammarValidator {
         }
         for (const rule of grammar.rules.filter(ast.isParserRule)) {
             const isDataType = isDataTypeRule(rule);
-            if (!isDataType && rule.type?.name && types.has(rule.type.name) === !!rule.infer) {
-                const keywordNode = rule.infer ? findKeywordNode(rule.$cstNode, 'infers') : findKeywordNode(rule.$cstNode, 'returns');
-                accept('error', getMessage(rule.type.name, rule.infer), {
+            if (!isDataType && rule.type?.name && types.has(rule.type.name) === !!rule.infers) {
+                const keywordNode = rule.infers ? findKeywordNode(rule.$cstNode, 'infers') : findKeywordNode(rule.$cstNode, 'returns');
+                accept('error', getMessage(rule.type.name, rule.infers), {
                     node: rule.type,
                     property: 'name',
-                    code: rule.infer ? IssueCodes.InvalidInfers : IssueCodes.InvalidReturns,
+                    code: rule.infers ? IssueCodes.InvalidInfers : IssueCodes.InvalidReturns,
                     data: keywordNode && toDocumentSegment(keywordNode)
                 });
-            } else if (isDataType && rule.infer) {
+            } else if (isDataType && rule.infers) {
                 const inferNode = findKeywordNode(rule.$cstNode, 'infers');
                 accept('error', 'Data type rules cannot infer a type.', {
                     node: rule,
-                    property: 'infer',
+                    property: 'infers',
                     code: IssueCodes.InvalidInfers,
                     data: inferNode && toDocumentSegment(inferNode)
                 });

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -87,7 +87,7 @@ export namespace IssueCodes {
     export const MissingImport = 'missing-import';
     export const UnnecessaryFileExtension = 'unnecessary-file-extension';
     export const InvalidReturns = 'invalid-returns';
-    export const InvalidInfer = 'invalid-infer';
+    export const InvalidInfers = 'invalid-infer';
     export const MissingInfer = 'missing-infer';
     export const SuperfluousInfer = 'superfluous-infer';
 }
@@ -249,19 +249,19 @@ export class LangiumGrammarValidator {
         for (const rule of grammar.rules.filter(ast.isParserRule)) {
             const isDataType = isDataTypeRule(rule);
             if (!isDataType && rule.type?.name && types.has(rule.type.name) === !!rule.infer) {
-                const keywordNode = findKeywordNode(rule.$cstNode, 'infer') || findKeywordNode(rule.$cstNode, 'returns');
+                const keywordNode = rule.infer ? findKeywordNode(rule.$cstNode, 'infers') : findKeywordNode(rule.$cstNode, 'returns');
                 accept('error', getMessage(rule.type.name, rule.infer), {
                     node: rule.type,
                     property: 'name',
-                    code: rule.infer ? IssueCodes.InvalidInfer : IssueCodes.InvalidReturns,
+                    code: rule.infer ? IssueCodes.InvalidInfers : IssueCodes.InvalidReturns,
                     data: keywordNode && toDocumentSegment(keywordNode)
                 });
             } else if (isDataType && rule.infer) {
-                const inferNode = findKeywordNode(rule.$cstNode, 'infer');
+                const inferNode = findKeywordNode(rule.$cstNode, 'infers');
                 accept('error', 'Data type rules cannot infer a type.', {
                     node: rule,
                     property: 'infer',
-                    code: IssueCodes.InvalidInfer,
+                    code: IssueCodes.InvalidInfers,
                     data: inferNode && toDocumentSegment(inferNode)
                 });
             }

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -87,7 +87,7 @@ export namespace IssueCodes {
     export const MissingImport = 'missing-import';
     export const UnnecessaryFileExtension = 'unnecessary-file-extension';
     export const InvalidReturns = 'invalid-returns';
-    export const InvalidInfers = 'invalid-infer';
+    export const InvalidInfers = 'invalid-infers';
     export const MissingInfer = 'missing-infer';
     export const SuperfluousInfer = 'superfluous-infer';
 }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -50,7 +50,7 @@ GrammarImport:
 	'import' path=STRING ';'?;
 
 ParserRule:
-	(entry?='entry' | fragment?='fragment')? RuleNameAndParams (wildcard?='*' | 'returns' type=ReturnType | infer?='infer' type=ReturnType)?
+	(entry?='entry' | fragment?='fragment')? RuleNameAndParams (wildcard?='*' | 'returns' type=ReturnType | infer?='infers' type=ReturnType)?
 	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
 		alternatives=Alternatives
 	';';
@@ -61,31 +61,31 @@ fragment RuleNameAndParams:
 Parameter:
 	name=ID;
 
-Alternatives infer AbstractElement:
+Alternatives infers AbstractElement:
 	ConditionalBranch ({infer Alternatives.elements+=current} ('|' elements+=ConditionalBranch)+)?;
 
-ConditionalBranch infer AbstractElement:
+ConditionalBranch infers AbstractElement:
 	  UnorderedGroup
 	| {infer Group} '<' guardCondition=Disjunction '>' (elements+=AbstractToken)+
 ;
 
-UnorderedGroup infer AbstractElement:
+UnorderedGroup infers AbstractElement:
 	Group ({infer UnorderedGroup.elements+=current} ('&' elements+=Group)+)?;
 
-Group infer AbstractElement:
+Group infers AbstractElement:
 	AbstractToken ({infer Group.elements+=current} elements+=AbstractToken+)?;
 
-AbstractToken infer AbstractElement:
+AbstractToken infers AbstractElement:
 	AbstractTokenWithCardinality |
 	Action;
 
-AbstractTokenWithCardinality infer AbstractElement:
+AbstractTokenWithCardinality infers AbstractElement:
 	(Assignment | AbstractTerminal) cardinality=('?'|'*'|'+')?;
 
-Action infer AbstractElement:
+Action infers AbstractElement:
 	{infer Action} '{' infer?='infer'? type=ID ('.' feature=FeatureName operator=('='|'+=') 'current')? '}';
 
-AbstractTerminal infer AbstractElement:
+AbstractTerminal infers AbstractElement:
 	Keyword |
 	RuleCall |
 	ParenthesizedElement |
@@ -106,52 +106,52 @@ NamedArgument:
 LiteralCondition:
 	true?='true' | 'false';
 
-Disjunction infer Condition:
+Disjunction infers Condition:
 	Conjunction ({infer Disjunction.left=current} '|' right=Conjunction)*;
 
-Conjunction infer Condition:
+Conjunction infers Condition:
 	Negation ({infer Conjunction.left=current} '&' right=Negation)*;
 
-Negation infer Condition:
+Negation infers Condition:
 	Atom | {infer Negation} '!' value=Negation;
 
-Atom infer Condition:
+Atom infers Condition:
 	ParameterReference | ParenthesizedCondition | LiteralCondition;
 
-ParenthesizedCondition infer Condition:
+ParenthesizedCondition infers Condition:
 	'(' Disjunction ')';
 
 ParameterReference:
 	parameter=[Parameter:ID];
 
-PredicatedKeyword infer Keyword:
+PredicatedKeyword infers Keyword:
 	(predicated?='=>' | firstSetPredicated?='->') value=STRING;
 
-PredicatedRuleCall infer RuleCall:
+PredicatedRuleCall infers RuleCall:
 	(predicated?='=>' | firstSetPredicated?='->') rule=[AbstractRule:ID] ('<' arguments+=NamedArgument (',' arguments+=NamedArgument)* '>')?;
 
-Assignment infer AbstractElement:
+Assignment infers AbstractElement:
 	{infer Assignment} (predicated?='=>' | firstSetPredicated?='->')? feature=FeatureName operator=('+='|'='|'?=') terminal=AssignableTerminal;
 
-AssignableTerminal infer AbstractElement:
+AssignableTerminal infers AbstractElement:
 	Keyword | RuleCall | ParenthesizedAssignableElement | CrossReference;
 
-ParenthesizedAssignableElement infer AbstractElement:
+ParenthesizedAssignableElement infers AbstractElement:
 	'(' AssignableAlternatives ')';
 
-AssignableAlternatives infer AbstractElement:
+AssignableAlternatives infers AbstractElement:
 	AssignableTerminal ({infer Alternatives.elements+=current} ('|' elements+=AssignableTerminal)+)?;
 
-CrossReference infer AbstractElement:
+CrossReference infers AbstractElement:
 	{infer CrossReference} '[' type=[AbstractType] ((deprecatedSyntax?='|' | ':') terminal=CrossReferenceableTerminal )? ']';
 
-CrossReferenceableTerminal infer AbstractElement:
+CrossReferenceableTerminal infers AbstractElement:
 	Keyword | RuleCall;
 
-ParenthesizedElement infer AbstractElement:
+ParenthesizedElement infers AbstractElement:
 	'(' Alternatives ')';
 
-PredicatedGroup infer Group:
+PredicatedGroup infers Group:
 	(predicated?='=>' | firstSetPredicated?='->') '(' elements+=Alternatives ')';
 
 TerminalRule:
@@ -161,41 +161,41 @@ TerminalRule:
 
 terminal RegexLiteral returns string: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\//;
 
-TerminalAlternatives infer AbstractElement:
+TerminalAlternatives infers AbstractElement:
 	TerminalGroup ({infer TerminalAlternatives.elements+=current} '|' elements+=TerminalGroup)*;
 
-TerminalGroup infer AbstractElement:
+TerminalGroup infers AbstractElement:
 	TerminalToken ({infer TerminalGroup.elements+=current} elements+=TerminalToken+)?;
 
-TerminalToken infer AbstractElement:
+TerminalToken infers AbstractElement:
 	TerminalTokenElement cardinality=('?'|'*'|'+')?;
 
-TerminalTokenElement infer AbstractElement:
+TerminalTokenElement infers AbstractElement:
 	CharacterRange | TerminalRuleCall | ParenthesizedTerminalElement | NegatedToken | UntilToken | RegexToken | Wildcard;
 
-ParenthesizedTerminalElement infer AbstractElement:
+ParenthesizedTerminalElement infers AbstractElement:
 	'(' TerminalAlternatives ')';
 
-TerminalRuleCall infer AbstractElement:
+TerminalRuleCall infers AbstractElement:
 	{infer TerminalRuleCall} rule=[TerminalRule:ID];
 
-NegatedToken infer AbstractElement:
+NegatedToken infers AbstractElement:
 	{infer NegatedToken} '!' terminal=TerminalTokenElement;
 
-UntilToken infer AbstractElement:
+UntilToken infers AbstractElement:
 	{infer UntilToken} '->' terminal=TerminalTokenElement;
 
-RegexToken infer AbstractElement:
+RegexToken infers AbstractElement:
 	{infer RegexToken} regex=RegexLiteral;
 
-Wildcard infer AbstractElement:
+Wildcard infers AbstractElement:
 	{infer Wildcard} '.';
 
-CharacterRange infer AbstractElement:
+CharacterRange infers AbstractElement:
 	{infer CharacterRange} left=Keyword ('..' right=Keyword)?;
 
 FeatureName returns string:
-	'current' | 'entry' | 'extends' | 'false' | 'fragment' | 'grammar' | 'hidden' | 'import' | 'interface' | 'returns' | 'terminal' | 'true' | 'type' | 'infer' | 'with' | PrimitiveType | ID;
+	'current' | 'entry' | 'extends' | 'false' | 'fragment' | 'grammar' | 'hidden' | 'import' | 'interface' | 'returns' | 'terminal' | 'true' | 'type' | 'infer' | 'infers' | 'with' | PrimitiveType | ID;
 
 terminal ID: /\^?[_a-zA-Z][\w_]*/;
 terminal STRING: /"[^"]*"|'[^']*'/;

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -50,7 +50,7 @@ GrammarImport:
 	'import' path=STRING ';'?;
 
 ParserRule:
-	(entry?='entry' | fragment?='fragment')? RuleNameAndParams (wildcard?='*' | 'returns' type=ReturnType | infer?='infers' type=ReturnType)?
+	(entry?='entry' | fragment?='fragment')? RuleNameAndParams (wildcard?='*' | 'returns' type=ReturnType | infers?='infers' type=ReturnType)?
 	(definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
 		alternatives=Alternatives
 	';';

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -144,7 +144,6 @@ export class LangiumParser {
             try {
                 result = implementation(args);
             } catch (err) {
-                console.log('Parser exception thrown!', err);
                 result = undefined;
             }
             if (!this.wrapper.IS_RECORDING && result === undefined) {


### PR DESCRIPTION
This is an alternative to #444 that instead of changing `returns` to `return` changes `infer` to `infers` for grammar rules for consistency.

The validations and code actions are not tested yet and probably need to be fixed.