### PR TITLE
A small test framework for checking diagnostics

### DIFF
--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -232,10 +232,10 @@ export interface ExpectDiagnosticOffsetOptions {
 export type Predicate<T> = (arg: T) => boolean;
 
 function isRangeEqual(lhs: Range, rhs: Range): boolean {
-    return lhs.start.character == rhs.start.character
-        && lhs.start.line == rhs.start.line
-        && lhs.end.character == rhs.end.character
-        && lhs.end.line == rhs.end.line;
+    return lhs.start.character === rhs.start.character
+        && lhs.start.line === rhs.start.line
+        && lhs.end.character === rhs.end.character
+        && lhs.end.line === rhs.end.line;
 }
 
 function filterByOptions<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, options: ExpectDiagnosticOptions<N>) {

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -241,13 +241,13 @@ function isRangeEqual(lhs: Range, rhs: Range): boolean {
 function filterByOptions<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, options: ExpectDiagnosticOptions<N>) {
     const filters: Array<Predicate<Diagnostic>> = [];
     if ('node' in options) {
-        const node = 'property' in options
-            ? findNodeForFeature(options.node.$cstNode, options.property!.name, options.property!.index)
+        const cstNode = options.property
+            ? findNodeForFeature(options.node.$cstNode, options.property.name, options.property.index)
             : options.node.$cstNode;
-        if (!node) {
+        if (!cstNode) {
             throw new Error('Cannot find the node!');
         }
-        filters.push(d => isRangeEqual(node.range, d.range));
+        filters.push(d => isRangeEqual(cstNode.range, d.range));
     }
     if ('offset' in options) {
         const outer = {

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -189,7 +189,7 @@ function replaceIndices(base: ExpectedBase): { output: string, indices: number[]
     return { output: input, indices, ranges: ranges.sort((a, b) => a[0] - b[0]) };
 }
 
-export function validationHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string) => Promise<Diagnostic[]> {
+export function validationHelper(services: LangiumServices): (input: string) => Promise<Diagnostic[]> {
     const parse = parseHelper(services);
     return async (input) => {
         const document = await parse(input);
@@ -208,7 +208,7 @@ export type DiagnosticFilterOptions = Partial<DiagnosticFilters>;
 
 function filterByOptions(diagnostics: Diagnostic[], filterOptions?: DiagnosticFilterOptions) {
     const options = filterOptions || {};
-    const filters: Predicate<Diagnostic>[] = [];
+    const filters: Array<Predicate<Diagnostic>> = [];
     if (options.severity) {
         filters.push(d => d.severity === options.severity);
     }
@@ -223,23 +223,23 @@ function filterByOptions(diagnostics: Diagnostic[], filterOptions?: DiagnosticFi
     return diagnostics.filter(diag => filters.every(holdsFor => holdsFor(diag)));
 }
 
-export function expectNoIssues(diagnostics: Diagnostic[], filterOptions?: DiagnosticFilterOptions) {
+export function expectNoIssues(diagnostics: Diagnostic[], filterOptions?: DiagnosticFilterOptions): void {
     const filtered = filterByOptions(diagnostics, filterOptions);
     expect(filtered).toHaveLength(0);
 }
 
-export function expectIssue(diagnostics: Diagnostic[], filterOptions?: DiagnosticFilterOptions) {
+export function expectIssue(diagnostics: Diagnostic[], filterOptions?: DiagnosticFilterOptions): void {
     const filtered = filterByOptions(diagnostics, filterOptions);
     expect(filtered).not.toHaveLength(0);
 }
 
-export function expectError(diagnostics: Diagnostic[], message: string | RegExp) {
+export function expectError(diagnostics: Diagnostic[], message: string | RegExp): void {
     expectIssue(diagnostics, {
         message,
         severity: DiagnosticSeverity.Error
     });
 }
-export function expectWarning(diagnostics: Diagnostic[], message: string | RegExp) {
+export function expectWarning(diagnostics: Diagnostic[], message: string | RegExp): void {
     expectIssue(diagnostics, {
         message,
         severity: DiagnosticSeverity.Warning

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -243,23 +243,23 @@ function containsRange(outer: Range, inner: Range): boolean {
 
 function filterByOptions<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, options: ExpectDiagnosticOptions<N>) {
     const filters: Array<Predicate<Diagnostic>> = [];
-    if ("node" in options) {
-        const node = "property" in options
+    if ('node' in options) {
+        const node = 'property' in options
             ? findNodeForFeature(options.node.$cstNode, options.property!.name, options.property!.index)
             : options.node.$cstNode;
         if (!node) {
-            throw new Error("Cannot find node!");
+            throw new Error('Cannot find the node!');
         }
         filters.push(d => containsRange(node.range, d.range));
     }
-    if ("offset" in options) {
+    if ('offset' in options) {
         const outer = {
             start: validationResult.document.textDocument.positionAt(options.offset),
             end: validationResult.document.textDocument.positionAt(options.offset + options.length - 1)
         };
         filters.push(d => containsRange(outer, d.range));
     }
-    if ("range" in options) {
+    if ('range' in options) {
         filters.push(d => containsRange(options.range!, d.range));
     }
     if (options.code) {

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { createLangiumGrammarServices } from '../../src';
-import { Grammar } from '../../src/grammar/generated/ast';
+import { Assignment, CrossReference, Grammar, Group, ParserRule } from '../../src/grammar/generated/ast';
 import { expectError, expectNoIssues, expectWarning, validationHelper, ValidationResult } from '../../src/test';
 
 const services = createLangiumGrammarServices();
@@ -39,16 +39,18 @@ describe('checkReferenceToRuleButNotType', () => {
     });
 
     test('CrossReference validation', () => {
-        const rule = validationResult.document.parseResult.value.rules[3];
+        const rule = ((validationResult.document.parseResult.value.rules[3] as ParserRule).alternatives as Assignment).terminal as CrossReference;
         expectError(validationResult, "Use the rule type 'DefType' instead of the typed rule name 'Definition' for cross references.", {
-            node: rule
+            node: rule,
+            property: { name: 'type' }
         });
     });
 
     test('AtomType validation', () => {
         const type = validationResult.document.parseResult.value.types[0];
         expectError(validationResult, "Use the rule type 'RefType' instead of the typed rule name 'Reference' for cross references.", {
-            node: type
+            node: type,
+            property: { name: 'typeAlternatives' }
         });
     });
 
@@ -70,7 +72,7 @@ describe('Check Rule Fragment Validation', () => {
 
     test('Rule Fragment Validation', () => {
         const fragmentType = validationResult.document.parseResult.value.types[0];
-        expectError(validationResult, 'Cannot use rule fragments in types.', { node: fragmentType });
+        expectError(validationResult, 'Cannot use rule fragments in types.', { node: fragmentType, property: { name: 'typeAlternatives' } });
     });
 });
 
@@ -89,9 +91,10 @@ describe('Checked Named CrossRefs', () => {
     });
 
     test('Named crossReference warning', () => {
-        const rule = validationResult.document.parseResult.value.rules[1];
+        const rule = ((validationResult.document.parseResult.value.rules[1] as ParserRule).alternatives as Group).elements[1] as Assignment;
         expectWarning(validationResult, 'The "name" property is not recommended for cross-references.', {
-            node: rule
+            node: rule,
+            property: { name: 'feature' }
         });
     });
 });

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -4,9 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
-import { createLangiumGrammarServices, Grammar, LangiumDocument } from '../../src';
-import { expectError, expectWarning, parseHelper, validationHelper } from '../../src/test';
+import { Diagnostic } from 'vscode-languageserver';
+import { createLangiumGrammarServices, Grammar } from '../../src';
+import { expectError, expectWarning, validationHelper } from '../../src/test';
 
 const services = createLangiumGrammarServices();
 const validate = validationHelper<Grammar>(services.grammar);

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -41,14 +41,14 @@ describe('checkReferenceToRuleButNotType', () => {
     test('CrossReference validation', () => {
         const rule = validationResult.document.parseResult.value.rules[3];
         expectError(validationResult, "Use the rule type 'DefType' instead of the typed rule name 'Definition' for cross references.", {
-            atNode: { node: rule }
+            node: rule
         });
     });
 
     test('AtomType validation', () => {
         const type = validationResult.document.parseResult.value.types[0];
         expectError(validationResult, "Use the rule type 'RefType' instead of the typed rule name 'Reference' for cross references.", {
-            atNode: { node: type }
+            node: type
         });
     });
 
@@ -70,7 +70,7 @@ describe('Check Rule Fragment Validation', () => {
 
     test('Rule Fragment Validation', () => {
         const fragmentType = validationResult.document.parseResult.value.types[0];
-        expectError(validationResult, 'Cannot use rule fragments in types.', { atNode: { node: fragmentType } });
+        expectError(validationResult, 'Cannot use rule fragments in types.', { node: fragmentType });
     });
 });
 
@@ -91,7 +91,7 @@ describe('Checked Named CrossRefs', () => {
     test('Named crossReference warning', () => {
         const rule = validationResult.document.parseResult.value.rules[1];
         expectWarning(validationResult, 'The "name" property is not recommended for cross-references.', {
-            atNode: { node: rule }
+            node: rule
         });
     });
 });

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -5,11 +5,11 @@
  ******************************************************************************/
 
 import { Diagnostic } from 'vscode-languageserver';
-import { createLangiumGrammarServices, Grammar } from '../../src';
+import { createLangiumGrammarServices } from '../../src';
 import { expectError, expectWarning, validationHelper } from '../../src/test';
 
 const services = createLangiumGrammarServices();
-const validate = validationHelper<Grammar>(services.grammar);
+const validate = validationHelper(services.grammar);
 
 describe('checkReferenceToRuleButNotType', () => {
 


### PR DESCRIPTION
I saw the task about `ValidationTestHelper` named #414 .
I used the verb `expect` instead of `assert`, since we use Jest with `expect()`.
The filters for diagnostic determination can be extended step by step. I have one for the message and one for the severity.

Closes #414 . @msujew what do you think about this approach?