### PR TITLE
Fix type inference for assigned actions

### DIFF
--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -196,8 +196,7 @@ function buildIsSubtypeMethod(astTypes: AstTypes): GeneratorNode {
     methodNode.indent(switchNode => {
         const groups = groupBySupertypes(astTypes);
 
-        for (const superTypes of groups.keys()) {
-            const typeGroup = groups.get(superTypes);
+        for (const [superTypes, typeGroup] of groups.entriesGroupedByKey()) {
             for (const typeName of typeGroup) {
                 switchNode.append(`case ${typeName}:`, NL);
             }

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -319,7 +319,7 @@ export function getExplicitRuleType(rule: ast.ParserRule): string | undefined {
 function getActionType(action: ast.Action): string | undefined {
     if(action.inferredType) {
         return action.inferredType.name;
-    } else if(action.type?.ref) {
+    } else if (action.type?.ref) {
         return getTypeName(action.type.ref);
     }
     return undefined; // not inferring and not referencing a valid type

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -148,8 +148,7 @@ export class LangiumGrammarValidator {
         const map = new MultiMap<string, { name: string } & AstNode>();
         extractor(grammar).forEach(e => map.add(e.name, e));
 
-        for (const name of map.keys()) {
-            const types = map.get(name);
+        for (const [, types] of map.entriesGroupedByKey()) {
             if (types.length > 1) {
                 types.forEach(e => {
                     accept('error', `A ${uniqueObjName}'s name has to be unique.`, { node: e, property: 'name' });
@@ -179,8 +178,7 @@ export class LangiumGrammarValidator {
                 importMap.add(resolvedGrammar, imp);
             }
         }
-        for (const grammar of importMap.keys()) {
-            const imports = importMap.get(grammar);
+        for (const [, imports] of importMap.entriesGroupedByKey()) {
             if (imports.length > 1) {
                 imports.forEach((imp, i) => {
                     if (i > 0) {
@@ -433,8 +431,7 @@ export class LangiumGrammarValidator {
             const propertyNameToNode: MultiMap<string, ast.Interface | readonly ast.ParserRule[]> = new MultiMap();
             this.collectPropertyNamesForHierarchy(nameToInterfaceInfo, new Set(), propertyNameToNode, interfaceName);
 
-            for (const propertyName of propertyNameToNode.keys()) {
-                const nodes = propertyNameToNode.get(propertyName) ?? [];
+            for (const [propertyName, nodes] of propertyNameToNode.entriesGroupedByKey()) {
                 if (nodes.length < 2) continue;
                 for (const node of nodes) {
                     const errorMessage = `A property '${propertyName}' has to be unique for the whole hierarchy.`;

--- a/packages/langium/src/grammar/type-system/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/inferred-types.ts
@@ -410,7 +410,7 @@ function calculateAst(alternatives: TypeAlternative[]): InterfaceType[] {
 }
 
 function flattenTypes(alternatives: TypeAlternative[]): TypeAlternative[] {
-    const nameToAlternatives = alternatives.reduce((acc, e) => { acc.add(e.name, e); return acc; }, new MultiMap<string, TypeAlternative>());
+    const nameToAlternatives = alternatives.reduce((acc, e) => acc.add(e.name, e), new MultiMap<string, TypeAlternative>());
     const types: TypeAlternative[] = [];
 
     for (const [name, namedAlternatives] of nameToAlternatives.entriesGroupedByKey()) {

--- a/packages/langium/src/grammar/type-system/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/inferred-types.ts
@@ -201,14 +201,14 @@ function buildSuperUnions(interfaces: InterfaceType[]): UnionType[] {
             allSupertypes.add(superType, interfaceType.name);
         }
     }
-    for (const superType of allSupertypes.keys()) {
+    for (const [superType, types] of allSupertypes.entriesGroupedByKey()) {
         if (!interfaces.some(e => e.name === superType)) {
             unions.push(new UnionType(
                 superType,
                 [{
                     array: false,
                     reference: false,
-                    types: [...allSupertypes.get(superType)]
+                    types
                 }],
                 { reflection: true }
             ));
@@ -410,14 +410,13 @@ function calculateAst(alternatives: TypeAlternative[]): InterfaceType[] {
 }
 
 function flattenTypes(alternatives: TypeAlternative[]): TypeAlternative[] {
-    const names = new Set<string>(alternatives.map(e => e.name));
+    const nameToAlternatives = alternatives.reduce((acc, e) => { acc.add(e.name, e); return acc; }, new MultiMap<string, TypeAlternative>());
     const types: TypeAlternative[] = [];
 
-    for (const name of names) {
+    for (const [name, namedAlternatives] of nameToAlternatives.entriesGroupedByKey()) {
         const properties: Property[] = [];
         const ruleCalls = new Set<string>();
         const type: TypeAlternative = { name, properties, ruleCalls: [], super: [] };
-        const namedAlternatives = alternatives.filter(e => e.name === name);
         for (const alt of namedAlternatives) {
             type.super.push(...alt.super);
             const altProperties = alt.properties;

--- a/packages/langium/src/grammar/type-system/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/inferred-types.ts
@@ -285,7 +285,7 @@ function addAction(graph: TypeGraph, parent: TypePart, action: Action): TypePart
             typeAlternatives: [{
                 array: action.operator === '+=',
                 reference: false,
-                types: graph.getSuperTypes(typeNode)
+                types: graph.root.ruleCalls.length !== 0 ? graph.root.ruleCalls : graph.getSuperTypes(typeNode)
             }]
         });
     }

--- a/packages/langium/src/utils/collections.ts
+++ b/packages/langium/src/utils/collections.ts
@@ -148,4 +148,11 @@ export class MultiMap<K, V> {
             .flat() as any;
     }
 
+    /**
+     * Returns a stream of key, value set pairs for every key in the map.
+     */
+    entriesGroupedByKey(): Stream<[K, V[]]> {
+        return stream(this.map.entries());
+    }
+
 }

--- a/packages/langium/test/grammar/type-system/inferred-types.spec.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.spec.ts
@@ -233,8 +233,54 @@ describeTypes('inferred types using chained actions', `
     Access:
         {infer Access} '.' member=ID;
 
+    IdRule:
+        'id' name=ID;
+    RuleName infers RuleType:
+        IdRule (
+            {infer FirstBranch.value=current} FirstBranchFragment
+        |   {infer SecondBranch.value=current} SecondBranchFragment
+        );
+    fragment FirstBranchFragment: 'First' first=ID;
+    fragment SecondBranchFragment: 'Second' second=ID;
+
     terminal ID returns string: /string/;
 `, types => {
+
+    test('RuleType is inferred as a union type', () => {
+        const ruleType = getType(types, 'RuleType') as UnionType;
+        expect(ruleType).toBeDefined();
+        expectUnion(ruleType, [{
+            array: false,
+            reference: false,
+            types: ['FirstBranch', 'IdRule', 'SecondBranch']
+        }]);
+    });
+
+    test('FirstBranch is inferred as first:string, value:IdRule', () => {
+        const firstBranch = getType(types, 'FirstBranch') as InterfaceType;
+        expect(firstBranch).toBeDefined();
+        expect(firstBranch.interfaceSuperTypes).toHaveLength(0);
+        expect(firstBranch.properties).toHaveLength(2);
+        expectProperty(firstBranch, {
+            name: 'first',
+            optional: false,
+            typeAlternatives: [{
+                array: false,
+                reference: false,
+                types: ['string']
+            }]
+        });
+        expectProperty(firstBranch, {
+            name: 'value',
+            optional: false,
+            typeAlternatives: [{
+                array: false,
+                reference: false,
+                types: ['IdRule']
+            }]
+        });
+
+    });
 
     test('Entry is inferred as a union type', () => {
         const entry = getType(types, 'Entry') as UnionType;


### PR DESCRIPTION
* Closes #470.
* Adds a test from the issue. 
* Adds updated generated grammars after previous PRs
* Adds a new method `entriesGroupedByKey` to the `MultiMap` collection that returns pairs [key, value[]] to replace the pattern:
```
for (const key of multiMap.keys()) {
    const values = multiMap.get(key);
    ...
}
```
with
```
for (const [key, values] of multiMap.entriesGroupedByKey()) {
    ...
}