### PR TITLE
Verify type of 'name' property

### DIFF
--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -620,7 +620,7 @@ export class LangiumGrammarValidator {
 
     checkAssignmentWithFeatureName(assignment: ast.Assignment, accept: ValidationAcceptor): void {
         if(assignment.feature === 'name' && ast.isCrossReference(assignment.terminal)) {
-            accept('warning', 'We recommend not to use the "name" property for cross-references.', { node: assignment, property: 'feature' });
+            accept('warning', 'The "name" property is not recommended for cross-references.', { node: assignment, property: 'feature' });
         }
     }
 }

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -29,6 +29,7 @@ export class LangiumGrammarValidationRegistry extends ValidationRegistry {
         const validator = services.validation.LangiumGrammarValidator;
         const checks: LangiumGrammarChecks = {
             AbstractRule: validator.checkRuleName,
+            Assignment: validator.checkAssignmentWithFeatureName,
             ParserRule: [
                 validator.checkParserRuleDataType,
                 validator.checkRuleParametersUsed
@@ -615,6 +616,12 @@ export class LangiumGrammarValidator {
             }
         }
         return undefined;
+    }
+
+    checkAssignmentWithFeatureName(assignment: ast.Assignment, accept: ValidationAcceptor): void {
+        if(assignment.feature === 'name' && ast.isCrossReference(assignment.terminal)) {
+            accept('warning', 'We recommend not to use the "name" property for cross-references.', { node: assignment, property: 'feature' });
+        }
     }
 }
 

