### PR TITLE
Use cross-references when using declared types

### DIFF
--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -246,9 +246,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "Addition",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Expression"
       },
       "alternatives": {
@@ -267,8 +266,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "BinaryExpression",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "BinaryExpression"
+                },
                 "feature": "left",
                 "operator": "=",
                 "elements": []
@@ -315,9 +316,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "Multiplication",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Expression"
       },
       "alternatives": {
@@ -336,8 +336,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "BinaryExpression",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "BinaryExpression"
+                },
                 "feature": "left",
                 "operator": "=",
                 "elements": []
@@ -384,9 +386,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "parameters": [],
       "name": "PrimaryExpression",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Expression"
       },
       "alternatives": {
@@ -418,8 +419,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "NumberLiteral",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "NumberLiteral"
+                },
                 "elements": []
               },
               {
@@ -441,8 +444,10 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "FunctionCall",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "FunctionCall"
+                },
                 "elements": []
               },
               {

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -305,10 +305,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
       "parameters": [],
       "name": "QualifiedName",
       "hiddenTokens": [],
-      "type": {
-        "$type": "ReturnType",
-        "name": "string"
-      },
+      "dataType": "string",
       "alternatives": {
         "$type": "Group",
         "elements": [

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -50,9 +50,9 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
 export interface Action extends AbstractElement {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     feature?: FeatureName
-    infer: boolean
+    inferredType: InferredType
     operator?: '+=' | '='
-    type: string
+    type: Reference<AbstractType>
 }
 
 export const Action = 'Action';
@@ -194,6 +194,17 @@ export function isGroup(item: unknown): item is Group {
     return reflection.isInstance(item, Group);
 }
 
+export interface InferredType extends AstNode {
+    readonly $container: Action | ParserRule;
+    name: string
+}
+
+export const InferredType = 'InferredType';
+
+export function isInferredType(item: unknown): item is InferredType {
+    return reflection.isInstance(item, InferredType);
+}
+
 export interface Interface extends AstNode {
     readonly $container: Grammar;
     attributes: Array<TypeAttribute>
@@ -291,14 +302,15 @@ export function isParameterReference(item: unknown): item is ParameterReference 
 export interface ParserRule extends AstNode {
     readonly $container: Grammar;
     alternatives: AbstractElement
+    dataType: PrimitiveType
     definesHiddenTokens: boolean
     entry: boolean
     fragment: boolean
     hiddenTokens: Array<Reference<AbstractRule>>
-    infers: boolean
+    inferredType: InferredType
     name: string
     parameters: Array<Parameter>
-    type?: ReturnType
+    returnType?: Reference<AbstractType>
     wildcard: boolean
 }
 
@@ -320,7 +332,7 @@ export function isRegexToken(item: unknown): item is RegexToken {
 }
 
 export interface ReturnType extends AstNode {
-    readonly $container: ParserRule | TerminalRule;
+    readonly $container: TerminalRule;
     name: PrimitiveType | string
 }
 
@@ -449,14 +461,14 @@ export function isWildcard(item: unknown): item is Wildcard {
     return reflection.isInstance(item, Wildcard);
 }
 
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
+export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'InferredType' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 
-export type LangiumGrammarAstReference = 'AtomType:refType' | 'CrossReference:type' | 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
+export type LangiumGrammarAstReference = 'Action:type' | 'AtomType:refType' | 'CrossReference:type' | 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'ParserRule:returnType' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'Assignment', 'AtomType', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'Grammar', 'GrammarImport', 'Group', 'Interface', 'Keyword', 'LiteralCondition', 'NamedArgument', 'NegatedToken', 'Negation', 'Parameter', 'ParameterReference', 'ParserRule', 'RegexToken', 'ReturnType', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'UnorderedGroup', 'UntilToken', 'Wildcard'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'Assignment', 'AtomType', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'Grammar', 'GrammarImport', 'Group', 'InferredType', 'Interface', 'Keyword', 'LiteralCondition', 'NamedArgument', 'NegatedToken', 'Negation', 'Parameter', 'ParameterReference', 'ParserRule', 'RegexToken', 'ReturnType', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'UnorderedGroup', 'UntilToken', 'Wildcard'];
     }
 
     isInstance(node: unknown, type: string): boolean {
@@ -513,6 +525,9 @@ export class LangiumGrammarAstReflection implements AstReflection {
 
     getReferenceType(referenceId: LangiumGrammarAstReference): string {
         switch (referenceId) {
+            case 'Action:type': {
+                return AbstractType;
+            }
             case 'AtomType:refType': {
                 return AbstractType;
             }
@@ -536,6 +551,9 @@ export class LangiumGrammarAstReflection implements AstReflection {
             }
             case 'ParserRule:hiddenTokens': {
                 return AbstractRule;
+            }
+            case 'ParserRule:returnType': {
+                return AbstractType;
             }
             case 'RuleCall:rule': {
                 return AbstractRule;

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -553,10 +553,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PrimitiveType",
       "hiddenTokens": [],
-      "type": {
-        "$type": "ReturnType",
-        "name": "string"
-      },
+      "dataType": "string",
       "alternatives": {
         "$type": "Alternatives",
         "elements": [
@@ -625,38 +622,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "cardinality": "?"
           }
         ]
-      }
-    },
-    {
-      "$type": "ParserRule",
-      "parameters": [],
-      "name": "ReturnType",
-      "hiddenTokens": [],
-      "alternatives": {
-        "$type": "Assignment",
-        "feature": "name",
-        "operator": "=",
-        "terminal": {
-          "$type": "Alternatives",
-          "elements": [
-            {
-              "$type": "RuleCall",
-              "arguments": [],
-              "rule": {
-                "$refText": "PrimitiveType"
-              },
-              "elements": []
-            },
-            {
-              "$type": "RuleCall",
-              "arguments": [],
-              "rule": {
-                "$refText": "ID"
-              }
-            }
-          ]
-        },
-        "elements": []
       }
     },
     {
@@ -782,45 +747,63 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "elements": []
                   },
                   {
-                    "$type": "Assignment",
-                    "feature": "type",
-                    "operator": "=",
-                    "terminal": {
-                      "$type": "RuleCall",
-                      "arguments": [],
-                      "rule": {
-                        "$refText": "ReturnType"
+                    "$type": "Alternatives",
+                    "elements": [
+                      {
+                        "$type": "Assignment",
+                        "feature": "returnType",
+                        "operator": "=",
+                        "terminal": {
+                          "$type": "CrossReference",
+                          "type": {
+                            "$refText": "AbstractType"
+                          },
+                          "terminal": {
+                            "$type": "RuleCall",
+                            "arguments": [],
+                            "rule": {
+                              "$refText": "ID"
+                            }
+                          }
+                        },
+                        "elements": []
+                      },
+                      {
+                        "$type": "Assignment",
+                        "feature": "dataType",
+                        "operator": "=",
+                        "terminal": {
+                          "$type": "RuleCall",
+                          "arguments": [],
+                          "rule": {
+                            "$refText": "PrimitiveType"
+                          }
+                        },
+                        "elements": []
                       }
-                    }
+                    ]
                   }
                 ]
               },
               {
-                "$type": "Group",
-                "elements": [
-                  {
-                    "$type": "Assignment",
-                    "feature": "infers",
-                    "operator": "?=",
-                    "terminal": {
-                      "$type": "Keyword",
-                      "value": "infers"
-                    },
-                    "elements": []
-                  },
-                  {
-                    "$type": "Assignment",
-                    "feature": "type",
-                    "operator": "=",
-                    "terminal": {
-                      "$type": "RuleCall",
-                      "arguments": [],
-                      "rule": {
-                        "$refText": "ReturnType"
+                "$type": "Assignment",
+                "feature": "inferredType",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [
+                    {
+                      "$type": "NamedArgument",
+                      "value": {
+                        "$type": "LiteralCondition"
                       }
                     }
+                  ],
+                  "rule": {
+                    "$refText": "InferredType"
                   }
-                ]
+                },
+                "elements": []
               }
             ],
             "cardinality": "?"
@@ -922,6 +905,72 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "Keyword",
             "value": ";"
+          }
+        ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [
+        {
+          "$type": "Parameter",
+          "name": "imperative"
+        }
+      ],
+      "name": "InferredType",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Alternatives",
+            "elements": [
+              {
+                "$type": "Group",
+                "guardCondition": {
+                  "$type": "ParameterReference",
+                  "parameter": {
+                    "$refText": "imperative"
+                  }
+                },
+                "elements": [
+                  {
+                    "$type": "Keyword",
+                    "value": "infer"
+                  }
+                ]
+              },
+              {
+                "$type": "Group",
+                "guardCondition": {
+                  "$type": "Negation",
+                  "value": {
+                    "$type": "ParameterReference",
+                    "parameter": {
+                      "$refText": "imperative"
+                    }
+                  }
+                },
+                "elements": [
+                  {
+                    "$type": "Keyword",
+                    "value": "infers"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "$type": "Assignment",
+            "feature": "name",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            }
           }
         ]
       }
@@ -1032,9 +1081,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Alternatives",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1053,8 +1101,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "Alternatives",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "Alternatives"
+                },
                 "feature": "elements",
                 "operator": "+=",
                 "elements": []
@@ -1093,9 +1143,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ConditionalBranch",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1114,8 +1163,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "Group",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "Group"
+                },
                 "elements": []
               },
               {
@@ -1162,9 +1213,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "UnorderedGroup",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1183,8 +1233,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "UnorderedGroup",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "UnorderedGroup"
+                },
                 "feature": "elements",
                 "operator": "+=",
                 "elements": []
@@ -1223,9 +1275,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Group",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1244,8 +1295,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "Group",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "Group"
+                },
                 "feature": "elements",
                 "operator": "+=",
                 "elements": []
