### PR TITLE
Improves Primitive Types

### DIFF
--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -34,7 +34,7 @@ export function isCondition(item: unknown): item is Condition {
 
 export type FeatureName = string;
 
-export type PrimitiveType = 'boolean' | 'date' | 'number' | 'string';
+export type PrimitiveType = 'Date' | 'bigint' | 'boolean' | 'number' | 'string';
 
 export interface AbstractElement extends AstNode {
     readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -576,7 +576,13 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           },
           {
             "$type": "Keyword",
-            "value": "date"
+            "value": "Date",
+            "elements": []
+          },
+          {
+            "$type": "Keyword",
+            "value": "bigint",
+            "elements": []
           }
         ]
       },

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -559,7 +559,7 @@ export class LangiumGrammarValidator {
 
     checkTerminalRuleReturnType(rule: ast.TerminalRule, accept: ValidationAcceptor): void {
         if (rule.type?.name && !isPrimitiveType(rule.type.name)) {
-            accept('error', "Terminal rules can only return primitive types like 'string', 'boolean', 'number' or 'date'.", { node: rule.type, property: 'name' });
+            accept('error', "Terminal rules can only return primitive types like 'string', 'boolean', 'number', 'Date' or 'bigint'.", { node: rule.type, property: 'name' });
         }
     }
 
@@ -627,7 +627,7 @@ export class LangiumGrammarValidator {
     }
 }
 
