### PR TITLE
Fix Type Validation w/ Optional Params

### DIFF
--- a/packages/langium/src/grammar/type-system/type-validator.ts
+++ b/packages/langium/src/grammar/type-system/type-validator.ts
@@ -174,7 +174,7 @@ function checkPropertiesConsistency(inferred: Property[], declared: Property[],
         !(found.typeAlternatives.length === 1 && found.typeAlternatives[0].array ||
             expected.typeAlternatives.length === 1 && expected.typeAlternatives[0].array);
 
-    // detects extra properties & check matched ones on consistency by 'opional'
+    // detects extra properties & check matched ones on consistency by 'optional'
     for (const foundProperty of inferred) {
         const expectedProperty = declared.find(e => foundProperty.name === e.name);
         if (expectedProperty) {
@@ -203,7 +203,7 @@ function checkPropertiesConsistency(inferred: Property[], declared: Property[],
     // detects lack of properties
     for (const foundProperty of declared) {
         const expectedProperty = inferred.find(e => foundProperty.name === e.name);
-        if (!expectedProperty) {
+        if (!expectedProperty && !foundProperty.optional) {
             errorToRuleNodes(`A property '${foundProperty.name}' is expected`);
         }
     }

--- a/packages/langium/src/grammar/type-system/type-validator.ts
+++ b/packages/langium/src/grammar/type-system/type-validator.ts
@@ -193,7 +193,7 @@ function checkPropertiesConsistency(inferred: Property[], declared: Property[],
             }
 
             if (checkOptional(foundProperty, expectedProperty) && !expectedProperty.optional && foundProperty.optional) {
-                errorToAssignment(foundProperty.name, `A property '${foundProperty.name}' can't be optional.`);
+                errorToRuleNodes(`A property '${foundProperty.name}' can't be optional`);
             }
         } else {
             errorToAssignment(foundProperty.name, `A property '${foundProperty.name}' is not expected.`);
@@ -201,10 +201,10 @@ function checkPropertiesConsistency(inferred: Property[], declared: Property[],
     }
 
     // detects lack of properties
-    for (const foundProperty of declared) {
-        const expectedProperty = inferred.find(e => foundProperty.name === e.name);
-        if (!expectedProperty && !foundProperty.optional) {
-            errorToRuleNodes(`A property '${foundProperty.name}' is expected`);
+    for (const expectedProperty of declared) {
+        const foundProperty = inferred.find(e => expectedProperty.name === e.name);
+        if (!foundProperty && !expectedProperty.optional) {
+            errorToRuleNodes(`A property '${expectedProperty.name}' is expected`);
         }
     }
 }

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -51,14 +51,10 @@ describe('validate params in types', () => {
         const document = await parseDocument(grammarServices, prog);
         let diagnostics: Diagnostic[] = await grammarServices.validation.DocumentValidator.validateDocument(document);
         diagnostics = diagnostics.filter(d => d.severity === DiagnosticSeverity.Error);
-        expect(diagnostics).toHaveLength(2);
+        expect(diagnostics).toHaveLength(1);
 
-        // verify the location of both errors, indicating the associated type for these rules requires a param
-        let d = diagnostics[0];
-        expect(d.range.start).toEqual({character: 8, line: 4});
-        expect(d.range.end).toEqual({character: 9, line: 4});
-
-        d = diagnostics[1];
+        // verify the location of the single diagnostic error, should be only for the 2nd rule
+        const d = diagnostics[0];
         expect(d.range.start).toEqual({character: 8, line: 5});
         expect(d.range.end).toEqual({character: 9, line: 5});
     });

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -35,7 +35,7 @@ describe('validate params in types', () => {
     });
 
     // verifies that missing required params use the right msg & position
-    test('verify that missing required param error, for multiple rules', async () => {
+    test('verify missing required param error is present for the correct rule', async () => {
         const prog = `
         interface A {
             name:string
@@ -56,7 +56,7 @@ describe('validate params in types', () => {
         // verify the location of the single diagnostic error, should be only for the 2nd rule
         const d = diagnostics[0];
         expect(d.range.start).toEqual({character: 8, line: 5});
-        expect(d.range.end).toEqual({character: 9, line: 5});
+        expect(d.range.end).toEqual({character: 34, line: 5});
     });
 
     // tests that an optional param in a declared type can be optionally present in a rule

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { createLangiumGrammarServices, isGrammar, toDiagnosticSeverity } from '../../../src';
+import { parseDocument } from '../../../src/test';
+
+const grammarServices = createLangiumGrammarServices().grammar;
+
+describe('validate optional params in types', () => {
+
+    // tests that an optional param in a declared type can be optionally present in a rule
+    test('optional param should not invalidate type', async () => {
+        const prog = `
+        grammar g
+        interface MyType {
+            name: string
+            count?: number
+        }
+        X returns MyType : name=ID;
+        Y returns MyType : name=ID count=NUMBER;
+        `.trim();
+
+        const document = await parseDocument(grammarServices, prog);
+
+        if(isGrammar(document.parseResult.value)) {
+            // verify we have no error diagnostics
+            const validationItems: DiagnosticSeverity[] = [];
+            grammarServices.validation.LangiumGrammarValidator.checkTypesConsistency(document.parseResult.value, (severity: 'error' | 'warning' | 'info' | 'hint') => {
+                if(severity === 'error') {
+                    validationItems.push(toDiagnosticSeverity(severity));
+                }
+            });
+            expect(validationItems).toHaveLength(0);
+        } else {
+            // something else went wrong
+            fail('Could not extract Grammar from document');
+        }
+    });
+
+});


### PR DESCRIPTION
Closes #488. Addresses the primary issue , but *not* the additional inheritance case. This allows rules to omit parameters that are declared as optional by their declared type. Previously, whether a parameter was optional or not was ignored while checking for property consistency.

Also adds a test case to verify that optional properties can be present (or not) in different rules of the same grammar.