### PR TITLE
Add a validation for assigned fragment calls

### DIFF
--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -576,13 +576,11 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           },
           {
             "$type": "Keyword",
-            "value": "Date",
-            "elements": []
+            "value": "Date"
           },
           {
             "$type": "Keyword",
-            "value": "bigint",
-            "elements": []
+            "value": "bigint"
           }
         ]
       },

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -25,7 +25,7 @@ describe('Langium grammar validation', () => {
         const validationResult = await validate(grammarText);
 
         // assert
-        expectError(validationResult, /assigns to a call of the fragment rule/, {
+        expectError(validationResult, /Cannot use fragment rule 'B' for assignment of property 'b'./, {
             node: (validationResult.document.parseResult.value.rules[0] as ParserRule).alternatives as Assignment,
             property: {name: 'terminal'}
         });

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -1,0 +1,33 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createLangiumGrammarServices } from '../../src';
+import { Assignment, Grammar, ParserRule } from '../../src/grammar/generated/ast';
+import { expectError, validationHelper } from '../../src/test';
+
+const services = createLangiumGrammarServices();
+const validate = validationHelper<Grammar>(services.grammar);
+
+describe('Langium grammar validation', () => {
+    test('Parser rule should not assign fragments', async () => {
+        // arrange
+        const grammarText = `
+        grammar Test
+        entry A: b=B;
+        fragment B: name=ID;
+        terminal ID returns string: /[a-z]+/;
+        `;
+
+        // act
+        const validationResult = await validate(grammarText);
+
+        // assert
+        expectError(validationResult, /assigns to a call of the fragment rule/, {
+            node: (validationResult.document.parseResult.value.rules[0] as ParserRule).alternatives as Assignment,
+            property: {name: 'terminal'}
+        });
+    });
+});


### PR DESCRIPTION
Closes #500 .

Easy, I hope that is the only place where you can do this.

About the wording of the error message: I added the names of the two involved rules, because 'this parser rule' might be not so helpful on a console printout. Maybe add the property name, too?