### PR TITLE
Upgraded TypeScript to latest version

### DIFF
--- a/examples/arithmetics/package.json
+++ b/examples/arithmetics/package.json
@@ -57,6 +57,6 @@
         "eslint": "^7.19.0",
         "eslint-plugin-header": "^3.1.1",
         "langium-cli": "0.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.6.2"
     }
 }

--- a/examples/domainmodel/package.json
+++ b/examples/domainmodel/package.json
@@ -59,7 +59,7 @@
         "eslint": "^7.19.0",
         "eslint-plugin-header": "^3.1.1",
         "langium-cli": "0.3.0",
-        "typescript": "^4.1.3",
+        "typescript": "^4.6.2",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3"
     }

--- a/examples/statemachine/package.json
+++ b/examples/statemachine/package.json
@@ -58,6 +58,6 @@
         "eslint": "^7.19.0",
         "eslint-plugin-header": "^3.1.1",
         "langium-cli": "0.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.6.2"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "eslint": "^7.19.0",
         "eslint-plugin-header": "^3.1.1",
         "langium-cli": "0.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -73,7 +73,7 @@
         "eslint-plugin-header": "^3.1.1",
         "jest": "^26.6.3",
         "langium-cli": "0.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -110,7 +110,7 @@
         "eslint": "^7.19.0",
         "eslint-plugin-header": "^3.1.1",
         "langium-cli": "0.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -9025,9 +9025,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -9663,7 +9663,7 @@
         "eslint": "^7.28.0",
         "eslint-plugin-header": "^3.1.1",
         "rimraf": "^3.0.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=12.10.0"
@@ -9688,7 +9688,7 @@
         "jest": "^26.6.3",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9719,7 +9719,7 @@
         "jest": "^26.6.3",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9760,7 +9760,7 @@
         "jest": "^26.6.3",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.2"
       }
     },
     "packages/langium-sprotty/node_modules/@types/jest": {
@@ -9791,7 +9791,7 @@
         "eslint": "^7.19.0",
         "eslint-plugin-header": "^3.1.1",
         "mocha": "^8.4.0",
-        "typescript": "^4.1.3",
+        "typescript": "^4.6.2",
         "vscode-test": "^1.5.0"
       },
       "engines": {
@@ -11367,7 +11367,7 @@
         "eslint-plugin-header": "^3.1.1",
         "langium": "0.3.0",
         "langium-cli": "0.3.0",
-        "typescript": "^4.1.3",
+        "typescript": "^4.6.2",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0"
       }
@@ -12395,7 +12395,7 @@
         "langium": "0.3.0",
         "langium-cli": "0.3.0",
         "lodash": "^4.17.21",
-        "typescript": "^4.1.3",
+        "typescript": "^4.6.2",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0"
       },
@@ -13307,7 +13307,7 @@
         "eslint-plugin-header": "^3.1.1",
         "lodash": "^4.17.21",
         "rimraf": "^3.0.2",
-        "typescript": "^4.2.2",
+        "typescript": "^4.6.2",
         "yeoman-generator": "^5.5.2"
       }
     },
@@ -14437,7 +14437,7 @@
         "jest": "^26.6.3",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
-        "typescript": "^4.2.2",
+        "typescript": "^4.6.2",
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-uri": "^3.0.2"
@@ -14474,7 +14474,7 @@
         "lodash": "^4.17.21",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@types/jest": {
@@ -14508,7 +14508,7 @@
         "rimraf": "^3.0.2",
         "sprotty-protocol": "^0.11.0",
         "ts-jest": "^26.5.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@types/jest": {
@@ -14536,7 +14536,7 @@
         "eslint-plugin-header": "^3.1.1",
         "langium": "0.3.0",
         "mocha": "^8.4.0",
-        "typescript": "^4.1.3",
+        "typescript": "^4.6.2",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0",
         "vscode-test": "^1.5.0"
@@ -16427,7 +16427,7 @@
         "langium": "0.3.0",
         "langium-cli": "0.3.0",
         "lodash": "^4.17.21",
-        "typescript": "^4.1.3",
+        "typescript": "^4.6.2",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0"
       }
@@ -16836,9 +16836,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "union-value": {

--- a/packages/generator-langium/langium-template/package.json
+++ b/packages/generator-langium/langium-template/package.json
@@ -58,6 +58,6 @@
         "@typescript-eslint/parser": "^4.14.1",
         "eslint": "^7.19.0",
         "langium-cli": "^0.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.6.2"
     }
 }

--- a/packages/generator-langium/package.json
+++ b/packages/generator-langium/package.json
@@ -45,7 +45,7 @@
     "eslint": "^7.28.0",
     "eslint-plugin-header": "^3.1.1",
     "rimraf": "^3.0.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/langium-cli/package.json
+++ b/packages/langium-cli/package.json
@@ -52,7 +52,7 @@
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/langium-sprotty/package.json
+++ b/packages/langium-sprotty/package.json
@@ -42,7 +42,7 @@
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -67,7 +67,7 @@
     "eslint": "^7.19.0",
     "eslint-plugin-header": "^3.1.1",
     "mocha": "^8.4.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.6.2",
     "vscode-test": "^1.5.0"
   },
   "repository": {

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -49,7 +49,7 @@
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/langium/src/utils/stream.ts
+++ b/packages/langium/src/utils/stream.ts
@@ -538,7 +538,7 @@ export class StreamImpl<S, T> implements Stream<T> {
         if (depth <= 0) {
             return this as unknown as FlatStream<T, D>;
         }
-        const stream = depth > 1 ? this.flat(depth - 1) as StreamImpl<S, unknown> : this;
+        const stream = depth > 1 ? this.flat(depth - 1) as unknown as StreamImpl<S, T> : this;
         type FlatMapState = { this: S, iterator?: Iterator<T, undefined> }
         return new StreamImpl<FlatMapState, T>(
             () => ({ this: stream.startFn() }),
@@ -557,7 +557,7 @@ export class StreamImpl<S, T> implements Stream<T> {
                         if (isIterable(value)) {
                             state.iterator = value[Symbol.iterator]() as Iterator<T>;
                         } else {
-                            return { done: false, value };
+                            return { done: false, value: value };
                         }
                     }
                 } while (state.iterator);


### PR DESCRIPTION
This PR fixes a compiler error with the latest TypeScript version 4.6.2. It occurs when a contributor opens Langium with the latest VS Code version.

In some places we used TS 4.1.3, in others we used TS 4.2.2. I have upgraded all versions to the latest (4.6.2):

* packages
* examples
* generator templates

@spoenemann / @msujew / @pluralia do you see any problems with upgrading the TS version in the generator template? This one might need to be thoroughly tested (e.g. in a fresh env using Gitpod). Thanks