### PR TITLE
Added streamAst utility function

### DIFF
--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -26,6 +26,7 @@ export class LangiumGrammarValidationRegistry extends ValidationRegistry {
         super(services);
         const validator = services.validation.LangiumGrammarValidator;
         const checks: ValidationChecks<ast.LangiumGrammarAstType> = {
+            Action: validator.checkActionTypeUnions,
             AbstractRule: validator.checkRuleName,
             Assignment: validator.checkAssignmentWithFeatureName,
             ParserRule: [
@@ -410,10 +411,11 @@ export class LangiumGrammarValidator {
                 }
             });
         }
-        for (const action of streamAllContents(grammar).filter(ast.isAction)) {
-            if (ast.isType(action.type)) {
-                accept('error', 'Actions cannot create union types.', { node: action, property: 'type' });
-            }
+    }
+
+    checkActionTypeUnions(action: ast.Action, accept: ValidationAcceptor): void {
+        if (ast.isType(action.type)) {
+            accept('error', 'Actions cannot create union types.', { node: action, property: 'type' });
         }
     }
 

--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -13,7 +13,7 @@ import { ScopeProvider } from '../../references/scope';
 import { LangiumServices } from '../../services';
 import { AstNode, AstNodeDescription, CstNode } from '../../syntax-tree';
 import { getContainerOfType, isAstNode } from '../../utils/ast-util';
-import { findLeafNodeAtOffset, findRelevantNode, flatten } from '../../utils/cst-util';
+import { findLeafNodeAtOffset, findRelevantNode, flattenCst } from '../../utils/cst-util';
 import { MaybePromise } from '../../utils/promise-util';
 import { stream } from '../../utils/stream';
 import { LangiumDocument } from '../../workspace/documents';
@@ -65,7 +65,7 @@ export class DefaultCompletionProvider implements CompletionProvider {
                 const commonSuperRule = this.findCommonSuperRule(node);
                 // In some cases, it is possible that we do not have a super rule
                 if (commonSuperRule) {
-                    const flattened = flatten(commonSuperRule.node).filter(e => e.offset < offset);
+                    const flattened = flattenCst(commonSuperRule.node).filter(e => e.offset < offset).toArray();
                     const possibleFeatures = this.ruleInterpreter.interpretRule(commonSuperRule.rule, [...flattened], offset);
                     // Remove features which we already identified during parsing
                     const partialMatches = possibleFeatures.filter(e => {

--- a/packages/langium/src/lsp/folding-range-provider.ts
+++ b/packages/langium/src/lsp/folding-range-provider.ts
@@ -6,9 +6,9 @@
 
 import { CancellationToken, FoldingRange, FoldingRangeKind, FoldingRangeParams } from 'vscode-languageserver';
 import { LangiumServices } from '../services';
-import { AstNode, CstNode, isLeafCstNode } from '../syntax-tree';
+import { AstNode, CstNode } from '../syntax-tree';
 import { streamAllContents } from '../utils/ast-util';
-import { streamCst } from '../utils/cst-util';
+import { flattenCst } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 
@@ -99,8 +99,8 @@ export class DefaultFoldingRangeProvider implements FoldingRangeProvider {
     protected collectCommentFolding(document: LangiumDocument, node: AstNode, acceptor: FoldingRangeAcceptor): void {
         const cstNode = node.$cstNode;
         if (cstNode) {
-            for (const node of streamCst(cstNode)) {
-                if (isLeafCstNode(node) && this.commentNames.includes(node.tokenType.name)) {
+            for (const node of flattenCst(cstNode)) {
+                if (this.commentNames.includes(node.tokenType.name)) {
                     const foldingRange = this.toFoldingRange(document, node, FoldingRangeKind.Comment);
                     if (foldingRange) {
                         acceptor(foldingRange);

--- a/packages/langium/src/lsp/reference-finder.ts
+++ b/packages/langium/src/lsp/reference-finder.ts
@@ -11,7 +11,7 @@ import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { AstNode, CstNode } from '../syntax-tree';
 import { getDocument, isReference } from '../utils/ast-util';
-import { findLeafNodeAtOffset, flatten } from '../utils/cst-util';
+import { findLeafNodeAtOffset, flattenCst } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 
@@ -76,7 +76,7 @@ export class DefaultReferenceFinder implements ReferenceFinder {
             return nameNode;
         if (node.$cstNode) {
             // try find first leaf with name as text
-            const leafNode = flatten(node.$cstNode).find((n) => n.text === name);
+            const leafNode = flattenCst(node.$cstNode).find((n) => n.text === name);
             if (leafNode)
                 return leafNode;
         }

--- a/packages/langium/src/utils/cst-util.ts
+++ b/packages/langium/src/utils/cst-util.ts
@@ -9,8 +9,12 @@ import { Range } from 'vscode-languageserver';
 import { DatatypeSymbol } from '../parser/langium-parser';
 import { AstNode, CstNode, CompositeCstNode, isCompositeCstNode, isLeafCstNode, LeafCstNode } from '../syntax-tree';
 import { DocumentSegment } from '../workspace/documents';
-import { TreeStream, TreeStreamImpl } from './stream';
+import { Stream, TreeStream, TreeStreamImpl } from './stream';
 
+/**
+ * Create a stream of all CST nodes that are directly and indirectly contained in the given root node,
+ * including the root node itself.
+ */
 export function streamCst(node: CstNode): TreeStream<CstNode> {
     return new TreeStreamImpl(node, element => {
         if (isCompositeCstNode(element)) {
@@ -18,17 +22,14 @@ export function streamCst(node: CstNode): TreeStream<CstNode> {
         } else {
             return [];
         }
-    });
+    }, { includeRoot: true });
 }
 
-export function flatten(node: CstNode): LeafCstNode[] {
-    if (isLeafCstNode(node)) {
-        return [node];
-    } else if (isCompositeCstNode(node)) {
-        return node.children.flatMap(e => flatten(e));
-    } else {
-        return [];
-    }
+/**
+ * Create a stream of all leaf nodes that are directly and indirectly contained in the given root node.
+ */
+export function flattenCst(node: CstNode): Stream<LeafCstNode> {
+    return streamCst(node).filter(isLeafCstNode);
 }
 
 export function tokenToRange(token: IToken): Range {

--- a/packages/langium/src/utils/stream.ts
+++ b/packages/langium/src/utils/stream.ts
@@ -732,16 +732,17 @@ export interface TreeStream<T> extends Stream<T> {
 
 /**
  * The default implementation of `TreeStream` takes a root element and a function that computes the
- * children of its argument. The root is not included in the stream.
+ * children of its argument. Whether the root node included in the stream is controlled with the
+ * `includeRoot` option, which defaults to `false`.
  */
 export class TreeStreamImpl<T>
     extends StreamImpl<{ iterators: Array<Iterator<T>>, pruned: boolean }, T>
     implements TreeStream<T> {
 
-    constructor(root: T, children: (node: T) => Iterable<T>) {
+    constructor(root: T, children: (node: T) => Iterable<T>, options?: { includeRoot?: boolean }) {
         super(
             () => ({
-                iterators: [children(root)[Symbol.iterator]()],
+                iterators: options?.includeRoot ? [[root][Symbol.iterator]()] : [children(root)[Symbol.iterator]()],
                 pruned: false
             }),
             state => {


### PR DESCRIPTION
 - Added an option to TreeStreamImpl to include the root node
 - Added `streamAst` function as alternative to `streamAllContents` to include the root node
 - Use the new function where it makes sense
 - Changed `streamCst` to include the root node to be consistent with the new function (the name is almost the same)