@@ -1274,9 +1327,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AbstractToken",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1306,9 +1358,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AbstractTokenWithCardinality",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1367,9 +1418,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Action",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1377,8 +1427,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "Action",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "Action"
+            },
             "elements": []
           },
           {
@@ -1386,26 +1438,49 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "value": "{"
           },
           {
-            "$type": "Assignment",
-            "feature": "infer",
-            "operator": "?=",
-            "terminal": {
-              "$type": "Keyword",
-              "value": "infer"
-            },
-            "cardinality": "?"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "type",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "arguments": [],
-              "rule": {
-                "$refText": "ID"
+            "$type": "Alternatives",
+            "elements": [
+              {
+                "$type": "Assignment",
+                "feature": "type",
+                "operator": "=",
+                "terminal": {
+                  "$type": "CrossReference",
+                  "type": {
+                    "$refText": "AbstractType"
+                  },
+                  "terminal": {
+                    "$type": "RuleCall",
+                    "arguments": [],
+                    "rule": {
+                      "$refText": "ID"
+                    }
+                  }
+                },
+                "elements": []
+              },
+              {
+                "$type": "Assignment",
+                "feature": "inferredType",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "arguments": [
+                    {
+                      "$type": "NamedArgument",
+                      "value": {
+                        "$type": "LiteralCondition",
+                        "true": true
+                      }
+                    }
+                  ],
+                  "rule": {
+                    "$refText": "InferredType"
+                  }
+                },
+                "elements": []
               }
-            }
+            ]
           },
           {
             "$type": "Group",
@@ -1465,9 +1540,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AbstractTerminal",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -1712,9 +1786,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Disjunction",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Condition"
       },
       "alternatives": {
@@ -1733,8 +1806,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "Disjunction",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "Disjunction"
+                },
                 "feature": "left",
                 "operator": "=",
                 "elements": []
