### PR TITLE
Fix type alternatives validation

### DIFF
--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -11,6 +11,7 @@ import { generatedHeader } from './util';
 
 export function generateModule(grammars: langium.Grammar[], config: LangiumConfig, grammarConfigMap: Map<langium.Grammar, LangiumLanguageConfig>): string {
     const parserConfig = config.chevrotainParserConfig;
+    const hasIParserConfigImport: boolean = !!parserConfig || grammars.some(grammar => grammarConfigMap.get(grammar)?.chevrotainParserConfig !== undefined);
     const node = new CompositeGeneratorNode();
 
     node.append(generatedHeader);
@@ -19,7 +20,7 @@ export function generateModule(grammars: langium.Grammar[], config: LangiumConfi
         node.append("import { Module } from '../../dependency-injection';", NL);
         node.contents.push("import { LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumSharedServices, LangiumServices } from '../../services';", NL);
     } else {
-        node.append(`import { LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumSharedServices, LangiumServices, LanguageMetaData, Module${parserConfig ? ', IParserConfig' : ''} } from 'langium';`, NL);
+        node.append(`import { LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumSharedServices, LangiumServices, LanguageMetaData, Module${hasIParserConfigImport ? ', IParserConfig' : ''} } from 'langium';`, NL);
     }
 
     node.append(

--- a/packages/langium-cli/src/langium.ts
+++ b/packages/langium-cli/src/langium.ts
@@ -12,6 +12,7 @@ import { generate, GenerateOptions, GeneratorResult } from './generate';
 import { cliVersion, elapsedTime, getTime, log, schema } from './generator/util';
 import { LangiumConfig, loadConfigs, RelativePath } from './package';
 import path from 'path';
+import _ from 'lodash';
 
 const program = new Command();
 program
@@ -42,7 +43,11 @@ async function forEachConfig(options: GenerateOptions, callback: (config: Langiu
         });
         process.exit(1);
     }
-    const results = await Promise.all(configs.map(config => callback(config, options)));
+    const results = await Promise.all(configs.map(config => {
+        config.projectName = _.camelCase(config.projectName);
+        config.projectName = config.projectName.charAt(0).toUpperCase() + config.projectName.slice(1);
+        return callback(config, options);
+    }));
     const allSuccessful = results.every(result => result === 'success');
     if (options.watch) {
         if (allSuccessful) {

--- a/packages/langium/src/grammar/type-system/declared-types.ts
+++ b/packages/langium/src/grammar/type-system/declared-types.ts
@@ -56,9 +56,11 @@ export function collectDeclaredTypes(interfaces: Interface[], types: Type[], inf
 }
 
 function atomTypeToPropertyType(type: AtomType): PropertyType {
-    return {
-        types: [type.refType ? getTypeName(type.refType.ref) : (type.primitiveType ?? `'${type.keywordType?.value}'`)],
-        reference: type.isRef === true,
-        array: type.isArray === true
-    };
+    let types: string[] = [];
+    if (type.refType) {
+        types = [type.refType.ref ? getTypeName(type.refType.ref) : type.refType.$refText];
+    } else {
+        types = [type.primitiveType ?? `'${type.keywordType?.value}'`];
+    }
+    return { types, reference: type.isRef === true, array: type.isArray === true };
 }

--- a/packages/langium/src/grammar/type-system/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/inferred-types.ts
@@ -295,14 +295,24 @@ function addAction(graph: TypeGraph, parent: TypePart, action: Action): TypePart
 function addAssignment(current: TypePart, assignment: Assignment): void {
     const typeItems: TypeCollection = { types: new Set(), reference: false };
     findTypes(assignment.terminal, typeItems);
-    current.properties.push({
-        name: assignment.feature,
-        optional: isOptional(assignment.cardinality),
-        typeAlternatives: [{
+
+    let typeAlternatives: PropertyType[] = [];
+    if (assignment.operator === '=' && !typeItems.reference) {
+        stream(typeItems.types)
+            .distinct()
+            .forEach(type => typeAlternatives.push({ array: false, types: [type], reference: false }));
+    } else {
+        typeAlternatives = [{
             array: assignment.operator === '+=',
             types: assignment.operator === '?=' ? ['boolean'] : Array.from(typeItems.types).sort(),
             reference: typeItems.reference
-        }]
+        }];
+    }
+
+    current.properties.push({
+        name: assignment.feature,
+        optional: isOptional(assignment.cardinality),
+        typeAlternatives
     });
 }
 

--- a/packages/langium/src/grammar/type-system/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/inferred-types.ts
@@ -203,18 +203,18 @@ function buildSuperUnions(interfaces: InterfaceType[]): UnionType[] {
     }
     for (const superType of allSupertypes.keys()) {
         if (!interfaces.some(e => e.name === superType)) {
-            unions.push({
-                name: superType,
-                reflection: true,
-                superTypes: new Set(),
-                union: [{
+            unions.push(new UnionType(
+                superType,
+                [{
                     array: false,
                     reference: false,
                     types: [...allSupertypes.get(superType)]
-                }]
-            });
+                }],
+                { reflection: true }
+            ));
         }
     }
+
     return unions;
 }
 

--- a/packages/langium/src/grammar/type-system/type-validator.ts
+++ b/packages/langium/src/grammar/type-system/type-validator.ts
@@ -18,7 +18,7 @@ export function validateTypesConsistency(grammar: Grammar, accept: ValidationAcc
     function applyErrorToRuleNodes(nodes: readonly ParserRule[], typeName: string): (errorMessage: string) => void {
         return (errorMessage: string) => {
             nodes.forEach(node => accept('error',
-                errorMessage + ` in inferred type '${typeName}'.`,
+                errorMessage + ` in a rule that returns a type '${typeName}'.`,
                 { node: node?.type ? node.type : node, property: 'name' }
             ));
         };

--- a/packages/langium/src/grammar/type-system/type-validator.ts
+++ b/packages/langium/src/grammar/type-system/type-validator.ts
@@ -181,12 +181,15 @@ function checkPropertiesConsistency(inferred: Property[], declared: Property[],
             const foundStringType = propertyTypeArrayToString(foundProperty.typeAlternatives);
             const expectedStringType = propertyTypeArrayToString(expectedProperty.typeAlternatives);
             if (foundStringType !== expectedStringType) {
-                let resultError = baseError(foundProperty.name, foundStringType, expectedStringType);
-                for (const errorInfo of checkAlternativesConsistencyHelper(foundProperty.typeAlternatives, expectedProperty.typeAlternatives)) {
-                    resultError = resultError + ` '${errorInfo.typeString}' ${errorInfo.errorMessage};`;
+                const typeAlternativesErrors = checkAlternativesConsistencyHelper(foundProperty.typeAlternatives, expectedProperty.typeAlternatives);
+                if (typeAlternativesErrors.length > 0) {
+                    let resultError = baseError(foundProperty.name, foundStringType, expectedStringType);
+                    for (const errorInfo of typeAlternativesErrors) {
+                        resultError = resultError + ` '${errorInfo.typeString}' ${errorInfo.errorMessage};`;
+                    }
+                    resultError = resultError.replace(/;$/, '.');
+                    errorToAssignment(foundProperty.name, resultError);
                 }
-                resultError = resultError.replace(/;$/, '.');
-                errorToAssignment(foundProperty.name, resultError);
             }
 
             if (checkOptional(foundProperty, expectedProperty) && !expectedProperty.optional && foundProperty.optional) {

--- a/packages/langium/src/grammar/type-system/type-validator.ts
+++ b/packages/langium/src/grammar/type-system/type-validator.ts
@@ -18,7 +18,7 @@ export function validateTypesConsistency(grammar: Grammar, accept: ValidationAcc
     function applyErrorToRuleNodes(nodes: readonly ParserRule[], typeName: string): (errorMessage: string) => void {
         return (errorMessage: string) => {
             nodes.forEach(node => accept('error',
-                errorMessage + ` in a rule that returns a type '${typeName}'.`,
+                errorMessage + ` in a rule that returns type '${typeName}'.`,
                 { node: node?.type ? node.type : node, property: 'name' }
             ));
         };

--- a/packages/langium/test/grammar/type-system/inferred-types.spec.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.spec.ts
@@ -150,7 +150,12 @@ describeTypes('inferred types for alternatives', `
                 {
                     array: false,
                     reference: false,
-                    types: ['number', 'string']
+                    types: ['string']
+                },
+                {
+                    array: false,
+                    reference: false,
+                    types: ['number']
                 }
             ]
         });


### PR DESCRIPTION
* Fixes #454 
* Improves the error message. "... expected in inferred type X" can confuse when we know, that we use here a declared type `X`. I propose to replace it with "... expected in a rule that returns a type X".
<img width="470" alt="Screenshot 2022-03-17 at 11 14 14" src="https://user-images.githubusercontent.com/15619772/159000411-fc1efc44-f0f9-486c-8d78-70ec5d81da34.png">

* Fixes error usage of `ref` property in `atomTypeToPropertyType` (it could be undefined)
* Makes `projectName` property in `langium-config.json` UpperCamelCase to avoid problems with generated files that use `projectName`
* Fixes `IParserConfig` import in the generated `module.ts`
* Fixes `UnionType` initialization