### PR TITLE
Refactor reference ID sourcing

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -115,7 +115,7 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
 
 export type ArithmeticsAstType = 'AbstractDefinition' | 'BinaryExpression' | 'DeclaredParameter' | 'Definition' | 'Evaluation' | 'Expression' | 'FunctionCall' | 'Module' | 'NumberLiteral' | 'Statement';
 
-export type ArithmeticsAstReference = 'FunctionCall:func';
+export type ArithmeticsAstReference = 'PrimaryExpression:func';
 
 export class ArithmeticsAstReflection implements AstReflection {
 
@@ -154,7 +154,7 @@ export class ArithmeticsAstReflection implements AstReflection {
 
     getReferenceType(referenceId: ArithmeticsAstReference): string {
         switch (referenceId) {
-            case 'FunctionCall:func': {
+            case 'PrimaryExpression:func': {
                 return AbstractDefinition;
             }
             default: {

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -29,7 +29,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -41,7 +42,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Statement"
+                "$refText": "Statement",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
@@ -64,14 +66,16 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Definition"
+              "$refText": "Definition",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Evaluation"
+              "$refText": "Evaluation",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -101,7 +105,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -120,7 +125,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "DeclaredParameter"
+                    "$refText": "DeclaredParameter",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -139,7 +145,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "DeclaredParameter"
+                        "$refText": "DeclaredParameter",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -165,7 +172,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Expression"
+                "$refText": "Expression",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -193,7 +201,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refId": "RuleCall:rule"
           },
           "arguments": []
         }
@@ -218,7 +227,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Expression"
+                "$refText": "Expression",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -242,7 +252,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
       "alternatives": {
         "$type": "RuleCall",
         "rule": {
-          "$refText": "Addition"
+          "$refText": "Addition",
+          "$refId": "RuleCall:rule"
         },
         "arguments": []
       },
@@ -266,7 +277,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Multiplication"
+              "$refText": "Multiplication",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -307,7 +319,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Multiplication"
+                    "$refText": "Multiplication",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -337,7 +350,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PrimaryExpression"
+              "$refText": "PrimaryExpression",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -378,7 +392,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "PrimaryExpression"
+                    "$refText": "PrimaryExpression",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -415,7 +430,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "Expression"
+                  "$refText": "Expression",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               },
@@ -442,7 +458,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NUMBER"
+                    "$refText": "NUMBER",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -466,7 +483,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractDefinition"
+                    "$refText": "AbstractDefinition",
+                    "$refId": "CrossReference:type"
                   },
                   "deprecatedSyntax": false
                 }
@@ -485,7 +503,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Expression"
+                        "$refText": "Expression",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -504,7 +523,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "Expression"
+                            "$refText": "Expression",
+                            "$refId": "RuleCall:rule"
                           },
                           "arguments": []
                         }
@@ -592,7 +612,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Definition"
+            "$refText": "Definition",
+            "$refId": "AtomType:refType"
           },
           "isArray": false,
           "isRef": false
@@ -600,7 +621,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ||(loa
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "DeclaredParameter"
+            "$refText": "DeclaredParameter",
+            "$refId": "AtomType:refType"
           },
           "isArray": false,
           "isRef": false

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -22,7 +22,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "AbstractElement"
+            "$refText": "AbstractElement",
+            "$refId": "RuleCall:rule"
           },
           "arguments": []
         },
@@ -43,14 +44,16 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PackageDeclaration"
+              "$refText": "PackageDeclaration",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Type"
+              "$refText": "Type",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -80,7 +83,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "QualifiedName"
+                "$refText": "QualifiedName",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -96,7 +100,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AbstractElement"
+                "$refText": "AbstractElement",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
@@ -124,14 +129,16 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "DataType"
+              "$refText": "DataType",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Entity"
+              "$refText": "Entity",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -161,7 +168,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -192,7 +200,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -211,12 +220,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Entity"
+                    "$refText": "Entity",
+                    "$refId": "CrossReference:type"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "QualifiedName"
+                      "$refText": "QualifiedName",
+                      "$refId": "RuleCall:rule"
                     },
                     "arguments": []
                   },
