### PR TITLE
Allow to create `LangiumServices` from a grammar string

### DIFF
--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -155,7 +155,7 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
     for (const grammar of grammars) {
         embedReferencedRules(grammar, ruleMap);
         // Create and validate the in-memory parser
-        const parserAnalysis = validateParser(grammar, config, configMap, documents);
+        const parserAnalysis = validateParser(grammar, config, configMap, grammarServices);
         if (parserAnalysis instanceof Error) {
             log('error', options, parserAnalysis.toString().red);
             return 'failure';

--- a/packages/langium-cli/src/parser-validation.ts
+++ b/packages/langium-cli/src/parser-validation.ts
@@ -4,17 +4,18 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { createServicesForGrammar, getDocument, Grammar, IParserConfig, isGrammar, isParserRule, LangiumDocuments, LangiumParser, LanguageMetaData, ParserRule, prepareLangiumParser } from 'langium';
+import { createServicesForGrammar, getDocument, Grammar, IParserConfig, isGrammar, isParserRule, LangiumDocuments, LangiumGrammarServices, LangiumParser, LanguageMetaData, ParserRule, prepareLangiumParser } from 'langium';
 import { getFilePath, LangiumConfig, LangiumLanguageConfig } from './package';
 
 export function validateParser(grammar: Grammar, config: LangiumConfig, grammarConfigMap: Map<Grammar, LangiumLanguageConfig>,
-    documents: LangiumDocuments): Error | undefined {
+    grammarServices: LangiumGrammarServices): Error | undefined {
     const parserConfig: IParserConfig = {
         ...config.chevrotainParserConfig,
         ...grammarConfigMap.get(grammar)?.chevrotainParserConfig,
         skipValidations: false
     };
     const services = createServicesForGrammar({
+        grammarServices,
         grammar,
         languageMetaData: languageConfigToMetaData(grammarConfigMap.get(grammar)!),
         parserConfig
@@ -33,7 +34,7 @@ export function validateParser(grammar: Grammar, config: LangiumConfig, grammarC
             for (const defError of parser.definitionErrors) {
                 message += '\n-------------------------------\n';
                 if (defError.ruleName) {
-                    const rule = findRule(defError.ruleName, grammar, documents);
+                    const rule = findRule(defError.ruleName, grammar, grammarServices.shared.workspace.LangiumDocuments);
                     if (rule && rule.$cstNode) {
                         const filePath = getFilePath(getDocument(rule).uri.fsPath, config);
                         const line = rule.$cstNode.range.start.line + 1;

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -5,10 +5,12 @@
  ******************************************************************************/
 
 import { URI, Utils } from 'vscode-uri';
-import { TypeResolutionError } from '..';
+import { createDefaultModule, createDefaultSharedModule } from '../default-module';
+import { inject, Module } from '../dependency-injection';
 import * as ast from '../grammar/generated/ast';
 import { CompositeCstNodeImpl } from '../parser/cst-node-builder';
-import { LangiumServices } from '../services';
+import { IParserConfig } from '../parser/parser-config';
+import { LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumServices, LangiumSharedServices } from '../services';
 import { AstNode, AstNodeDescription, CstNode } from '../syntax-tree';
 import { extractRootNode, getContainerOfType, getDocument, Mutable, streamAllContents } from '../utils/ast-util';
 import { MultiMap } from '../utils/collections';
@@ -17,7 +19,10 @@ import { escapeRegExp } from '../utils/regex-util';
 import { AstNodeDescriptionProvider } from '../workspace/ast-descriptions';
 import { AstNodeLocator } from '../workspace/ast-node-locator';
 import { LangiumDocument, LangiumDocuments, PrecomputedScopes } from '../workspace/documents';
-import { createLangiumGrammarServices } from './langium-grammar-module';
+import { interpretAstReflection } from './ast-reflection-interpreter';
+import { createLangiumGrammarServices, LangiumGrammarServices } from './langium-grammar-module';
+import { LanguageMetaData } from './language-meta-data';
+import { TypeResolutionError } from './type-system/types-util';
 
 export type Cardinality = '?' | '*' | '+' | undefined;
 export type Operator = '=' | '+=' | '?=' | undefined;
@@ -409,20 +414,59 @@ function resolveTransitiveImportsInternal(documents: LangiumDocuments, grammar: 
     return Array.from(grammars);
 }
 
+export function createServicesForGrammar(config: {
+    grammar: string | ast.Grammar,
+    grammarServices?: LangiumGrammarServices,
+    parserConfig?: IParserConfig,
+    languageMetaData?: LanguageMetaData,
+    module?: Module<LangiumServices>
+    sharedModule?: Module<LangiumSharedServices>
+}): LangiumServices {
+    const grammarServices = config.grammarServices ?? createLangiumGrammarServices().grammar;
+    const grammarNode = typeof config.grammar === 'string' ? grammarServices.parser.LangiumParser.parse<ast.Grammar>(config.grammar).value : config.grammar;
+    prepareGrammar(grammarServices, grammarNode);
+
+    const parserConfig = config.parserConfig ?? {
+        skipValidations: false
+    };
+    const languageMetaData = config.languageMetaData ?? {
+        caseInsensitive: false,
+        fileExtensions: ['.test'],
+        languageId: 'test'
+    };
+    const generatedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedServices> = {
+        AstReflection: () => interpretAstReflection(grammarNode),
+    };
+    const generatedModule: Module<LangiumServices, LangiumGeneratedServices> = {
+        Grammar: () => grammarNode,
+        LanguageMetaData: () => languageMetaData,
+        parser: {
+            ParserConfig: () => parserConfig
+        }
+    };
+    const shared = inject(createDefaultSharedModule(), generatedSharedModule, config.sharedModule);
+    const services = inject(createDefaultModule({ shared }), generatedModule, config.module);
+    return services;
+}
+
 export function loadGrammar(json: string): ast.Grammar {
     const services = createLangiumGrammarServices().grammar;
     const astNode = services.serializer.JsonSerializer.deserialize(json);
     if (!ast.isGrammar(astNode)) {
         throw new Error('Could not load grammar from specified json input.');
     }
-    const grammar = astNode as Mutable<ast.Grammar>;
+    return prepareGrammar(services, astNode);
+}
+
+function prepareGrammar(services: LangiumServices, grammar: ast.Grammar): ast.Grammar {
+    const mutableGrammar = grammar as Mutable<ast.Grammar>;
     const document = services.shared.workspace.LangiumDocumentFactory.fromModel(grammar, URI.parse('memory://grammar.langium'));
-    grammar.$document = document;
+    mutableGrammar.$document = document;
     document.precomputedScopes = computeGrammarScope(services, grammar);
     return grammar;
 }
 
-export function computeGrammarScope(services: LangiumServices, grammar: ast.Grammar): PrecomputedScopes {
+function computeGrammarScope(services: LangiumServices, grammar: ast.Grammar): PrecomputedScopes {
     const nameProvider = services.references.NameProvider;
     const descriptions = services.workspace.AstNodeDescriptionProvider;
     const document = getDocument(grammar);
@@ -443,6 +487,7 @@ export function computeGrammarScope(services: LangiumServices, grammar: ast.Gram
     }
     return scopes;
 }
+
 /**
  * Add synthetic Interface in case of explicitly or implicitly inferred type:<br>
  * cases: `ParserRule: ...;` or `ParserRule infers Type: ...;`

--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -431,8 +431,8 @@ export function createServicesForGrammar(config: {
     };
     const languageMetaData = config.languageMetaData ?? {
         caseInsensitive: false,
-        fileExtensions: ['.test'],
-        languageId: 'test'
+        fileExtensions: [`.${grammarNode.name?.toLowerCase() ?? 'unknown'}`],
+        languageId: grammarNode.name ?? 'UNKNOWN'
     };
     const generatedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedServices> = {
         AstReflection: () => interpretAstReflection(grammarNode),

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -4,15 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstNode, createDefaultModule, createDefaultSharedModule, createLangiumGrammarServices, createLangiumParser, Grammar, inject, interpretAstReflection, IParserConfig, LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumParser, LangiumServices, LangiumSharedServices, Module } from '../../src';
-import { parseHelper } from '../../src/test';
-
-const grammarServices = createLangiumGrammarServices().grammar;
-const helper = parseHelper<Grammar>(grammarServices);
+import { AstNode, createServicesForGrammar, LangiumParser } from '../../src';
 
 describe('Predicated grammar rules with alternatives', () => {
 
-    let parser: LangiumParser;
     const content = `
     grammar TestGrammar
 
@@ -33,10 +28,7 @@ describe('Predicated grammar rules with alternatives', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
-        parser = parserFromGrammar(grammar);
-    });
+    const parser = parserFromGrammar(content);
 
     function hasProp(prop: string): void {
         const main = parser.parse(prop + '1').value;
@@ -48,40 +40,16 @@ describe('Predicated grammar rules with alternatives', () => {
         });
     }
 
-    test('Should parse RuleA correctly', () => {
-        hasProp('a');
-    });
-
-    test('Should parse RuleB correctly', () => {
-        hasProp('b');
-    });
-
-    test('Should parse RuleC correctly', () => {
-        hasProp('c');
-    });
-
-    test('Should parse RuleD correctly', () => {
-        hasProp('d');
-    });
-
-    test('Should parse RuleE correctly', () => {
-        hasProp('e');
-    });
-
-    test('Should parse RuleF correctly', () => {
-        hasProp('f');
-    });
-
-    test('Should parse RuleG correctly', () => {
-        hasProp('g');
-    });
-
+    for (const letter of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) {
+        const current = letter;
+        test(`Should parse Rule${current.toUpperCase()} correctly`, () => {
+            hasProp(current);
+        });
+    }
 });
 
 describe('Predicated groups', () => {
 
-    let grammar: Grammar;
-    let parser: LangiumParser;
     const content = `
     grammar TestGrammar
 
@@ -110,10 +78,7 @@ describe('Predicated groups', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    beforeAll(async () => {
-        grammar = (await helper(content)).parseResult.value;
-        parser = parserFromGrammar(grammar);
-    });
+    const parser = parserFromGrammar(content);
 
     function expectCorrectParse(text: string, a: number, b = 0): void {
         const result = parser.parse(text);
@@ -179,7 +144,7 @@ describe('Predicated groups', () => {
 });
 
 describe('Handle unordered group', () => {
-    let grammar: Grammar;
+
     const content = `
     grammar TestUnorderedGroup
     
@@ -198,17 +163,7 @@ describe('Handle unordered group', () => {
     terminal STRING: /"[^"]*"|'[^']*'/;
     `;
 
-    beforeAll(async () => {
-        grammar = (await helper(content)).parseResult.value;
-    });
-
-    let parser: LangiumParser;
-    test('Should work without Parser Definition Errors', () => {
-        expect(() => {
-            parser = parserFromGrammar(grammar);
-        }).not.toThrow();
-        expect(parser).not.toBeUndefined();
-    });
+    const parser = parserFromGrammar(content);
 
     test('Should parse documents without Errors', () => {
         type bookType = { version?: string, author?: string, descr?: string }
@@ -291,7 +246,6 @@ function parseAndCheck(model: string, parser: LangiumParser): AstNode {
 }
 
 describe('One name for terminal and non-terminal rules', () => {
-    let grammar: Grammar;
     const content = `
     grammar Test
 
@@ -307,30 +261,22 @@ describe('One name for terminal and non-terminal rules', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    beforeAll(async () => {
-        grammar = (await helper(content)).parseResult.value;
-    });
-
     test('Should work without Parser Definition Errors', () => {
         expect(() => {
-            parserFromGrammar(grammar);
+            parserFromGrammar(content);
         }).not.toThrow();
     });
 
 });
 
 describe('Boolean value converter', () => {
-    let parser: LangiumParser;
     const content = `
     grammar G
     entry M: value?='true';
     hidden terminal WS: /\\s+/;
     `;
 
-    beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
-        parser = parserFromGrammar(grammar);
-    });
+    const parser = parserFromGrammar(content);
 
     function expectValue(input: string, value: unknown): void {
         const main = parser.parse(input).value as unknown as { value: unknown };
@@ -351,7 +297,6 @@ describe('Boolean value converter', () => {
 });
 
 describe('BigInt Parser value converter', () => {
-    let parser: LangiumParser;
     const content = `
     grammar G
     entry M: value=BIGINT;
@@ -359,10 +304,7 @@ describe('BigInt Parser value converter', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
-        parser = parserFromGrammar(grammar);
-    });
+    const parser = parserFromGrammar(content);
 
     function expectValue(input: string, value: unknown): void {
         const main = parser.parse(input).value as unknown as { value: unknown };
@@ -380,7 +322,6 @@ describe('BigInt Parser value converter', () => {
 });
 
 describe('Date Parser value converter', () => {
-    let parser: LangiumParser;
     const content = `
     grammar G
     entry M: value=DATE;
@@ -388,10 +329,7 @@ describe('Date Parser value converter', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
-        parser = parserFromGrammar(grammar);
-    });
+    const parser = parserFromGrammar(content);
 
     test('Should have no definition errors', () => {
         expect(parser.definitionErrors).toHaveLength(0);
@@ -405,7 +343,6 @@ describe('Date Parser value converter', () => {
 
 describe('Parser calls value converter', () => {
 
-    let parser: LangiumParser;
     const content = `
     grammar TestGrammar
     entry Main:
@@ -431,10 +368,7 @@ describe('Parser calls value converter', () => {
     hidden terminal ML_COMMENT: /\\/\\*[\\s\\S]*?\\*\\//;
     `;
 
-    beforeAll(async () => {
-        const grammar = (await helper(content)).parseResult.value;
-        parser = parserFromGrammar(grammar);
-    });
+    const parser = parserFromGrammar(content);
 
     function expectValue(input: string, value: unknown): void {
         const main = parser.parse(input).value as unknown as { value: unknown };
@@ -498,23 +432,6 @@ describe('Parser calls value converter', () => {
     });
 });
 
-function parserFromGrammar(grammar: Grammar): LangiumParser {
-    const parserConfig: IParserConfig = {
-        skipValidations: false
-    };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const unavailable: () => any = () => ({});
-    const generatedSharedModule: Module<LangiumSharedServices, LangiumGeneratedSharedServices> = {
-        AstReflection: () => interpretAstReflection(grammar),
-    };
-    const generatedModule: Module<LangiumServices, LangiumGeneratedServices> = {
-        Grammar: () => grammar,
-        LanguageMetaData: unavailable,
-        parser: {
-            ParserConfig: () => parserConfig
-        }
-    };
-    const shared = inject(createDefaultSharedModule(), generatedSharedModule);
-    const services = inject(createDefaultModule({ shared }), generatedModule);
-    return createLangiumParser(services);
+function parserFromGrammar(grammar: string): LangiumParser {
+    return createServicesForGrammar({ grammar }).parser.LangiumParser;
 }


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/421

Allows us to delete quite a lot of code, as we needed a lot of async wrapping previously. The new method runs sync.