@@ -1766,9 +1841,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Conjunction",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Condition"
       },
       "alternatives": {
@@ -1787,8 +1861,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "Conjunction",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "Conjunction"
+                },
                 "feature": "left",
                 "operator": "=",
                 "elements": []
@@ -1820,9 +1896,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Negation",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Condition"
       },
       "alternatives": {
@@ -1841,8 +1916,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "Negation",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "Negation"
+                },
                 "elements": []
               },
               {
@@ -1871,9 +1948,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Atom",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Condition"
       },
       "alternatives": {
@@ -1911,9 +1987,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedCondition",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Condition"
       },
       "alternatives": {
@@ -1968,9 +2043,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PredicatedKeyword",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Keyword"
       },
       "alternatives": {
@@ -2021,9 +2095,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PredicatedRuleCall",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "RuleCall"
       },
       "alternatives": {
@@ -2130,9 +2203,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Assignment",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2140,8 +2212,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "Assignment",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "Assignment"
+            },
             "elements": []
           },
           {
@@ -2225,9 +2299,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AssignableTerminal",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2273,9 +2346,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedAssignableElement",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2305,9 +2377,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "AssignableAlternatives",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2326,8 +2397,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "Alternatives",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "Alternatives"
+                },
                 "feature": "elements",
                 "operator": "+=",
                 "elements": []