-const primitiveTypes = ['string', 'number', 'boolean', 'Date'];
+const primitiveTypes = ['string', 'number', 'boolean', 'Date', 'bigint'];
 
 function isPrimitiveType(type: string): boolean {
     return primitiveTypes.includes(type);

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -31,7 +31,7 @@ AtomType:
     (primitiveType=PrimitiveType | isRef?='@'? refType=[AbstractType]) isArray?='[]'? | keywordType=Keyword;
 
 PrimitiveType returns string:
-    'string' | 'number' | 'boolean' | 'date';
+    'string' | 'number' | 'boolean' | 'Date' | 'bigint';
 
 type AbstractType = Interface | Type | Action | ParserRule;
 

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -45,8 +45,6 @@ export class DefaultValueConverter implements ValueConverter {
             case 'STRING': return convertString(input);
             case 'ID': return convertID(input);
             case 'REGEXLITERAL': return convertString(input);
-            case 'BIGINT': return convertBigint(input);
-            case 'DATE': return convertDate(input);
         }
         switch (getRuleType(rule)?.toLowerCase()) {
             case 'number': return convertNumber(input);

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -45,6 +45,8 @@ export class DefaultValueConverter implements ValueConverter {
             case 'STRING': return convertString(input);
             case 'ID': return convertID(input);
             case 'REGEXLITERAL': return convertString(input);
+            case 'BIGINT': return convertBigint(input);
+            case 'DATE': return convertDate(input);
         }
         switch (getRuleType(rule)?.toLowerCase()) {
             case 'number': return convertNumber(input);

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -49,6 +49,8 @@ export class DefaultValueConverter implements ValueConverter {
         switch (getRuleType(rule)?.toLowerCase()) {
             case 'number': return convertNumber(input);
             case 'boolean': return convertBoolean(input);
+            case 'bigint': return convertBigint(input);
+            case 'date': return convertDate(input);
             default: return input;
         }
     }
@@ -68,6 +70,14 @@ export function convertID(input: string): string {
 
 export function convertInt(input: string): number {
     return parseInt(input);
+}
+
+export function convertBigint(input: string): bigint {
+    return BigInt(input);
+}
+
+export function convertDate(input: string): Date {
+    return new Date(input);
 }
 
 export function convertNumber(input: string): number {

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -207,6 +207,37 @@ describe('One name for terminal and non-terminal rules', () => {
 
 });
 
+describe('Boolean value converter', () => {
+    let parser: LangiumParser;
+    const content = `
+    grammar G
+    entry M: value?='true';
+    hidden terminal WS: /\\s+/;
+    `;
+
+    beforeAll(async () => {
+        const grammar = (await helper(content)).parseResult.value;
+        parser = parserFromGrammar(grammar);
+    });
+
+    function expectValue(input: string, value: unknown): void {
+        const main = parser.parse(input).value as unknown as { value: unknown };
+        expect(main.value).toBe(value);
+    }
+
+    test('Should have no definition errors', () => {
+        expect(parser.definitionErrors).toHaveLength(0);
+    });
+
+    test('Parsed Boolean is correct', () => {
+        expectValue('true', true);
+        // normal behavior when a property type can be resolved to only boolean
+        // gives us true/false values representing the parse result
+        expectValue('false', false);
+        expectValue('something-else-entirely', false);
+    });
+});
+
 describe('BigInt Parser value converter', () => {
     let parser: LangiumParser;
     const content = `
@@ -333,9 +364,10 @@ describe('Parser calls value converter', () => {
 
     test('Should parse bool correctly', () => {
         expectValue('b true', true);
-        // this is the current 'boolean' behavior, either true/undefined, no false
+        // this is the current 'boolean' behavior when a prop type can't be resolved to just a boolean
+        // either true/undefined, no false in this case
         expectValue('b false', undefined);
-        // no distinguishing between the bad parse case
+        // ...then no distinguishing between the bad parse case when the type is unclear
         expectValue('b asdfg', undefined);
     });
 

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -306,14 +306,14 @@ describe('Parser calls value converter', () => {
     QFN returns string: ID ('.' QFN)?;
     terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
 
-    fragment BigVal:
-        value=BIGINT 'n';
-    terminal BIGINT returns bigint: /[0-9]+(?=n)/;
+    fragment BigVal: value=BINT 'n';
+    terminal BINT returns bigint: INT /(?=n)/;
 
     terminal DATE returns Date: /[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2})?/;
 
-    Number returns number: NUM;
-    terminal NUM returns number: /-?[0-9]+(\\.[0-9]+)?/;
+    Number returns number:
+        INT ('.' INT)?;
+    terminal INT returns number: /[0-9]+/;
 
     hidden terminal WS: /\\s+/;
     hidden terminal ML_COMMENT: /\\/\\*[\\s\\S]*?\\*\\//;

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -86,14 +86,24 @@ describe('Checked Named CrossRefs', () => {
     });
 });
 
-describe('Check primitive types', () => {
+describe('Check grammar with primitives', () => {
     const grammar = `
     grammar PrimGrammar
-    entry A: 'a' s=STR b=BOOL n=NUM b=BIG d=DATE;
+    entry Expr:
+        (String | Bool | Num | BigInt | DateObj)*;
+    String:
+        'String' val=STR;
+    Bool:
+        'Bool' val?='true';
+    Num:
+        'Num' val=NUM;
+    BigInt:
+        'BigInt' val=BIG 'n';
+    DateObj:
+        'Date' val=DATE;
     terminal STR: /[_a-zA-Z][\\w_]*/;
-    terminal BOOL returns boolean: /true|false/;
+    terminal BIG returns bigint: /[0-9]+(?=n)/;
     terminal NUM returns number: /[0-9]+(\\.[0-9])?/;
-    terminal BIG returns bigint: /[0-9]+/;
     terminal DATE returns Date: /[0-9]{4}-{0-9}2-{0-9}2/+;
     `.trim();
 
@@ -107,27 +117,6 @@ describe('Check primitive types', () => {
     test('No validation errors in grammar', () => {
         expect(validationData.diagnostics.filter(d => d.severity === DiagnosticSeverity.Error)).toHaveLength(0);
     });
-
-    // 2. using the build parser, attempt to parse various primitives
-    // 3. try to parse a good case of all
-    // 3. Try a big int of 0x1fffffffffffff, from MDN example
-    //  should succed, giving a value of '9007199254740991n'
-    // 4. try to parse a big int of 1.1, which should fail
-    // 5. try to parse an ISO 8601 date, YYYY-MM-DDTHH:mm:ss.ssssZ .... or ±YYYYYY-MM-DDTHH:mm:ss.sssZ, should succeed
-    //  2022-10-04T12:13:11
-    // 6. Try to parse a date string by hand
-    //  19 September 1999 15:31 UTC (should also succeed)
-    // 7. try to parse a garbage date: 2022 Apples, should fail
-
-    // parseAndValidate(g_allPrims).then(validationData => {
-    //     test('No primitive type errors', () => {
-    //         expectError(validationData, 'blah blah');
-    //     });
-    // });
-
-    // test('No primitive type errors', () => {
-    //     expectError(validationData, 'blah blah');
-    // });
 });
 
 interface ValidatorData {

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -87,31 +87,47 @@ describe('Checked Named CrossRefs', () => {
 });
 
 describe('Check primitive types', () => {
-    const g_allPrims = `
-    grammar G
-    entry A: 'a' s=STR b=BOOL n=NUM b=BIG;
+    const grammar = `
+    grammar PrimGrammar
+    entry A: 'a' s=STR b=BOOL n=NUM b=BIG d=DATE;
     terminal STR: /[_a-zA-Z][\\w_]*/;
     terminal BOOL returns boolean: /true|false/;
     terminal NUM returns number: /[0-9]+(\\.[0-9])?/;
     terminal BIG returns bigint: /[0-9]+/;
+    terminal DATE returns Date: /[0-9]{4}-{0-9}2-{0-9}2/+;
     `.trim();
-    // TODO, still needs testing for 'Date'
 
     let validationData: ValidatorData;
+
+    // 1. build a parser from this grammar, verify it works
+    beforeAll(async () => {
+        validationData = await parseAndValidate(grammar);
+    });
+
+    test('No validation errors in grammar', () => {
+        expect(validationData.diagnostics.filter(d => d.severity === DiagnosticSeverity.Error)).toHaveLength(0);
+    });
+
+    // 2. using the build parser, attempt to parse various primitives
+    // 3. try to parse a good case of all
+    // 3. Try a big int of 0x1fffffffffffff, from MDN example
+    //  should succed, giving a value of '9007199254740991n'
+    // 4. try to parse a big int of 1.1, which should fail
+    // 5. try to parse an ISO 8601 date, YYYY-MM-DDTHH:mm:ss.ssssZ .... or ±YYYYYY-MM-DDTHH:mm:ss.sssZ, should succeed
+    //  2022-10-04T12:13:11
+    // 6. Try to parse a date string by hand
+    //  19 September 1999 15:31 UTC (should also succeed)
+    // 7. try to parse a garbage date: 2022 Apples, should fail
+
     // parseAndValidate(g_allPrims).then(validationData => {
     //     test('No primitive type errors', () => {
     //         expectError(validationData, 'blah blah');
     //     });
     // });
 
-    // but i see why they did this here, I can just create several test enclosures to do work instead...
-    beforeAll(async () => {
-        validationData = await parseAndValidate(g_allPrims);
-    });
-
-    test('No primitive type errors', () => {
-        expectError(validationData, 'blah blah');
-    });
+    // test('No primitive type errors', () => {
+    //     expectError(validationData, 'blah blah');
+    // });
 });
 
 interface ValidatorData {

--- a/packages/langium/test/validation/grammar-validation.test.ts
+++ b/packages/langium/test/validation/grammar-validation.test.ts
@@ -86,6 +86,34 @@ describe('Checked Named CrossRefs', () => {
     });
 });
 
+describe('Check primitive types', () => {
+    const g_allPrims = `
+    grammar G
+    entry A: 'a' s=STR b=BOOL n=NUM b=BIG;
+    terminal STR: /[_a-zA-Z][\\w_]*/;
+    terminal BOOL returns boolean: /true|false/;
+    terminal NUM returns number: /[0-9]+(\\.[0-9])?/;
+    terminal BIG returns bigint: /[0-9]+/;
+    `.trim();
+    // TODO, still needs testing for 'Date'
+
+    let validationData: ValidatorData;
+    // parseAndValidate(g_allPrims).then(validationData => {
+    //     test('No primitive type errors', () => {
+    //         expectError(validationData, 'blah blah');
+    //     });
+    // });
+
+    // but i see why they did this here, I can just create several test enclosures to do work instead...
+    beforeAll(async () => {
+        validationData = await parseAndValidate(g_allPrims);
+    });
+
+    test('No primitive type errors', () => {
+        expectError(validationData, 'blah blah');
+    });
+});
+
 interface ValidatorData {
     document: LangiumDocument;
     diagnostics: Diagnostic[];


### PR DESCRIPTION
Closes #482 and Closes #199, by improving the primitive types present in Langium. In particular, this PR adds the `bigint` built-in type, along with an associated default value converter. 

In addition:
- `date` was changed to `Date` to match the casing in typescript.
- error messages for primitive types were updated to include `bigint` and `Date`
- added default value converter for `Date`
- modified existing tests to incorporate `bigint` and `Date` primitives
- added new tests to enforce parsing/conversion behavior

There are some key points to note with this PR:
- [It is *not* recommended to parse date strings directly via the `Date()` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#parameters), but I have this in place for now as a proof of concept. I think it may be worth a little bit more work to recognize only ISO 8601 strings, or RFC 2822, a combination of the two, or some other approach that is safer. It could be as simple as deconstructing the date components and using another constructor on the `Date` object instead.
- Booleans are still kind of odd, given that the values are either `true` for a successful parse or `undefined`, rather than `true` and `false`. [In the token builder tests, I noticed a test that builds a grammar that tries to capture a false value incorrectly](https://github.com/langium/langium/blob/main/packages/langium/test/parser/token-builder.test.ts#L95). Specifically,
    ```
    terminal BOOLEAN returns boolean: /true|false/;
    ```
   Which can parse both **true** and **false** to produce a value of `true`. If you try to remove **false** from the regex to only recognize **true**, you run into the awkward situation of being unable to distinguish between false and a failed parse.

    Ultimately, my thought is whether I should expand this PR to allow boolean assignments to have the expected true/false values, instead of true/undefined.

- Recognizing bigints is a little tricky, and so I've attempted to provide good examples in the tests of how this can be done properly. Lookahead and terminal ordering are both important to disambiguate between ints and bigints. Beyond that, they actually work pretty well!