@@ -237,7 +248,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Feature"
+                "$refText": "Feature",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
@@ -279,7 +291,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -295,12 +308,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "Type"
+                "$refText": "Type",
+                "$refId": "CrossReference:type"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "QualifiedName"
+                  "$refText": "QualifiedName",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               },
@@ -326,7 +341,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$refText": "ID",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -340,7 +356,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ||(loa
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               }

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -29,7 +29,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -48,7 +49,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Event"
+                    "$refText": "Event",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 },
@@ -71,7 +73,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Command"
+                    "$refText": "Command",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 },
@@ -91,7 +94,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "State"
+                "$refText": "State",
+                "$refId": "CrossReference:type"
               },
               "deprecatedSyntax": false
             }
@@ -103,7 +107,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "State"
+                "$refText": "State",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
@@ -127,7 +132,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refId": "RuleCall:rule"
           },
           "arguments": []
         }
@@ -149,7 +155,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refId": "RuleCall:rule"
           },
           "arguments": []
         }
@@ -178,7 +185,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -201,7 +209,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Command"
+                    "$refText": "Command",
+                    "$refId": "CrossReference:type"
                   },
                   "deprecatedSyntax": false
                 },
@@ -221,7 +230,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Transition"
+                "$refText": "Transition",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
@@ -253,7 +263,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "Event"
+                "$refText": "Event",
+                "$refId": "CrossReference:type"
               },
               "deprecatedSyntax": false
             }
@@ -269,7 +280,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ||(l
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "State"
+                "$refText": "State",
+                "$refId": "CrossReference:type"
               },
               "deprecatedSyntax": false
             }

--- a/packages/langium/src/grammar/ast-reflection-interpreter.ts
+++ b/packages/langium/src/grammar/ast-reflection-interpreter.ts
@@ -22,7 +22,7 @@ export function interpretAstReflection(grammar: Grammar, documents?: LangiumDocu
         emptyDocuments = createLangiumGrammarServices().shared.workspace.LangiumDocuments;
     }
     const collectedTypes = collectAst(documents ?? emptyDocuments, [grammar]);
-    const allTypes = collectedTypes.interfaces.map(e => e.name).concat(collectedTypes.unions.map(e => e.name));
+    const allTypes = collectedTypes.interfaces.map(e => e.name).concat(collectedTypes.unions.map(e => e.name)).sort();
     const references = buildCrossReferenceTypes(grammar.rules.filter(isParserRule));
     const metaData = buildTypeMetaData(collectedTypes);
     const superTypeMap = buildSupertypeMap(collectedTypes);

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -455,7 +455,7 @@ export function isWildcard(item: unknown): item is Wildcard {
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'InferredType' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 
-export type LangiumGrammarAstReference = 'Action:type' | 'AtomType:refType' | 'CrossReference:type' | 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'ParserRule:returnType' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
+export type LangiumGrammarAstReference = 'Action:type' | 'AtomType:refType' | 'CrossReference:type' | 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'ParserRule:returnType' | 'PredicatedRuleCall:rule' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
 
 export class LangiumGrammarAstReflection implements AstReflection {
 
@@ -546,6 +546,9 @@ export class LangiumGrammarAstReflection implements AstReflection {
             }
             case 'ParserRule:returnType': {
                 return AbstractType;
+            }
+            case 'PredicatedRuleCall:rule': {
+                return AbstractRule;
             }
             case 'RuleCall:rule': {
                 return AbstractRule;

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "ID"
+                    "$refText": "ID",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -57,12 +58,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "Grammar"
+                        "$refText": "Grammar",
+                        "$refId": "CrossReference:type"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$refText": "ID"
+                          "$refText": "ID",
+                          "$refId": "RuleCall:rule"
                         },
                         "arguments": []
                       },
@@ -83,12 +86,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "Grammar"
+                            "$refText": "Grammar",
+                            "$refId": "CrossReference:type"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refId": "RuleCall:rule"
                             },
                             "arguments": []
                           },
@@ -127,12 +132,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractRule"
+                            "$refText": "AbstractRule",
+                            "$refId": "CrossReference:type"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refId": "RuleCall:rule"
                             },
                             "arguments": []
                           },