--- a/packages/langium/src/references/naming.ts
+++ b/packages/langium/src/references/naming.ts
@@ -12,8 +12,7 @@ export interface NamedAstNode extends AstNode {
 }
 
 export function isNamed(node: AstNode): node is NamedAstNode {
-    return (node as NamedAstNode).name !== undefined
-        && typeof (node as NamedAstNode).name === 'string';
+    return typeof (node as NamedAstNode).name === 'string';
 }
 
 /**

--- a/packages/langium/src/references/naming.ts
+++ b/packages/langium/src/references/naming.ts
@@ -13,7 +13,7 @@ export interface NamedAstNode extends AstNode {
 
 export function isNamed(node: AstNode): node is NamedAstNode {
     return (node as NamedAstNode).name !== undefined
-        && typeof (node as NamedAstNode).name === "string";
+        && typeof (node as NamedAstNode).name === 'string';
 }
 
 /**

--- a/packages/langium/src/references/naming.ts
+++ b/packages/langium/src/references/naming.ts
@@ -12,7 +12,8 @@ export interface NamedAstNode extends AstNode {
 }
 
 export function isNamed(node: AstNode): node is NamedAstNode {
-    return (node as NamedAstNode).name !== undefined;
+    return (node as NamedAstNode).name !== undefined
+        && typeof (node as NamedAstNode).name === "string";
 }
 
 /**

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -56,17 +56,6 @@ export function expectSymbols(services: LangiumServices, expectEqual: ExpectFunc
     };
 }
 
-export function expectRecursiveSerializationError(services: LangiumServices): (input: string) => Promise<void> {
-    return async input => {
-        const document = await parseDocument(services, input);
-        const symbolProvider = services.lsp.DocumentSymbolProvider;
-        const symbols = await symbolProvider.getSymbols(document, textDocumentParams(document));
-
-        const serialize = () => JSON.stringify(symbols);
-        expect(serialize).not.toThrowError(/Converting circular structure to JSON/);
-    };
-}
-
 export function expectFoldings(services: LangiumServices, expectEqual: ExpectFunction): (input: ExpectedBase) => Promise<void> {
     return async input => {
         const { output, ranges } = replaceIndices(input);

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -56,6 +56,17 @@ export function expectSymbols(services: LangiumServices, expectEqual: ExpectFunc
     };
 }
 
+export function expectRecursiveSerializationError(services: LangiumServices): (input: string) => Promise<void> {
+    return async input => {
+        const document = await parseDocument(services, input);
+        const symbolProvider = services.lsp.DocumentSymbolProvider;
+        const symbols = await symbolProvider.getSymbols(document, textDocumentParams(document));
+
+        const serialize = () => JSON.stringify(symbols);
+        expect(serialize).not.toThrowError(/Converting circular structure to JSON/);
+    };
+}
+
 export function expectFoldings(services: LangiumServices, expectEqual: ExpectFunction): (input: ExpectedBase) => Promise<void> {
     return async input => {
         const { output, ranges } = replaceIndices(input);

--- a/packages/langium/test/lsp/document-symbol.test.ts
+++ b/packages/langium/test/lsp/document-symbol.test.ts
@@ -6,7 +6,7 @@
 
 import { Position, Range, SymbolKind } from 'vscode-languageserver';
 import { createLangiumGrammarServices } from '../../src';
-import { expectRecursiveSerializationError, expectSymbols } from '../../src/test';
+import { expectSymbols } from '../../src/test';
 import { expectFunction } from '../fixture';
 
 const text = `
@@ -17,7 +17,6 @@ const text = `
 
 const grammarServices = createLangiumGrammarServices().grammar;
 const symbols = expectSymbols(grammarServices, expectFunction);
-const recursiveSerializationError = expectRecursiveSerializationError(grammarServices);
 
 describe('Document symbols', () => {
 
@@ -48,20 +47,5 @@ describe('Document symbols', () => {
             ]
         });
     });
-
-    test('Should not produce recursive symbol structure', async () => {
-        const input = `
-            grammar HelloWorld
-            entry Model:
-                (persons+=Person | greetings+=Greeting)*;
-            Person:
-                'person' name=ID;
-            Greeting:
-                'Hello' name=[Person] '!';
-            
-            hidden terminal WS: /\s+/;
-            terminal ID: /[_a-zA-Z][\w_]*/; 
-        `;
-        await recursiveSerializationError(input);
-    });
 });
+

--- a/packages/langium/test/lsp/document-symbol.test.ts
+++ b/packages/langium/test/lsp/document-symbol.test.ts
@@ -6,7 +6,7 @@
 
 import { Position, Range, SymbolKind } from 'vscode-languageserver';
 import { createLangiumGrammarServices } from '../../src';
-import { expectSymbols } from '../../src/test';
+import { expectRecursiveSerializationError, expectSymbols } from '../../src/test';
 import { expectFunction } from '../fixture';
 
 const text = `
@@ -17,6 +17,7 @@ const text = `
 
 const grammarServices = createLangiumGrammarServices().grammar;
 const symbols = expectSymbols(grammarServices, expectFunction);
+const recursiveSerializationError = expectRecursiveSerializationError(grammarServices);
 
 describe('Document symbols', () => {
 
@@ -46,5 +47,21 @@ describe('Document symbols', () => {
                 }
             ]
         });
+    });
+
+    test('Should not produce recursive symbol structure', async () => {
+        const input = `
+            grammar HelloWorld
+            entry Model:
+                (persons+=Person | greetings+=Greeting)*;
+            Person:
+                'person' name=ID;
+            Greeting:
+                'Hello' name=[Person] '!';
+            
+            hidden terminal WS: /\s+/;
+            terminal ID: /[_a-zA-Z][\w_]*/; 
+        `;
+        await recursiveSerializationError(input);
     });
 });

--- a/packages/langium/test/references/naming.test.ts
+++ b/packages/langium/test/references/naming.test.ts
@@ -1,0 +1,19 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { isNamed } from '../../src';
+
+describe('Naming Tests', () => {
+
+    // implemented to guard against issue #483, where a name bound to a cross-ref (non string) can crash the server
+    test('Verify named nodes must have a string type', async () => {
+        const testNode = {
+            $type: 'terminal',
+            name: {}
+        };
+        expect(isNamed(testNode)).toBeFalsy();
+    });
+});

--- a/packages/langium/test/references/naming.test.ts
+++ b/packages/langium/test/references/naming.test.ts
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright 2021 TypeFox GmbH
+ * Copyright 2022 TypeFox GmbH
  * This program and the accompanying materials are made available under the
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -53,7 +53,7 @@ describe('Checked Named CrossRefs', () => {
     grammar g
     A: 'a' name=ID;
     B: 'b' name=[A];
-    terminal ID: /[_a-zA-Z][\w_]*/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
     `.trim();
 
     let validationData: ValidatorData;

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -48,19 +48,13 @@ describe('checkReferenceToRuleButNotType', () => {
 
 });
 
