### PR TITLE
Check parser rule `args` for `undefined`

### DIFF
--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -190,7 +190,7 @@ function buildPredicate(condition: Condition): Predicate {
         return (args) => !value(args);
     } else if (isParameterReference(condition)) {
         const name = condition.parameter.ref!.name;
-        return (args) => args[name] === true;
+        return (args) => args !== undefined && args[name] === true;
     } else if (isLiteralCondition(condition)) {
         const value = !!condition.true;
         return () => value;


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/480

During parser self analysis, the `args` will always be `undefined`. In this case the `ParameterReference` check returns with an error, which is caught by Chevrotain, stopping the self analysis for this rule. This however, leaves the parser in an invalid state and consequently results in parsing errors.