### PR TITLE
Fixed two cancellation bugs, added isOperationCancelled

### DIFF
--- a/packages/langium-sprotty/src/lsp.ts
+++ b/packages/langium-sprotty/src/lsp.ts
@@ -8,7 +8,7 @@ import {
     Connection, NotificationType
 } from 'vscode-languageserver';
 import { ActionMessage } from 'sprotty-protocol';
-import { OperationCancelled } from 'langium';
+import { isOperationCancelled } from 'langium';
 import { LangiumSprottySharedServices } from './sprotty-services';
 
 export namespace DiagramActionNotification {
@@ -28,7 +28,7 @@ export function addDiagramHandler(connection: Connection, services: LangiumSprot
     connection.onNotification(DiagramActionNotification.type, message => {
         diagramServerManager.acceptAction(message)
             .catch(err => {
-                if (err !== OperationCancelled) {
+                if (!isOperationCancelled(err)) {
                     console.error('Error: ', err);
                 }
             });

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -10,7 +10,7 @@ import {
 } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import { LangiumServices, LangiumSharedServices } from '../services';
-import { OperationCancelled, startCancelableOperation } from '../utils/promise-util';
+import { isOperationCancelled, startCancelableOperation } from '../utils/promise-util';
 import { DocumentState, LangiumDocument } from '../workspace/documents';
 import { DefaultSemanticTokenOptions } from './semantic-token-provider';
 
@@ -92,7 +92,7 @@ export function addDocumentsHandler(connection: Connection, services: LangiumSha
         changePromise = documentBuilder
             .update(changed, deleted ?? [], changeTokenSource.token)
             .catch(err => {
-                if (err !== OperationCancelled) {
+                if (!isOperationCancelled(err)) {
                     console.error('Error: ', err);
                 }
             });
@@ -272,7 +272,7 @@ export function createRequestHandler<P extends { textDocument: TextDocumentIdent
 }
 
 function responseError<E = void>(err: unknown): ResponseError<E> {
-    if (err === OperationCancelled) {
+    if (isOperationCancelled(err)) {
         return new ResponseError(LSPErrorCodes.RequestCancelled, 'The request has been cancelled.');
     }
     if (err instanceof ResponseError) {

--- a/packages/langium/src/references/scope.ts
+++ b/packages/langium/src/references/scope.ts
@@ -185,7 +185,7 @@ export class DefaultScopeComputation implements ScopeComputation {
         const rootNode = document.parseResult.value;
         const scopes = new MultiMap<AstNode, AstNodeDescription>();
         for (const node of streamAllContents(rootNode)) {
-            interruptAndCheck(cancelToken);
+            await interruptAndCheck(cancelToken);
             this.processNode(node, document, scopes);
         }
         return scopes;

--- a/packages/langium/src/utils/promise-util.ts
+++ b/packages/langium/src/utils/promise-util.ts
@@ -45,6 +45,14 @@ export function setInterruptionPeriod(period: number): void {
 export const OperationCancelled = Symbol('OperationCancelled');
 
 /**
+ * Use this in a `catch` block to check whether the thrown object indicates that the operation
+ * has been cancelled.
+ */
+export function isOperationCancelled(err: unknown): err is typeof OperationCancelled {
+    return err === OperationCancelled;
+}
+
+/**
  * This function does two things:
  *  1. Check the elapsed time since the last call to this function or to `startCancelableOperation`. If the predefined
  *     period (configured with `setInterruptionPeriod`) is exceeded, execution is delayed with `delayNextTick`.

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -12,7 +12,7 @@ import { LangiumServices } from '../services';
 import { AstNode } from '../syntax-tree';
 import { streamAllContents } from '../utils/ast-util';
 import { tokenToRange } from '../utils/cst-util';
-import { interruptAndCheck } from '../utils/promise-util';
+import { interruptAndCheck, isOperationCancelled } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 import { DiagnosticInfo, ValidationAcceptor, ValidationRegistry } from './validation-registry';
 
@@ -91,6 +91,9 @@ export class DefaultDocumentValidator implements DocumentValidator {
         try {
             diagnostics.push(...await this.validateAst(parseResult.value, document, cancelToken));
         } catch (err) {
+            if (isOperationCancelled(err)) {
+                throw err;
+            }
             console.error('An error occurred during validation:', err);
         }
 


### PR DESCRIPTION
 * `DefaultDocumentValidator` needs to check whether a caught error is the OperationCancelled symbol.
 * `DefaultScopeComputation` had a missing `await` while calling `interruptAndCheck`.
 * Added `isOperationCancelled` to check an error. In case at some point we see problems with the strict symbol equality, we could enhance that function to something like this:
   ```
   export function isOperationCancelled(err: unknown): err is typeof OperationCancelled {
       return err === OperationCancelled || typeof err === 'symbol' && err.description === 'OperationCancelled';
   }
   ```