-describe('Validate that cross-references are not named as "name"', () => {
+describe('Checked Named CrossRefs', () => {
     const grammar = `
-    grammar HelloWorld
-    entry Model:
-        (persons+=Person | greetings+=Greeting)*;
-    Person:
-        'person' name=ID;
-    Greeting:
-        'Hello' name=[Person] '!';
-    
-    hidden terminal WS: /\s+/;
+    grammar g
+    A: 'a' name=ID;
+    B: 'b' name=[A];
     terminal ID: /[_a-zA-Z][\w_]*/;
-    `;
+    `.trim();
 
     let validationData: ValidatorData;
 
@@ -69,7 +63,7 @@ describe('Validate that cross-references are not named as "name"', () => {
     });
 
     test('Named crossReference warning', () => {
-        expectWarning(validationData, 'We recommend not to use the "name" property for cross-references.');
+        expectWarning(validationData, 'The "name" property is not recommended for cross-references.');
     });
 });
 
@@ -88,27 +82,27 @@ async function parseAndValidate(grammar: string): Promise<ValidatorData> {
 }
 
 function expecting(severity: DiagnosticSeverity) {
-  return function(data: ValidatorData, msg: string, at?: string): void {
-    const found: { msg?: string; at?: string } = {};
-    for (const diagnostic of data.diagnostics.filter(d => d.severity === severity)) {
-        if (diagnostic.message === msg) {
-            found.msg = diagnostic.message;
-            if (at) {
-                const diagnosticMarkedText = data.document.textDocument.getText(diagnostic.range);
-                found.at = diagnosticMarkedText;
-                if (at === diagnosticMarkedText) {
+    return function(data: ValidatorData, msg: string, at?: string): void {
+        const found: { msg?: string; at?: string } = {};
+        for (const diagnostic of data.diagnostics.filter(d => d.severity === severity)) {
+            if (diagnostic.message === msg) {
+                found.msg = diagnostic.message;
+                if (at) {
+                    const diagnosticMarkedText = data.document.textDocument.getText(diagnostic.range);
+                    found.at = diagnosticMarkedText;
+                    if (at === diagnosticMarkedText) {
+                        return;
+                    }
+                } else {
                     return;
                 }
-            } else {
-                return;
             }
         }
-    }
-    expect(found.msg).toBe(msg);
-    if (at) {
-        expect(found.at).toBe(at);
-    }
-  }
+        expect(found.msg).toBe(msg);
+        if (at) {
+            expect(found.at).toBe(at);
+        }
+    };
 }
 
 const expectError = expecting(DiagnosticSeverity.Error);


### PR DESCRIPTION
This closes #483 by extending an existing check in the`isNamed` function of naming.ts. This verifies that the type of the name property on an **AstNode** is actually a string, as opposed to only checking if it's undefined or not. The check avoids misidentifying an AstNode containing a named cross ref as a regular named one (with a string). 

Before this fix, such an AstNode could sneak past into the underlying jsonrpc lib and would be stringified, producing a TypeError.

We also added a *warning* diagnostic about assigning cross refs to a 'name' property, as it's likely not what was intended.

Tests have been added to check both the behavior of the updated function and the new warning. For the later, we generalized `expectError` into `expecting`, allowing us to use the same function for different diagnostic values.

Both @Lotes and I were working on this, so please feel free to give some feedback for both of us!