### PR TITLE
Cache CST node range

### DIFF
--- a/packages/langium/src/parser/cst-node-builder.ts
+++ b/packages/langium/src/parser/cst-node-builder.ts
@@ -159,9 +159,12 @@ export class CompositeCstNodeImpl extends AbstractCstNode implements CompositeCs
 
     get range(): Range {
         if (this.children.length > 0) {
-            const { range: firstRange } = this.firstNonHiddenNode;
-            const { range: lastRange } = this.lastNonHiddenNode;
-            return { start: firstRange.start, end: lastRange.end.line < firstRange.start.line ? firstRange.start : lastRange.end };
+            if (this._rangeCache === undefined) {
+                const { range: firstRange } = this.firstNonHiddenNode;
+                const { range: lastRange } = this.lastNonHiddenNode;
+                this._rangeCache = { start: firstRange.start, end: lastRange.end.line < firstRange.start.line ? firstRange.start : lastRange.end };
+            }
+            return this._rangeCache;
         } else {
             return { start: Position.create(0, 0), end: Position.create(0, 0) };
         }
@@ -187,6 +190,7 @@ export class CompositeCstNodeImpl extends AbstractCstNode implements CompositeCs
     }
 
     readonly children: CstNode[] = new CstNodeContainer(this);
+    private _rangeCache?: Range;
 }
 
 class CstNodeContainer extends Array<CstNode> {


### PR DESCRIPTION
While developing my extension I ran into a performance issue when loading a relatively small 100loc source file. The problem seems to be that the folding rage provider iterates over all AST nodes and accesses the range of the CST node. 

```
get range (/home/ruedi/git/langium/packages/langium/lib/parser/cst-node-builder.js:136)
get range (/home/ruedi/git/langium/packages/langium/lib/parser/cst-node-builder.js:137)
get range (/home/ruedi/git/langium/packages/langium/lib/parser/cst-node-builder.js:136)
toFoldingRange (/home/ruedi/git/langium/packages/langium/lib/lsp/folding-range-provider.js:87)
collectObjectFolding (/home/ruedi/git/langium/packages/langium/lib/lsp/folding-range-provider.js:67)
collectFolding (/home/ruedi/git/langium/packages/langium/lib/lsp/folding-range-provider.js:35)
getFoldingRanges (/home/ruedi/git/langium/packages/langium/lib/lsp/folding-range-provider.js:20)
```
I created a small test script which loads the source file, iterates over all nodes and accesses the range:

```
const { shared, Scad } = createScadServices(undefined);
const textDocument = shared.workspace.TextDocumentFactory.fromUri(URI.file('/home/ruedi/Dropbox/cad/flexureMicroscope.scad'));
const document = shared.workspace.LangiumDocumentFactory.fromTextDocument<Input>(textDocument);
const sum = streamAllContents(document.parseResult.value).map(node => node.$cstNode!.range.start.line ?? 0).reduce((a, b) => a + b);
console.log('sum', sum);
```

Performance without caching: 50s. With caching: 0.6s => about x100 performance advantage.

I am not sure if this is the best way of implementing this. Perhaps it would be better to construct the range while the tree is built?