@@ -153,12 +160,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                             "terminal": {
                               "$type": "CrossReference",
                               "type": {
-                                "$refText": "AbstractRule"
+                                "$refText": "AbstractRule",
+                                "$refId": "CrossReference:type"
                               },
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$refText": "ID"
+                                  "$refText": "ID",
+                                  "$refId": "RuleCall:rule"
                                 },
                                 "arguments": []
                               },
@@ -188,7 +197,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "GrammarImport"
+                "$refText": "GrammarImport",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
@@ -204,7 +214,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractRule"
+                    "$refText": "AbstractRule",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -216,7 +227,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Interface"
+                    "$refText": "Interface",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -228,7 +240,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Type"
+                    "$refText": "Type",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -261,7 +274,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -280,7 +294,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractType"
+                    "$refText": "AbstractType",
+                    "$refId": "CrossReference:type"
                   },
                   "deprecatedSyntax": false
                 }
@@ -299,7 +314,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "AbstractType"
+                        "$refText": "AbstractType",
+                        "$refId": "CrossReference:type"
                       },
                       "deprecatedSyntax": false
                     }
@@ -313,7 +329,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "SchemaType"
+              "$refText": "SchemaType",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -344,7 +361,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TypeAttribute"
+                "$refText": "TypeAttribute",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
@@ -380,7 +398,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -402,7 +421,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TypeAlternatives"
+              "$refText": "TypeAlternatives",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -434,7 +454,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AtomType"
+                "$refText": "AtomType",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -453,7 +474,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AtomType"
+                    "$refText": "AtomType",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -488,7 +510,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "PrimitiveType"
+                        "$refText": "PrimitiveType",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -513,7 +536,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractType"
+                            "$refText": "AbstractType",
+                            "$refId": "CrossReference:type"
                           },
                           "deprecatedSyntax": false
                         }
@@ -541,7 +565,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Keyword"
+                "$refText": "Keyword",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -608,7 +633,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -620,7 +646,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TypeAlternatives"
+              "$refText": "TypeAlternatives",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -647,14 +674,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParserRule"
+              "$refText": "ParserRule",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalRule"
+              "$refText": "TerminalRule",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -684,7 +713,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$refText": "STRING",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -736,7 +766,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleNameAndParams"
+              "$refText": "RuleNameAndParams",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -769,12 +800,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractType"
+                            "$refText": "AbstractType",
+                            "$refId": "CrossReference:type"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refId": "RuleCall:rule"
                             },
                             "arguments": []
                           },
@@ -788,7 +821,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "PrimitiveType"
+                            "$refText": "PrimitiveType",
+                            "$refId": "RuleCall:rule"
                           },
                           "arguments": []
                         }
@@ -804,7 +838,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "InferredType"
+                    "$refText": "InferredType",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": [
                     {
@@ -847,12 +882,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "AbstractRule"
+                        "$refText": "AbstractRule",
+                        "$refId": "CrossReference:type"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$refText": "ID"
+                          "$refText": "ID",
+                          "$refId": "RuleCall:rule"
                         },
                         "arguments": []
                       },
@@ -873,12 +910,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractRule"
+                            "$refText": "AbstractRule",
+                            "$refId": "CrossReference:type"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refId": "RuleCall:rule"
                             },
                             "arguments": []
                           },
@@ -909,7 +948,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Alternatives"
+                "$refText": "Alternatives",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -947,7 +987,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "guardCondition": {
                   "$type": "ParameterReference",
                   "parameter": {
-                    "$refText": "imperative"
+                    "$refText": "imperative",
+                    "$refId": "ParameterReference:parameter"
                   }
                 },
                 "elements": [
@@ -964,7 +1005,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "value": {
                     "$type": "ParameterReference",
                     "parameter": {
-                      "$refText": "imperative"
+                      "$refText": "imperative",
+                      "$refId": "ParameterReference:parameter"
                     }
                   }
                 },
@@ -984,7 +1026,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -1011,7 +1054,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -1033,7 +1077,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Parameter"
+                        "$refText": "Parameter",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -1052,7 +1097,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "Parameter"
+                            "$refText": "Parameter",
+                            "$refId": "RuleCall:rule"
                           },
                           "arguments": []
                         }
