### PR TITLE
Hover provider for crossrefs

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -8,13 +8,13 @@ import { Connection, TextDocuments } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Module } from './dependency-injection';
 import { createGrammarConfig } from './grammar/grammar-config';
+import { MultilineCommentHoverProvider } from './lsp';
 import { DefaultCompletionProvider } from './lsp/completion/completion-provider';
 import { RuleInterpreter } from './lsp/completion/rule-interpreter';
 import { DefaultDocumentHighlighter } from './lsp/document-highlighter';
 import { DefaultDocumentSymbolProvider } from './lsp/document-symbol-provider';
 import { DefaultFoldingRangeProvider } from './lsp/folding-range-provider';
 import { DefaultGoToResolverProvider } from './lsp/goto';
-import { LangiumGrammarHoverProvider } from './lsp/langium-grammar-hover-provider';
 import { DefaultReferenceFinder } from './lsp/reference-finder';
 import { DefaultRenameHandler } from './lsp/rename-refactoring';
 import { createLangiumParser } from './parser/langium-parser-builder';
@@ -62,7 +62,7 @@ export function createDefaultModule(context: DefaultModuleContext): Module<Langi
                 RuleInterpreter: () => new RuleInterpreter()
             },
             DocumentSymbolProvider: (services) => new DefaultDocumentSymbolProvider(services),
-            HoverProvider: (services) => new LangiumGrammarHoverProvider(services),
+            HoverProvider: (services) => new MultilineCommentHoverProvider(services),
             FoldingRangeProvider: (services) => new DefaultFoldingRangeProvider(services),
             ReferenceFinder: (services) => new DefaultReferenceFinder(services),
             GoToResolver: (services) => new DefaultGoToResolverProvider(services),

--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -14,7 +14,7 @@ import { DefaultDocumentHighlighter } from './lsp/document-highlighter';
 import { DefaultDocumentSymbolProvider } from './lsp/document-symbol-provider';
 import { DefaultFoldingRangeProvider } from './lsp/folding-range-provider';
 import { DefaultGoToResolverProvider } from './lsp/goto';
-import { MultilineCommentHoverProvider } from './lsp/hover-provider';
+import { LangiumGrammarHoverProvider } from './lsp/langium-grammar-hover-provider';
 import { DefaultReferenceFinder } from './lsp/reference-finder';
 import { DefaultRenameHandler } from './lsp/rename-refactoring';
 import { createLangiumParser } from './parser/langium-parser-builder';
@@ -62,7 +62,7 @@ export function createDefaultModule(context: DefaultModuleContext): Module<Langi
                 RuleInterpreter: () => new RuleInterpreter()
             },
             DocumentSymbolProvider: (services) => new DefaultDocumentSymbolProvider(services),
-            HoverProvider: (services) => new MultilineCommentHoverProvider(services),
+            HoverProvider: (services) => new LangiumGrammarHoverProvider(services),
             FoldingRangeProvider: (services) => new DefaultFoldingRangeProvider(services),
             ReferenceFinder: (services) => new DefaultReferenceFinder(services),
             GoToResolver: (services) => new DefaultGoToResolverProvider(services),

--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -6,7 +6,6 @@
 
 import { createDefaultModule, createDefaultSharedModule, DefaultSharedModuleContext } from '../default-module';
 import { inject, Module } from '../dependency-injection';
-import { LangiumGrammarHoverProvider } from '../lsp/langium-grammar-hover-provider';
 import { LangiumServices, LangiumSharedServices, PartialLangiumServices } from '../services';
 import { LangiumGrammarGeneratedModule, LangiumGrammarGeneratedSharedModule } from './generated/module';
 import { LangiumGrammarCodeActionProvider } from './langium-grammar-code-actions';
@@ -14,6 +13,7 @@ import { LangiumGrammarScopeComputation, LangiumScopeProvider } from './langium-
 import { LangiumGrammarSemanticTokenProvider } from './langium-grammar-semantic-token-provider';
 import { LangiumGrammarValidationRegistry, LangiumGrammarValidator } from './langium-grammar-validator';
 import { LangiumGrammarFoldingRangeProvider } from './lsp/langium-grammar-folding-range-provider';
