### PR TITLE
Create TextDocument lazily, deprecate TextDocumentFactory

### DIFF
--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -4,7 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
 import { TypeResolutionError } from '..';
 import * as ast from '../grammar/generated/ast';
@@ -17,7 +16,7 @@ import { streamCst } from '../utils/cst-util';
 import { escapeRegExp } from '../utils/regex-util';
 import { AstNodeDescriptionProvider } from '../workspace/ast-descriptions';
 import { AstNodeLocator } from '../workspace/ast-node-locator';
-import { documentFromText, LangiumDocument, LangiumDocuments, PrecomputedScopes } from '../workspace/documents';
+import { LangiumDocument, LangiumDocuments, PrecomputedScopes } from '../workspace/documents';
 import { createLangiumGrammarServices } from './langium-grammar-module';
 
 export type Cardinality = '?' | '*' | '+' | undefined;
@@ -398,12 +397,7 @@ export function loadGrammar(json: string): ast.Grammar {
         throw new Error('Could not load grammar from specified json input.');
     }
     const grammar = astNode as Mutable<ast.Grammar>;
-    const textDocument = TextDocument.create('memory://grammar.langium', 'langium', 0, '');
-    const document = documentFromText(textDocument, {
-        lexerErrors: [],
-        parserErrors: [],
-        value: grammar
-    });
+    const document = services.shared.workspace.LangiumDocumentFactory.fromModel(grammar, URI.parse('memory://grammar.langium'));
     grammar.$document = document;
     document.precomputedScopes = computeGrammarScope(services, grammar);
     return grammar;

--- a/packages/langium/src/workspace/index-manager.ts
+++ b/packages/langium/src/workspace/index-manager.ts
@@ -134,14 +134,14 @@ export class DefaultIndexManager implements IndexManager {
         for (const data of indexData) {
             data.node = undefined; // clear reference to the AST Node
         }
-        this.simpleIndex.set(document.textDocument.uri, indexData);
+        this.simpleIndex.set(document.uri.toString(), indexData);
         document.state = DocumentState.IndexedContent;
     }
 
     async updateReferences(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<void> {
         const services = this.serviceRegistry.getServices(document.uri);
         const indexData: ReferenceDescription[] = await services.index.ReferenceDescriptionProvider.createDescriptions(document, cancelToken);
-        this.referenceIndex.set(document.textDocument.uri, indexData);
+        this.referenceIndex.set(document.uri.toString(), indexData);
         document.state = DocumentState.IndexedReferences;
     }
 


### PR DESCRIPTION
Closes #279. I did not remove the `textDocument` property from `LangiumDocument` because it's being used in numerous LSP related services. Instead I changed that property to a lazily evaluated getter. As result, a `TextDocument` is no longer created for documents that are loaded in the background (by the `WorkspaceManager`), but not opened in an editor. As soon as the user opens a DSL file in the editor, the client sends a `didOpen` notification, which triggers the creation of a `TextDocument` in the server, so the resulting `LangiumDocument` has a direct reference to that `TextDocument`.

As a side effect, this change deprecates `TextDocumentFactory` because we no longer create those documents eagerly.