### PR TITLE
Automatically add additional documents to LangiumDocuments

### DIFF
--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -249,7 +249,6 @@ export class DefaultLangiumDocuments implements LangiumDocuments {
         }
         const textDoc = this.textDocuments.get(uriString) ?? this.textDocumentFactory.fromUri(uri);
         langiumDoc = this.langiumDocumentFactory.fromTextDocument(textDoc, uri);
-        this.documentMap.set(uriString, langiumDoc);
         return langiumDoc;
     }
 

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -249,6 +249,7 @@ export class DefaultLangiumDocuments implements LangiumDocuments {
         }
         const textDoc = this.textDocuments.get(uriString) ?? this.textDocumentFactory.fromUri(uri);
         langiumDoc = this.langiumDocumentFactory.fromTextDocument(textDoc, uri);
+        this.documentMap.set(uriString, langiumDoc);
         return langiumDoc;
     }
 

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -49,7 +49,9 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
         const documents: LangiumDocument[] = [];
         const collector = (document: LangiumDocument) => {
             documents.push(document);
-            this.langiumDocuments.addDocument(document);
+            if (!this.langiumDocuments.hasDocument(document.uri)) {
+                this.langiumDocuments.addDocument(document);
+            }
         };
         await Promise.all(
             folders.map(wf => this.getRootFolder(wf))

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -47,7 +47,10 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
     async initializeWorkspace(folders: WorkspaceFolder[]): Promise<void> {
         const fileExtensions = this.serviceRegistry.all.flatMap(e => e.LanguageMetaData.fileExtensions);
         const documents: LangiumDocument[] = [];
-        const collector = (document: LangiumDocument) => documents.push(document);
+        const collector = (document: LangiumDocument) => {
+            documents.push(document);
+            this.langiumDocuments.addDocument(document);
+        };
         await Promise.all(
             folders.map(wf => this.getRootFolder(wf))
                 .map(async rf => this.traverseFolder(rf, fileExtensions, collector))


### PR DESCRIPTION
Closes #465 

This is also a problem I encountered while working on a customer project.

With my use-case, it seems that it could be solved by delegating the responsibility to add documents to `LangiumDocuments` to the `collector` instead of the `getOrCreateDocument` method.

There are most likely parts that I overlooked, but we can start from there.