### PR TITLE
Remove node `path` dependency

### DIFF
--- a/examples/arithmetics/test/arithmetics-cli.test.ts
+++ b/examples/arithmetics/test/arithmetics-cli.test.ts
@@ -30,7 +30,7 @@ interface CliResult {
 
 async function cli(args: string[]): Promise<CliResult> {
     return new Promise(resolve => {
-        exec(`node ${path.join(__dirname, '../bin/cli')} ${args.join(' ')}`, (error, stdout, stderr) => {
+        exec(`node "${path.join(__dirname, '../bin/cli')}" "${args.join('" "')}"`, (error, stdout, stderr) => {
             resolve({
                 code: error && error.code ? error.code : 0,
                 error,

--- a/examples/domainmodel/test/domainmodel-cli.test.ts
+++ b/examples/domainmodel/test/domainmodel-cli.test.ts
@@ -41,7 +41,7 @@ describe('Test the domainmodel CLI', () => {
     });
 
     test('Via CLI: Generator command returns code 0 and creates expected files', async () => {
-        const result = await cli(['generate', rawfileName, `-d ${destination}`]);
+        const result = await cli(['generate', rawfileName, '-d', destination]);
         if(result.code !== 0) {
             console.log('Error code:', result.code);
             console.log('Error message:', result.error);
@@ -65,7 +65,7 @@ interface CliResult {
 
 async function cli(args: string[]): Promise<CliResult> {
     return new Promise(resolve => {
-        exec(`node ${path.join(__dirname, '../bin/cli')} ${args.join(' ')}`, (error, stdout, stderr) => {
+        exec(`node "${path.join(__dirname, '../bin/cli')}" "${args.join('" "')}"`, (error, stdout, stderr) => {
             resolve({
                 code: error && error.code ? error.code : 0,
                 error,

--- a/examples/statemachine/test/statemachine-cli.test.ts
+++ b/examples/statemachine/test/statemachine-cli.test.ts
@@ -14,7 +14,7 @@ describe('Test the statemachine CLI', () => {
     const destination = 'statemachine-example-test';
 
     test('Generator command returns code 0 and creates expected files', async () => {
-        const result = await cli(['generate', fileName, `-d ${destination}`]);
+        const result = await cli(['generate', fileName, '-d', destination]);
         expect(result.code).toBe(0);
 
         fileName = fileName.replace(/\..*$/, '').replace(/[.-]/g, '');
@@ -38,7 +38,7 @@ interface CliResult {
 
 async function cli(args: string[]): Promise<CliResult> {
     return new Promise(resolve => {
-        exec(`node ${path.join(__dirname, '../bin/cli')} ${args.join(' ')}`, (error, stdout, stderr) => {
+        exec(`node "${path.join(__dirname, '../bin/cli')}" "${args.join('" "')}"`, (error, stdout, stderr) => {
             resolve({
                 code: error && error.code ? error.code : 0,
                 error,

--- a/packages/langium-sprotty/src/diagram-server-manager.ts
+++ b/packages/langium-sprotty/src/diagram-server-manager.ts
@@ -71,7 +71,7 @@ export class DefaultDiagramServerManager implements DiagramServerManager {
             // Track the document URIs to diagram servers via the `sourceUri` option sent with the `RequestModelAction`
             .map(doc => <[LangiumDocument, DiagramServer]>[
                 doc,
-                stream(this.diagramServerMap.values()).find(server => doc.uri.toString() === server.state.options?.sourceUri)
+                stream(this.diagramServerMap.values()).find(server => equalURI(doc.uri, server.state.options?.sourceUri as string))
             ])
             .forEach(entry => {
                 if (entry[1]) {

--- a/packages/langium-vscode/src/extension.ts
+++ b/packages/langium-vscode/src/extension.ts
@@ -5,7 +5,6 @@
  ******************************************************************************/
 
 import * as vscode from 'vscode';
-import * as path from 'path';
 import {
     LanguageClient, LanguageClientOptions, ServerOptions, TransportKind
 } from 'vscode-languageclient/node';
@@ -26,7 +25,7 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
-    const serverModule = context.asAbsolutePath(path.join('out', 'language-server', 'main'));
+    const serverModule = context.asAbsolutePath('./out/language-server/main');
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
     // By setting `process.env.DEBUG_BREAK` to a truthy value, the language server will wait until a debugger is attached.

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -4,7 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import path from 'path';
 import { DiagnosticTag } from 'vscode-languageserver-types';
 import { Utils } from 'vscode-uri';
 import { References } from '../references/references';
@@ -14,6 +13,7 @@ import { getContainerOfType, getDocument, streamAllContents } from '../utils/ast
 import { MultiMap } from '../utils/collections';
 import { toDocumentSegment } from '../utils/cst-util';
 import { stream } from '../utils/stream';
+import { relativeURI } from '../utils/uri-utils';
 import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from '../validation/validation-registry';
 import { LangiumDocument, LangiumDocuments } from '../workspace/documents';
 import * as ast from './generated/ast';
@@ -386,7 +386,7 @@ export class LangiumGrammarValidator {
             const grammar = document.parseResult.value;
             // Only check if the rule is sourced from another document
             if (ast.isGrammar(grammar) && refDoc !== document && !importedDocuments.has(refDoc)) {
-                let relative = path.relative(Utils.dirname(document.uri).fsPath, refDoc.uri.fsPath);
+                let relative = relativeURI(Utils.dirname(document.uri), refDoc.uri);
                 if (relative.endsWith('.langium')) {
                     relative = relative.substring(0, relative.length - '.langium'.length);
                 }

--- a/packages/langium/src/index.ts
+++ b/packages/langium/src/index.ts
@@ -34,6 +34,7 @@ export * from './utils/ast-util';
 export * from './utils/collections';
 export * from './utils/cst-util';
 export * from './utils/promise-util';
+export * from './utils/uri-utils';
 export * from './utils/regex-util';
 export * from './utils/stream';
 export * from './validation/document-validator';

--- a/packages/langium/src/lsp/document-highlighter.ts
+++ b/packages/langium/src/lsp/document-highlighter.ts
@@ -12,6 +12,7 @@ import { AstNode, CstNode, Reference } from '../syntax-tree';
 import { findLocalReferences, getDocument } from '../utils/ast-util';
 import { findLeafNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
+import { equalURI } from '../utils/uri-utils';
 import { LangiumDocument } from '../workspace/documents';
 
 /**
@@ -48,7 +49,7 @@ export class DefaultDocumentHighlighter implements DocumentHighlighter {
         const targetAstNode = this.references.findDeclaration(selectedNode)?.element;
         if (targetAstNode) {
             const refs: Array<[CstNode, DocumentHighlightKind]> = [];
-            if (getDocument(targetAstNode).uri.toString() === document.uri.toString()) {
+            if (equalURI(getDocument(targetAstNode).uri, document.uri)) {
                 const nameNode = this.findNameNode(targetAstNode);
                 if (nameNode) {
                     refs.push([nameNode, this.getHighlightKind(nameNode)]);

--- a/packages/langium/src/utils/uri-utils.ts
+++ b/packages/langium/src/utils/uri-utils.ts
@@ -1,0 +1,27 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { URI } from 'vscode-uri';
+
+export function equalURI(a?: URI | string, b?: URI | string): boolean {
+    return a?.toString() === b?.toString();
+}
+
+export function relativeURI(from: URI, to: URI): string {
+    const fromPath = from.path;
+    const toPath = to.path;
+    const fromParts = fromPath.split('/').filter(e => e.length > 0);
+    const toParts = toPath.split('/').filter(e => e.length > 0);
+    let i = 0;
+    for (; i < fromParts.length; i++) {
+        if (fromParts[i] !== toParts[i]) {
+            break;
+        }
+    }
+    const backPart = '../'.repeat(fromParts.length - i);
+    const toPart = toParts.slice(i).join('/');
+    return backPart + toPart;
+}

--- a/packages/langium/src/workspace/ast-descriptions.ts
+++ b/packages/langium/src/workspace/ast-descriptions.ts
@@ -12,6 +12,7 @@ import { AstNode, AstNodeDescription } from '../syntax-tree';
 import { getDocument, isLinkingError, streamAst, streamContents, streamReferences } from '../utils/ast-util';
 import { toDocumentSegment } from '../utils/cst-util';
 import { interruptAndCheck } from '../utils/promise-util';
+import { equalURI } from '../utils/uri-utils';
 import { AstNodeLocator } from './ast-node-locator';
 import { DocumentSegment, LangiumDocument } from './documents';
 
@@ -146,7 +147,7 @@ export class DefaultReferenceDescriptionProvider implements ReferenceDescription
                         targetUri: refAstNodeDescr.documentUri,
                         targetPath: refAstNodeDescr.path,
                         segment: toDocumentSegment(refCstNode),
-                        local: refAstNodeDescr.documentUri.toString() === docUri.toString()
+                        local: equalURI(refAstNodeDescr.documentUri, docUri)
                     };
                     descr.push(refDescr);
                 }

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -71,10 +71,6 @@ export interface DocumentSegment {
     readonly end: number
 }
 
-export function equalURI(uri1: URI, uri2: URI): boolean {
-    return uri1.toString() === uri2.toString();
-}
-
 /**
  * Shared service for creating `TextDocument` instances.
  * @deprecated This service is no longer necessary and will be removed.

--- a/packages/langium/src/workspace/file-system-provider.ts
+++ b/packages/langium/src/workspace/file-system-provider.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import fs from 'fs';
+import * as fs from 'fs';
 import { URI, Utils } from 'vscode-uri';
 
 export interface FileSystemNode {
@@ -34,6 +34,22 @@ export interface FileSystemProvider {
      * @returns The list of file system entries that are contained within the specified directory.
      */
     readDirectory(uri: URI): Promise<FileSystemNode[]>;
+}
+
+export class EmptyFileSystemProvider implements FileSystemProvider {
+
+    readFile(): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+
+    readFileSync(): string {
+        throw new Error('Method not implemented.');
+    }
+
+    async readDirectory(): Promise<FileSystemNode[]> {
+        return [];
+    }
+
 }
 
 export type NodeTextEncoding = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'latin1';

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -4,7 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import path from 'path';
 import { WorkspaceFolder } from 'vscode-languageserver';
 import { URI, Utils } from 'vscode-uri';
 import { ServiceRegistry } from '../service-registry';
@@ -108,7 +107,8 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
         if (entry.isDirectory) {
             return name !== 'node_modules' && name !== 'out';
         } else if (entry.isFile) {
-            return fileExtensions.includes(path.extname(name));
+            const extname = Utils.extname(entry.uri);
+            return fileExtensions.includes(extname);
         }
         return false;
     }

--- a/packages/langium/test/utils/uri-utils.test.ts
+++ b/packages/langium/test/utils/uri-utils.test.ts
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { URI } from 'vscode-uri';
+import { relativeURI, equalURI } from '../../src/utils/uri-utils';
+
+describe('URI Utils', () => {
+    test('relative path in same directory', () => {
+        const from = URI.file('/a/b');
+        const to = URI.file('/a/b/d.txt');
+        expect(relativeURI(from, to)).toBe('d.txt');
+    });
+
+    test('relative path in parent directory', () => {
+        const from = URI.file('/a/b');
+        const to = URI.file('a/d.txt');
+        expect(relativeURI(from, to)).toBe('../d.txt');
+    });
+
+    test('relative path in sub directory', () => {
+        const from = URI.file('/a');
+        const to = URI.file('/a/b/c.txt');
+        expect(relativeURI(from, to)).toBe('b/c.txt');
+    });
+
+    test('relative path in other directory', () => {
+        const from = URI.file('/a/b');
+        const to = URI.file('/a/c/d.txt');
+        expect(relativeURI(from, to)).toBe('../c/d.txt');
+    });
+
+    test('Equal uris are equal', () => {
+        const uri1 = 'file:///a/b';
+        const uri2 = 'file:///a/b';
+        expect(equalURI(uri1, uri2)).toBeTruthy();
+        expect(equalURI(URI.parse(uri1), URI.parse(uri2))).toBeTruthy();
+        expect(equalURI(uri1, URI.parse(uri2))).toBeTruthy();
+        expect(equalURI(URI.parse(uri1), uri2)).toBeTruthy();
+    });
+
+    test('Non-equal uris are not equal', () => {
+        const uri1 = 'file:///a/b';
+        const uri2 = 'file:///c/b';
+        expect(equalURI(uri1, uri2)).toBeFalsy();
+        expect(equalURI(URI.parse(uri1), URI.parse(uri2))).toBeFalsy();
+        expect(equalURI(uri1, URI.parse(uri2))).toBeFalsy();
+        expect(equalURI(URI.parse(uri1), uri2)).toBeFalsy();
+        expect(equalURI(uri1, undefined)).toBeFalsy();
+    });
+});


### PR DESCRIPTION
Also adds some more uri utility functions, which replace the functionality of the `path` dependency.