@@ -2366,9 +2439,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "CrossReference",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2376,8 +2448,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "CrossReference",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "CrossReference"
+            },
             "elements": []
           },
           {
@@ -2445,9 +2519,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "CrossReferenceableTerminal",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2477,9 +2550,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedElement",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2509,9 +2581,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "PredicatedGroup",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "Group"
       },
       "alternatives": {
@@ -2563,6 +2634,38 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "value": ")"
           }
         ]
+      }
+    },
+    {
+      "$type": "ParserRule",
+      "parameters": [],
+      "name": "ReturnType",
+      "hiddenTokens": [],
+      "alternatives": {
+        "$type": "Assignment",
+        "feature": "name",
+        "operator": "=",
+        "terminal": {
+          "$type": "Alternatives",
+          "elements": [
+            {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "PrimitiveType"
+              },
+              "elements": []
+            },
+            {
+              "$type": "RuleCall",
+              "arguments": [],
+              "rule": {
+                "$refText": "ID"
+              }
+            }
+          ]
+        },
+        "elements": []
       }
     },
     {
@@ -2702,9 +2805,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalAlternatives",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2723,8 +2825,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "TerminalAlternatives",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "TerminalAlternatives"
+                },
                 "feature": "elements",
                 "operator": "+=",
                 "elements": []
@@ -2756,9 +2860,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalGroup",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2777,8 +2880,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "elements": [
               {
                 "$type": "Action",
-                "infer": true,
-                "type": "TerminalGroup",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "TerminalGroup"
+                },
                 "feature": "elements",
                 "operator": "+=",
                 "elements": []