@@ -1088,7 +1134,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refId": "RuleCall:rule"
           },
           "arguments": []
         }
@@ -1113,7 +1160,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ConditionalBranch"
+              "$refText": "ConditionalBranch",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -1143,7 +1191,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ConditionalBranch"
+                        "$refText": "ConditionalBranch",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -1176,7 +1225,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "UnorderedGroup"
+              "$refText": "UnorderedGroup",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -1201,7 +1251,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Disjunction"
+                    "$refText": "Disjunction",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -1217,7 +1268,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractToken"
+                    "$refText": "AbstractToken",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 },
@@ -1247,7 +1299,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Group"
+              "$refText": "Group",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -1277,7 +1330,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Group"
+                        "$refText": "Group",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -1310,7 +1364,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AbstractToken"
+              "$refText": "AbstractToken",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -1333,7 +1388,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractToken"
+                    "$refText": "AbstractToken",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 },
@@ -1364,14 +1420,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AbstractTokenWithCardinality"
+              "$refText": "AbstractTokenWithCardinality",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Action"
+              "$refText": "Action",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -1400,14 +1458,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "Assignment"
+                  "$refText": "Assignment",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               },
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "AbstractTerminal"
+                  "$refText": "AbstractTerminal",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               }
@@ -1476,12 +1536,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractType"
+                    "$refText": "AbstractType",
+                    "$refId": "CrossReference:type"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "ID"
+                      "$refText": "ID",
+                      "$refId": "RuleCall:rule"
                     },
                     "arguments": []
                   },
@@ -1495,7 +1557,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "InferredType"
+                    "$refText": "InferredType",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": [
                     {
@@ -1525,7 +1588,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "FeatureName"
+                    "$refText": "FeatureName",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -1581,42 +1645,48 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$refText": "Keyword",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$refText": "RuleCall",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedElement"
+              "$refText": "ParenthesizedElement",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedKeyword"
+              "$refText": "PredicatedKeyword",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedRuleCall"
+              "$refText": "PredicatedRuleCall",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedGroup"
+              "$refText": "PredicatedGroup",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -1639,7 +1709,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "STRING"
+            "$refText": "STRING",
+            "$refId": "RuleCall:rule"
           },
           "arguments": []
         }
@@ -1664,12 +1735,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractRule"
+                "$refText": "AbstractRule",
+                "$refId": "CrossReference:type"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               },
@@ -1690,7 +1763,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NamedArgument"
+                    "$refText": "NamedArgument",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -1709,7 +1783,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "NamedArgument"
+                        "$refText": "NamedArgument",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -1749,12 +1824,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Parameter"
+                    "$refText": "Parameter",
+                    "$refId": "CrossReference:type"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "ID"
+                      "$refText": "ID",
+                      "$refId": "RuleCall:rule"
                     },
                     "arguments": []
                   },
@@ -1780,7 +1857,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Disjunction"
+                "$refText": "Disjunction",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -1835,7 +1913,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Conjunction"
+              "$refText": "Conjunction",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -1862,7 +1941,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Conjunction"
+                    "$refText": "Conjunction",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -1892,7 +1972,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Negation"
+              "$refText": "Negation",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -1919,7 +2000,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Negation"
+                    "$refText": "Negation",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -1949,7 +2031,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Atom"
+              "$refText": "Atom",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -1974,7 +2057,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Negation"
+                    "$refText": "Negation",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -2003,21 +2087,24 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParameterReference"
+              "$refText": "ParameterReference",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedCondition"
+              "$refText": "ParenthesizedCondition",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "LiteralCondition"
+              "$refText": "LiteralCondition",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -2047,7 +2134,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Disjunction"
+              "$refText": "Disjunction",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -2074,12 +2162,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$refText": "Parameter"
+            "$refText": "Parameter",
+            "$refId": "CrossReference:type"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$refText": "ID",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -2123,7 +2213,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$refText": "STRING",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -2167,12 +2258,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractRule"
+                "$refText": "AbstractRule",
+                "$refId": "CrossReference:type"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               },
@@ -2193,7 +2286,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NamedArgument"
+                    "$refText": "NamedArgument",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -2212,7 +2306,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "NamedArgument"
+                        "$refText": "NamedArgument",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -2274,7 +2369,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "FeatureName"
+                "$refText": "FeatureName",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -2308,7 +2404,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AssignableTerminal"
+                "$refText": "AssignableTerminal",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -2335,28 +2432,32 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$refText": "Keyword",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$refText": "RuleCall",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedAssignableElement"
+              "$refText": "ParenthesizedAssignableElement",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "CrossReference"
+              "$refText": "CrossReference",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -2386,7 +2487,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AssignableAlternatives"
+              "$refText": "AssignableAlternatives",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -2416,7 +2518,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AssignableTerminal"
+              "$refText": "AssignableTerminal",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -2446,7 +2549,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "AssignableTerminal"
+                        "$refText": "AssignableTerminal",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -2494,7 +2598,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractType"
+                "$refText": "AbstractType",
+                "$refId": "CrossReference:type"
               },
               "deprecatedSyntax": false
             }