+import { LangiumGrammarHoverProvider } from './lsp/langium-grammar-hover-provider';
 
 export type LangiumGrammarAddedServices = {
     validation: {

--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -6,6 +6,7 @@
 
 import { createDefaultModule, createDefaultSharedModule, DefaultSharedModuleContext } from '../default-module';
 import { inject, Module } from '../dependency-injection';
+import { LangiumGrammarHoverProvider } from '../lsp/langium-grammar-hover-provider';
 import { LangiumServices, LangiumSharedServices, PartialLangiumServices } from '../services';
 import { LangiumGrammarGeneratedModule, LangiumGrammarGeneratedSharedModule } from './generated/module';
 import { LangiumGrammarCodeActionProvider } from './langium-grammar-code-actions';
@@ -30,7 +31,8 @@ export const LangiumGrammarModule: Module<LangiumGrammarServices, PartialLangium
     lsp: {
         FoldingRangeProvider: (services) => new LangiumGrammarFoldingRangeProvider(services),
         CodeActionProvider: () => new LangiumGrammarCodeActionProvider(),
-        SemanticTokenProvider: () => new LangiumGrammarSemanticTokenProvider()
+        SemanticTokenProvider: () => new LangiumGrammarSemanticTokenProvider(),
+        HoverProvider: (services) => new LangiumGrammarHoverProvider(services)
     },
     references: {
         ScopeComputation: (services) => new LangiumGrammarScopeComputation(services),

--- a/packages/langium/src/grammar/lsp/langium-grammar-hover-provider.ts
+++ b/packages/langium/src/grammar/lsp/langium-grammar-hover-provider.ts
@@ -4,10 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 import { Hover, HoverParams } from 'vscode-languageserver';
-import {CrossReference, findLeafNodeAtOffset, findNameAssignment, findRelevantNode, Grammar, isCrossReference, isKeyword, isParserRule, isRuleCall, isType, LangiumDocument, LangiumDocuments, LangiumServices } from '..';
-import { AstNode } from '../syntax-tree';
-import { MaybePromise } from '../utils/promise-util';
-import { MultilineCommentHoverProvider } from './hover-provider';
+import { AstNode } from '../../syntax-tree';
+import { MaybePromise } from '../../utils/promise-util';
+import { MultilineCommentHoverProvider } from '../../lsp/hover-provider';
+import { CrossReference, findLeafNodeAtOffset, findNameAssignment, findRelevantNode, Grammar, isCrossReference, isKeyword, isParserRule, isRuleCall, isType, LangiumDocument, LangiumDocuments, LangiumServices } from '../..';
 
 export class LangiumGrammarHoverProvider extends MultilineCommentHoverProvider {
 

--- a/packages/langium/src/lsp/langium-grammar-hover-provider.ts
+++ b/packages/langium/src/lsp/langium-grammar-hover-provider.ts
@@ -58,7 +58,7 @@ export class LangiumGrammarHoverProvider extends MultilineCommentHoverProvider {
                 const typeName = ref.name;
                 const terminal = node.terminal;
                 let terminalName = '';
-                if (terminal === undefined){
+                if (terminal === undefined) {
                     const terminalRule = findNameAssignment(ref);
                     if (terminalRule && isRuleCall(terminalRule.terminal)){
                         terminalName = terminalRule.terminal.rule.ref!.name;

--- a/packages/langium/src/lsp/langium-grammar-hover-provider.ts
+++ b/packages/langium/src/lsp/langium-grammar-hover-provider.ts
@@ -65,7 +65,7 @@ export class LangiumGrammarHoverProvider extends MultilineCommentHoverProvider {
                     }
                 } else if (isKeyword(terminal)) {
                     terminalName = terminal.value;
-                } else if (isRuleCall(terminal)){
+                } else if (isRuleCall(terminal)) {
                     terminalName = terminal.rule.ref!.name;
                 }
 

--- a/packages/langium/src/lsp/langium-grammar-hover-provider.ts
+++ b/packages/langium/src/lsp/langium-grammar-hover-provider.ts
@@ -72,7 +72,7 @@ export class LangiumGrammarHoverProvider extends MultilineCommentHoverProvider {
                 return {
                     contents: {
                         kind: 'markdown',
-                        value: `[${typeName}:${terminalName}]`
+                        value: '```\n' + `[${typeName}:${terminalName}]` + '\n```'
                     }
                 };
             }

--- a/packages/langium/src/lsp/langium-grammar-hover-provider.ts
+++ b/packages/langium/src/lsp/langium-grammar-hover-provider.ts
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+import { Hover, HoverParams } from 'vscode-languageserver';
+import {CrossReference, findLeafNodeAtOffset, findNameAssignment, Grammar, isCrossReference, isParserRule, isType, LangiumDocuments, LangiumServices, RuleCall } from '..';
+import { AstNode } from '../syntax-tree';
+import { findRelevantNode } from '../utils/cst-util';
+import { MaybePromise } from '../utils/promise-util';
+import { LangiumDocument } from '../workspace/documents';
+import { MultilineCommentHoverProvider } from './hover-provider';
+
+export class LangiumGrammarHoverProvider extends MultilineCommentHoverProvider {
+
+    readonly grammar: Grammar;
+    readonly documents: LangiumDocuments;
+    constructor(services: LangiumServices) {
+        super(services);
+        this.grammar = services.Grammar;
+        this.documents = services.shared.workspace.LangiumDocuments;
+    }
+
+    getHoverContent(document: LangiumDocument<AstNode>, params: HoverParams): MaybePromise<Hover | undefined> {
+        const rootNode = document.parseResult?.value?.$cstNode;
+        if(rootNode)  {
+            const offset = document.textDocument.offsetAt(params.position);
+            const cstNode = findLeafNodeAtOffset(rootNode, offset);
+            if(cstNode){
+                const relevantNode = findRelevantNode(cstNode);
+                if(isCrossReference(relevantNode)){
+                    return this.getCrossReferenceHoverContent(relevantNode);
+                } else {
+                    return super.getHoverContent(document, params);
+                }
+            }
+        }
+        return undefined;
+    }
+
+    getCrossReferenceHoverContent(node: CrossReference): MaybePromise<Hover | undefined> {
+
+        const ref = node.type.ref;
+
+        if(ref){
+            if(isType(ref)){
+                return {
+                    contents: {
+                        kind: 'markdown',
+                        value: ref.$cstNode!.text
+                    }
+                };
+            }
+            else if(isParserRule(ref)){
+                let terminal;
+                if(node.$cstNode?.text.includes(':')){
+                    terminal = node.$cstNode?.text.split(':')[1].replace(']', '');
+                } else {
+                    terminal = (findNameAssignment(ref)?.terminal as RuleCall).rule.$refText;
+                }
+
+                return {
+                    contents: {
+                        kind: 'markdown',
+                        value: `[${ref.name}:${terminal}]`,
+                    },
+                };
+            }
+        }
+
+        return undefined;
+    }
+
+}

--- a/packages/langium/src/lsp/langium-grammar-hover-provider.ts
+++ b/packages/langium/src/lsp/langium-grammar-hover-provider.ts
@@ -51,7 +51,7 @@ export class LangiumGrammarHoverProvider extends MultilineCommentHoverProvider {
                 return {
                     contents: {
                         kind: 'markdown',
-                        value: ref.$cstNode!.text
+                        value: '```\n' + ref.$cstNode!.text + '\n```'
                     }
                 };
             } else if (isParserRule(ref)) {


### PR DESCRIPTION
Solves part of #355 

Added hover behavior when hovering a cross-reference.

1. If the cross-reference references a type alternative, the hover content is the type alternative itself.
```
type T = A | B;

R : prop = [T];
```
Hovering over `[T]` displays `type T = A | B;
`

2. If the cross-reference refers to a parser rule and has an explicit terminal.
```
R: prop = [T:X];
```
Hovering over `[T:X]` displays `[T:X]`

3. If the cross-reference refers to a parser rule and has no explicit terminal
```
R: prop = [T]
```
Hovering over `[T]` displays `[T:X]` with `X` being the terminal associated with the property `name` in the rule T