@@ -2807,9 +2912,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalToken",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2855,9 +2959,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalTokenElement",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2927,9 +3030,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "ParenthesizedTerminalElement",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2959,9 +3061,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "TerminalRuleCall",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -2969,8 +3070,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "TerminalRuleCall",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "TerminalRuleCall"
+            },
             "elements": []
           },
           {
@@ -2999,9 +3102,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "NegatedToken",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -3009,8 +3111,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "NegatedToken",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "NegatedToken"
+            },
             "elements": []
           },
           {
@@ -3037,9 +3141,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "UntilToken",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -3047,8 +3150,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "UntilToken",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "UntilToken"
+            },
             "elements": []
           },
           {
@@ -3075,9 +3180,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "RegexToken",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -3085,8 +3189,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "RegexToken",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "RegexToken"
+            },
             "elements": []
           },
           {
@@ -3109,9 +3215,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "Wildcard",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -3119,8 +3224,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "Wildcard",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "Wildcard"
+            },
             "elements": []
           },
           {
@@ -3135,9 +3242,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "CharacterRange",
       "hiddenTokens": [],
-      "infers": true,
-      "type": {
-        "$type": "ReturnType",
+      "inferredType": {
+        "$type": "InferredType",
         "name": "AbstractElement"
       },
       "alternatives": {
@@ -3145,8 +3251,10 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "elements": [
           {
             "$type": "Action",
-            "infer": true,
-            "type": "CharacterRange",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "CharacterRange"
+            },
             "elements": []
           },
           {
@@ -3192,10 +3300,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "parameters": [],
       "name": "FeatureName",
       "hiddenTokens": [],
-      "type": {
-        "$type": "ReturnType",
-        "name": "string"
-      },
+      "dataType": "string",
       "alternatives": {
         "$type": "Alternatives",
         "elements": [

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -248,12 +248,12 @@ export class LangiumGrammarValidator {
         }
         for (const rule of grammar.rules.filter(ast.isParserRule)) {
             const isDataType = isDataTypeRule(rule);
-            const isInfers = !!rule.inferredType;
+            const isInfers = !rule.returnType && !rule.dataType;
             const ruleTypeName = getTypeName(rule);
             if (!isDataType && ruleTypeName && types.has(ruleTypeName) === isInfers) {
                 const keywordNode = isInfers ? findKeywordNode(rule.$cstNode, 'infer') : findKeywordNode(rule.$cstNode, 'returns');
                 accept('error', getMessage(ruleTypeName, isInfers), {
-                    node: rule.inferredType,
+                    node: rule.inferredType ?? rule,
                     property: 'name',
                     code: isInfers ? IssueCodes.InvalidInfers : IssueCodes.InvalidReturns,
                     data: keywordNode && toDocumentSegment(keywordNode)

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -41,19 +41,20 @@ type AbstractType = Interface | Type | Action | ParserRule;
 Type:
     'type' name=ID '=' TypeAlternatives ';'?;
 
-ReturnType:
-    name=(PrimitiveType | ID);
-
 AbstractRule: ParserRule | TerminalRule;
 
 GrammarImport:
     'import' path=STRING ';'?;
 
 ParserRule:
-    (entry?='entry' | fragment?='fragment')? RuleNameAndParams (wildcard?='*' | 'returns' type=ReturnType | infers?='infers' type=ReturnType)?
+    (entry?='entry' | fragment?='fragment')?
+    RuleNameAndParams
+    (wildcard?='*' | ('returns' (returnType=[AbstractType:ID] | dataType=PrimitiveType)) | inferredType=InferredType<false>)?
     (definesHiddenTokens?='hidden' '(' (hiddenTokens+=[AbstractRule:ID] (',' hiddenTokens+=[AbstractRule:ID])*)? ')')? ':'
-        alternatives=Alternatives
-    ';';
+    alternatives=Alternatives ';';
+
+InferredType<imperative>:
+    (<imperative> 'infer' | <!imperative> 'infers') name=ID;
 
 fragment RuleNameAndParams:
     name=ID ('<' (parameters+=Parameter (',' parameters+=Parameter)*)? '>')?;
@@ -83,8 +84,8 @@ AbstractTokenWithCardinality infers AbstractElement:
     (Assignment | AbstractTerminal) cardinality=('?'|'*'|'+')?;
 
 Action infers AbstractElement:
-    {infer Action} '{' infer?='infer'? type=ID ('.' feature=FeatureName operator=('='|'+=') 'current')? '}';
-
+    {infer Action} '{' (type=[AbstractType:ID] | inferredType=InferredType<true>) ('.' feature=FeatureName operator=('='|'+=') 'current')? '}';
+    
 AbstractTerminal infers AbstractElement:
     Keyword |
     RuleCall |
@@ -153,6 +154,9 @@ ParenthesizedElement infers AbstractElement:
 
 PredicatedGroup infers Group:
     (predicated?='=>' | firstSetPredicated?='->') '(' elements+=Alternatives ')';
+
+ReturnType:
+    name=(PrimitiveType | ID);
 
 TerminalRule:
     hidden?='hidden'? 'terminal' (fragment?='fragment' name=ID | name=ID ('returns' type=ReturnType)?) ':'

--- a/packages/langium/src/grammar/type-system/declared-types.ts
+++ b/packages/langium/src/grammar/type-system/declared-types.ts
@@ -22,7 +22,7 @@ export function collectDeclaredTypes(interfaces: Interface[], types: Type[], inf
     const declaredTypes: AstTypes = { unions: [], interfaces: [] };
     // add interfaces
     for (const interfaceType of interfaces) {
-        const superTypes = interfaceType.superTypes.map(e => getTypeName(e.ref));
+        const superTypes = interfaceType.superTypes.filter(e => e.ref).map(e => getTypeName(e.ref!));
         const properties: Property[] = interfaceType.attributes.map(e => <Property>{
             name: e.name,
             optional: e.isOptional === true,
@@ -40,7 +40,7 @@ export function collectDeclaredTypes(interfaces: Interface[], types: Type[], inf
 
         if (reflection) {
             for (const maybeRef of type.typeAlternatives) {
-                if (maybeRef.refType) {
+                if (maybeRef.refType?.ref) {
                     childToSuper.add(getTypeName(maybeRef.refType.ref), type.name);
                 }
             }

--- a/packages/langium/src/grammar/type-system/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/inferred-types.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { getRuleType, getTypeName, isOptional } from '../grammar-util';
+import { getExplicitRuleType, getRuleType, getTypeName, isOptional } from '../grammar-util';
 import { AbstractElement, Action, Alternatives, Assignment, Group, isAction, isAlternatives, isAssignment, isCrossReference, isGroup, isKeyword, isParserRule, isRuleCall, isUnorderedGroup, ParserRule, RuleCall, UnorderedGroup } from '../generated/ast';
 import { stream } from '../../utils/stream';
 import { AstTypes, distictAndSorted, Property, PropertyType, InterfaceType, UnionType } from './types-util';
@@ -187,7 +187,7 @@ export function collectInferredTypes(parserRules: ParserRule[], datatypeRules: P
     for (const rule of datatypeRules) {
         const types = isAlternatives(rule.alternatives) && rule.alternatives.elements.every(e => isKeyword(e)) ?
             stream(rule.alternatives.elements).filter(isKeyword).map(e => `'${e.value}'`).toArray().sort() :
-            [rule.type?.name ?? 'string'];
+            [getExplicitRuleType(rule) ?? 'string'];
         inferredTypes.unions.push(new UnionType(rule.name, [<PropertyType>{ types, reference: false, array: false }]));
     }
     return inferredTypes;
@@ -275,7 +275,7 @@ function collectElement(graph: TypeGraph, current: TypePart, element: AbstractEl
 }
 
 function addAction(graph: TypeGraph, parent: TypePart, action: Action): TypePart {
-    const typeNode = graph.connect(parent, newTypePart(action.type));
+    const typeNode = graph.connect(parent, newTypePart(action.inferredType?.name));
 
     if (action.feature && action.operator) {
         typeNode.actionWithAssignment = true;

--- a/packages/langium/src/grammar/type-system/type-validator.ts
+++ b/packages/langium/src/grammar/type-system/type-validator.ts
@@ -19,7 +19,7 @@ export function validateTypesConsistency(grammar: Grammar, accept: ValidationAcc
         return (errorMessage: string) => {
             nodes.forEach(node => accept('error',
                 errorMessage + ` in a rule that returns type '${typeName}'.`,
-                { node: node?.type ? node.type : node, property: 'name' }
+                { node: node?.inferredType ? node.inferredType : node, property: 'name' }
             ));
         };
     }
@@ -38,7 +38,7 @@ export function validateTypesConsistency(grammar: Grammar, accept: ValidationAcc
         } else {
             const specificError = `Inferred and declared versions of type ${typeName} have to be types or interfaces both.`;
             typeInfo.nodes.forEach(node => accept('error', specificError,
-                { node: node?.type ? node.type : node, property: 'name' }
+                { node: node?.inferredType ? node.inferredType : node, property: 'name' }
             ));
             accept('error', specificError,
                 { node: typeInfo.node, property: 'name' }

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -7,10 +7,11 @@
 import { URI } from 'vscode-uri';
 import { CompositeGeneratorNode, IndentNode, NL } from '../../generator/generator-node';
 import { processGeneratorNode } from '../../generator/node-processor';
-import { Grammar, Interface, isParserRule, ParserRule, Type } from '../generated/ast';
-import { isDataTypeRule, resolveImport } from '../grammar-util';
+import { CstNode } from '../../syntax-tree';
 import { getDocument } from '../../utils/ast-util';
 import { LangiumDocuments } from '../../workspace/documents';
+import { Grammar, Interface, isParserRule, ParserRule, Type } from '../generated/ast';
+import { isDataTypeRule, resolveImport } from '../grammar-util';
 
 export type Property = {
     name: string,
@@ -86,7 +87,16 @@ export class InterfaceType {
         return processGeneratorNode(interfaceNode);
     }
 }
+export class TypeResolutionError extends Error {
+    readonly target: CstNode | undefined;
 
+    constructor(message: string, target: CstNode | undefined) {
+        super(message);
+        this.name = 'TypeResolutionError';
+        this.target = target;
+    }
+
+}
 export type AstResources = {
     parserRules: Set<ParserRule>,
     datatypeRules: Set<ParserRule>,

--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -254,7 +254,8 @@ function getGuardCondition(element: AbstractElement): Condition | undefined {
 }
 
 function buildAction(ctx: RuleContext, action: Action): Method {
-    return () => ctx.parser.action(action.type, action);
+    const actionType = getTypeName(action);
+    return () => ctx.parser.action(actionType, action);
 }
 
 function buildCrossReference(ctx: RuleContext, crossRef: CrossReference, terminal = crossRef.terminal): Method {

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -6,6 +6,7 @@
 
 import { AbstractElement, AbstractRule, isCrossReference, isRuleCall } from '../grammar/generated/ast';
 import { getCrossReferenceTerminal } from '../grammar/grammar-util';
+import { getRuleType } from '../grammar/grammar-util';
 import { CstNode } from '../syntax-tree';
 
 /**
@@ -45,7 +46,7 @@ export class DefaultValueConverter implements ValueConverter {
             case 'ID': return convertID(input);
             case 'REGEXLITERAL': return convertString(input);
         }
-        switch (rule.type?.name?.toLowerCase()) {
+        switch (getRuleType(rule)?.toLowerCase()) {
             case 'number': return convertNumber(input);
             case 'boolean': return convertBoolean(input);
             default: return input;

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -118,16 +118,6 @@ export interface CstNode extends DocumentSegment {
 }
 
 /**
- * Text range for the CST.
- */
-export interface CstRange {
-    /** Start offset in the document text */
-    start: number;
-    /** End offset (exclusive) in the document text */
-    end: number;
-}
-
-/**
  * A composite CST node has children, but no directly associated token.
  */
 export interface CompositeCstNode extends CstNode {

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -13,7 +13,7 @@ import { isOperationCancelled, MaybePromise } from '../utils/promise-util';
 export type DiagnosticInfo<N extends AstNode, P = Properties<N>> = {
     /** The AST node to which the diagnostic is attached. */
     node: N,
-    /** If a property name is given, the diagnostic is resticted to the corresponding text region. */
+    /** If a property name is given, the diagnostic is restricted to the corresponding text region. */
     property?: P,
     /** In case of a multi-value property (array), an index can be given to select a specific element. */
     index?: number,
@@ -69,7 +69,10 @@ export class ValidationRegistry {
                 }
                 console.error('An error occurred during validation:', err);
                 const message = err instanceof Error ? err.message : String(err);
-                accept('error', 'An error occurred during validation: ' + message, { node });
+                if(err instanceof Error && err.stack) {
+                    console.error(err.stack);
+                }
+                accept('error', 'An error occurred during validation: ' + message, {node});
             }
         };
     }

--- a/packages/langium/test/grammar/type-system/inferred-types.spec.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.spec.ts
@@ -221,17 +221,17 @@ describeTypes('inferred types using chained actions', `
 	D: E ({infer D.e=current} d=ID)?;
     E: e=ID;
     F: value=ID ({infer F.item=current} value=ID)*;
-    G: ({X} x=ID | {Y} y=ID | {Z} z=ID) {infer G.front=current} back=ID;
+    G: ({infer X} x=ID | {infer Y} y=ID | {infer Z} z=ID) {infer G.front=current} back=ID;
 
     Entry:
 	    Expr;
     Expr:
-        {Ref} ref=ID
-        ({Access.receiver=current} '.' member=ID)*;
+        {infer Ref} ref=ID
+        ({infer Access.receiver=current} '.' member=ID)*;
     Ref:
-        {Ref} ref=ID;
+        {infer Ref} ref=ID;
     Access:
-        {Access} '.' member=ID;
+        {infer Access} '.' member=ID;
 
     terminal ID returns string: /string/;
 `, types => {

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -44,7 +44,7 @@ describe('tokenBuilder#longerAlts', () => {
     beforeAll(async () => {
         const text = `
         grammar test
-        Main: {Main} 'A' 'AB' 'ABC';
+        Main: {infer Main} 'A' 'AB' 'ABC';
         terminal AB: /ABD?/;
         `;
         const grammar = (await helper(text)).parseResult.value;


### PR DESCRIPTION
Grammar changes as described in #440
- tests are passing
- generator generates same result as before the change