@@ -2527,7 +2632,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "CrossReferenceableTerminal"
+                    "$refText": "CrossReferenceableTerminal",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -2561,14 +2667,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$refText": "Keyword",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$refText": "RuleCall",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -2598,7 +2706,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Alternatives"
+              "$refText": "Alternatives",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -2649,7 +2758,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Alternatives"
+                "$refText": "Alternatives",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -2680,14 +2790,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "PrimitiveType"
+                "$refText": "PrimitiveType",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             },
             {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -2743,7 +2855,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ID"
+                        "$refText": "ID",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -2760,7 +2873,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ID"
+                        "$refText": "ID",
+                        "$refId": "RuleCall:rule"
                       },
                       "arguments": []
                     }
@@ -2779,7 +2893,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "ReturnType"
+                            "$refText": "ReturnType",
+                            "$refId": "RuleCall:rule"
                           },
                           "arguments": []
                         }
@@ -2802,7 +2917,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalAlternatives"
+                "$refText": "TerminalAlternatives",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -2847,7 +2963,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalGroup"
+              "$refText": "TerminalGroup",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -2874,7 +2991,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "TerminalGroup"
+                    "$refText": "TerminalGroup",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -2904,7 +3022,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalToken"
+              "$refText": "TerminalToken",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -2927,7 +3046,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "TerminalToken"
+                    "$refText": "TerminalToken",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 },
@@ -2958,7 +3078,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalTokenElement"
+              "$refText": "TerminalTokenElement",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -3007,49 +3128,56 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "CharacterRange"
+              "$refText": "CharacterRange",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalRuleCall"
+              "$refText": "TerminalRuleCall",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedTerminalElement"
+              "$refText": "ParenthesizedTerminalElement",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "NegatedToken"
+              "$refText": "NegatedToken",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "UntilToken"
+              "$refText": "UntilToken",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RegexToken"
+              "$refText": "RegexToken",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Wildcard"
+              "$refText": "Wildcard",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -3079,7 +3207,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalAlternatives"
+              "$refText": "TerminalAlternatives",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
@@ -3120,12 +3249,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "TerminalRule"
+                "$refText": "TerminalRule",
+                "$refId": "CrossReference:type"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refId": "RuleCall:rule"
                 },
                 "arguments": []
               },
@@ -3169,7 +3300,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalTokenElement"
+                "$refText": "TerminalTokenElement",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -3211,7 +3343,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalTokenElement"
+                "$refText": "TerminalTokenElement",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -3249,7 +3382,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "RegexLiteral"
+                "$refText": "RegexLiteral",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -3317,7 +3451,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Keyword"
+                "$refText": "Keyword",
+                "$refId": "RuleCall:rule"
               },
               "arguments": []
             }
@@ -3336,7 +3471,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Keyword"
+                    "$refText": "Keyword",
+                    "$refId": "RuleCall:rule"
                   },
                   "arguments": []
                 }
@@ -3427,14 +3563,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PrimitiveType"
+              "$refText": "PrimitiveType",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$refText": "ID",
+              "$refId": "RuleCall:rule"
             },
             "arguments": []
           }
@@ -3505,7 +3643,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Interface"
+            "$refText": "Interface",
+            "$refId": "AtomType:refType"
           },
           "isArray": false,
           "isRef": false
@@ -3513,7 +3652,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Type"
+            "$refText": "Type",
+            "$refId": "AtomType:refType"
           },
           "isArray": false,
           "isRef": false
@@ -3521,7 +3661,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Action"
+            "$refText": "Action",
+            "$refId": "AtomType:refType"
           },
           "isArray": false,
           "isRef": false
@@ -3529,7 +3670,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "ParserRule"
+            "$refText": "ParserRule",
+            "$refId": "AtomType:refType"
           },
           "isArray": false,
           "isRef": false

--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -8,6 +8,7 @@ import { CancellationToken, CompletionItem, CompletionItemKind, CompletionList, 
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
 import * as ast from '../../grammar/generated/ast';
 import { getTypeNameAtElement } from '../../grammar/grammar-util';
+import { getReferenceId } from '../../references/linker';
 import { isNamed } from '../../references/naming';
 import { ScopeProvider } from '../../references/scope';
 import { LangiumServices } from '../../services';
@@ -128,7 +129,7 @@ export class DefaultCompletionProvider implements CompletionProvider {
         const assignment = getContainerOfType(crossRef, ast.isAssignment);
         const parserRule = getContainerOfType(crossRef, ast.isParserRule);
         if (assignment && parserRule) {
-            const scope = this.scopeProvider.getScope(context, `${getTypeNameAtElement(parserRule, assignment)}:${assignment.feature}`);
+            const scope = this.scopeProvider.getScope(context, getReferenceId(getTypeNameAtElement(parserRule, assignment), assignment.feature));
             const duplicateStore = new Set<string>();
             scope.getAllElements().forEach(e => {
                 if (!duplicateStore.has(e.name)) {

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -55,7 +55,7 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 }
                 // If it is a reference, just return the name
                 if (isReference(item)) {
-                    return { $refText: item.$refText } as Reference; // surprisingly this cast works at the time of writing, although $refNode is absent
+                    return { $refText: item.$refText, $refId: item.$refId } as Reference; // surprisingly this cast works at the time of writing, although $refNode is absent
                 }
                 let newItem: Record<string, unknown> | unknown[];
                 // If it is an array, replicate the array.
@@ -88,8 +88,7 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
                     if (isReference(item) && isAstNode(container)) {
-                        const refId = getReferenceId(container.$type, propName!);
-                        const reference = this.linker.buildReference(container, item.$refNode, refId, item.$refText);
+                        const reference = this.linker.buildReference(container, item.$refNode, item.$refId, item.$refText);
                         value[i] = reference;
                     } else if (typeof item === 'object' && item !== null) {
                         internalRevive(item);

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -49,6 +49,8 @@ export interface Reference<T extends AstNode = AstNode> {
     readonly $refNode: CstNode;
     /** The actual text used to look up in the surrounding scope */
     readonly $refText: string;
+    /** A unique identifier for the cross reference type */
+    readonly $refId: string;
     /** The node description for the AstNode returned by `ref`  */
     readonly $nodeDescription?: AstNodeDescription;
 }

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -14,7 +14,9 @@ import { escapeRegExp } from '../utils/regex-util';
 import { LangiumDocument } from '../workspace/documents';
 import { findNodeForFeature } from '../grammar/grammar-util';
 
-export function parseHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string) => Promise<LangiumDocument<T>> {
+export type ParseHelper<T extends AstNode> = (input: string) => Promise<LangiumDocument<T>>
+
+export function parseHelper<T extends AstNode = AstNode>(services: LangiumServices): ParseHelper<T> {
     const metaData = services.LanguageMetaData;
     const documentBuilder = services.shared.workspace.DocumentBuilder;
     return async input => {

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -4,12 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { URI } from 'vscode-uri';
 import { AstNode, createDefaultModule, createDefaultSharedModule, createLangiumGrammarServices, Grammar, inject, interpretAstReflection, IParserConfig, LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumParser, LangiumServices, LangiumSharedServices, LanguageMetaData, Module } from '../../src';
-import { parseHelper } from '../../src/test';
+import { ParseHelper, parseHelper } from '../../src/test';
 
 const grammarServices = createLangiumGrammarServices().grammar;
-const helper = parseHelper<Grammar>(grammarServices);
+const grammarHelper = parseHelper<Grammar>(grammarServices);
 
 describe('Predicated grammar rules with alternatives', () => {
 
@@ -35,7 +34,7 @@ describe('Predicated grammar rules with alternatives', () => {
     `;
 
     beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
+        const grammar = (await grammarHelper(content)).parseResult.value;
         parser = servicesFromGrammar(grammar).parser.LangiumParser;
     });
 
@@ -112,7 +111,7 @@ describe('Predicated groups', () => {
     `;
 
     beforeAll(async () => {
-        grammar = (await helper(content)).parseResult.value;
+        grammar = (await grammarHelper(content)).parseResult.value;
         parser = servicesFromGrammar(grammar).parser.LangiumParser;
     });
 
@@ -200,7 +199,7 @@ describe('Handle unordered group', () => {
     `;
 
     beforeAll(async () => {
-        grammar = (await helper(content)).parseResult.value;
+        grammar = (await grammarHelper(content)).parseResult.value;
     });
 
     let parser: LangiumParser;
@@ -309,7 +308,7 @@ describe('One name for terminal and non-terminal rules', () => {
     `;
 
     beforeAll(async () => {
-        grammar = (await helper(content)).parseResult.value;
+        grammar = (await grammarHelper(content)).parseResult.value;
     });
 
     test('Should work without Parser Definition Errors', () => {
@@ -329,7 +328,7 @@ describe('Boolean value converter', () => {
     `;
 
     beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
+        const grammar = (await grammarHelper(content)).parseResult.value;
         parser = servicesFromGrammar(grammar).parser.LangiumParser;
     });
 
@@ -361,7 +360,7 @@ describe('BigInt Parser value converter', () => {
     `;
 
     beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
+        const grammar = (await grammarHelper(content)).parseResult.value;
         parser = servicesFromGrammar(grammar).parser.LangiumParser;
     });
 
@@ -390,7 +389,7 @@ describe('Date Parser value converter', () => {
     `;
 
     beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
+        const grammar = (await grammarHelper(content)).parseResult.value;
         parser = servicesFromGrammar(grammar).parser.LangiumParser;
     });
 
@@ -433,7 +432,7 @@ describe('Parser calls value converter', () => {
     `;
 
     beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
+        const grammar = (await grammarHelper(content)).parseResult.value;
         parser = servicesFromGrammar(grammar).parser.LangiumParser;
     });
 
@@ -501,7 +500,8 @@ describe('Parser calls value converter', () => {
 
 describe('Fragment parsing', () => {
 
-    let services: LangiumServices;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let helper: ParseHelper<any>;
     const content = `
     grammar TestGrammar
     entry Main: values+=(A | B)+;
@@ -515,16 +515,14 @@ describe('Fragment parsing', () => {
     `;
 
     beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
-        services = servicesFromGrammar(grammar);
+        const grammar = (await grammarHelper(content)).parseResult.value;
+        const services = servicesFromGrammar(grammar);
+        helper = parseHelper(services);
     });
 
     test('Resolves cross reference correctly', async () => {
-        const document = services.shared.workspace.LangiumDocumentFactory.fromString('a A b A', URI.parse('memory://x.test'));
-        services.shared.workspace.LangiumDocuments.addDocument(document);
-        await services.shared.workspace.DocumentBuilder.build([document]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const main = document.parseResult.value as any;
+        const main = (await helper('a A b A')).parseResult.value;
         const a = main.values[0];
         const b = main.values[1];
         expect(a.name).toBe('A');


### PR DESCRIPTION
Due to issues in fragment cross reference resolution, I had to refactor how all cross ref IDs are calculated. We should merge this before 0.4.

For reference: When creating a cross reference in a fragment, the cross reference can never be resolved (thanks to @gfontorbe for figuring this out)

```
Test: 'test' Frag;
fragment Frag: ref=[Item]; // Never resolves
```