### PR TITLE
Handle workspace changes using a mutex

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -27,7 +27,7 @@ import { DefaultScopeComputation, DefaultScopeProvider } from './references/scop
 import { DefaultJsonSerializer } from './serializer/json-serializer';
 import { DefaultServiceRegistry } from './service-registry';
 import { LangiumDefaultServices, LangiumDefaultSharedServices, LangiumServices, LangiumSharedServices } from './services';
-import { ReadWriteMutex } from './utils/promise-util';
+import { MutexLock } from './utils/promise-util';
 import { DefaultDocumentValidator } from './validation/document-validator';
 import { ValidationRegistry } from './validation/validation-registry';
 import { DefaultAstNodeDescriptionProvider, DefaultReferenceDescriptionProvider } from './workspace/ast-descriptions';
@@ -119,7 +119,7 @@ export function createDefaultSharedModule(context: DefaultSharedModuleContext = 
             IndexManager: (services) => new DefaultIndexManager(services),
             WorkspaceManager: (services) => new DefaultWorkspaceManager(services),
             FileSystemProvider: () => new NodeFileSystemProvider(),
-            ReadWriteMutex: () => new ReadWriteMutex()
+            MutexLock: () => new MutexLock()
         }
     };
 }

--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -27,6 +27,7 @@ import { DefaultScopeComputation, DefaultScopeProvider } from './references/scop
 import { DefaultJsonSerializer } from './serializer/json-serializer';
 import { DefaultServiceRegistry } from './service-registry';
 import { LangiumDefaultServices, LangiumDefaultSharedServices, LangiumServices, LangiumSharedServices } from './services';
+import { ReadWriteMutex } from './utils/promise-util';
 import { DefaultDocumentValidator } from './validation/document-validator';
 import { ValidationRegistry } from './validation/validation-registry';
 import { DefaultAstNodeDescriptionProvider, DefaultReferenceDescriptionProvider } from './workspace/ast-descriptions';
@@ -117,7 +118,8 @@ export function createDefaultSharedModule(context: DefaultSharedModuleContext = 
             TextDocumentFactory: (services) => new DefaultTextDocumentFactory(services),
             IndexManager: (services) => new DefaultIndexManager(services),
             WorkspaceManager: (services) => new DefaultWorkspaceManager(services),
-            FileSystemProvider: () => new NodeFileSystemProvider()
+            FileSystemProvider: () => new NodeFileSystemProvider(),
+            ReadWriteMutex: () => new ReadWriteMutex()
         }
     };
 }

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -33,6 +33,7 @@ import type { ScopeComputation, ScopeProvider } from './references/scope';
 import type { JsonSerializer } from './serializer/json-serializer';
 import type { ServiceRegistry } from './service-registry';
 import type { AstReflection } from './syntax-tree';
+import type { ReadWriteMutex } from './utils/promise-util';
 import type { DocumentValidator } from './validation/document-validator';
 import type { ValidationRegistry } from './validation/validation-registry';
 import type { AstNodeDescriptionProvider, ReferenceDescriptionProvider } from './workspace/ast-descriptions';
@@ -139,6 +140,7 @@ export type LangiumDefaultSharedServices = {
         TextDocumentFactory: TextDocumentFactory
         WorkspaceManager: WorkspaceManager
         FileSystemProvider: FileSystemProvider
+        ReadWriteMutex: ReadWriteMutex
     }
 }
 

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -33,7 +33,7 @@ import type { ScopeComputation, ScopeProvider } from './references/scope';
 import type { JsonSerializer } from './serializer/json-serializer';
 import type { ServiceRegistry } from './service-registry';
 import type { AstReflection } from './syntax-tree';
-import type { ReadWriteMutex } from './utils/promise-util';
+import type { MutexLock } from './utils/promise-util';
 import type { DocumentValidator } from './validation/document-validator';
 import type { ValidationRegistry } from './validation/validation-registry';
 import type { AstNodeDescriptionProvider, ReferenceDescriptionProvider } from './workspace/ast-descriptions';
@@ -140,7 +140,7 @@ export type LangiumDefaultSharedServices = {
         TextDocumentFactory: TextDocumentFactory
         WorkspaceManager: WorkspaceManager
         FileSystemProvider: FileSystemProvider
-        ReadWriteMutex: ReadWriteMutex
+        MutexLock: MutexLock
     }
 }
 

--- a/packages/langium/src/utils/promise-util.ts
+++ b/packages/langium/src/utils/promise-util.ts
@@ -79,100 +79,28 @@ export async function interruptAndCheck(token: CancellationToken): Promise<void>
 }
 
 /**
- * Utility class to allow for mutually exclusive read and write access.
- *
- * Can perform multiple read accesses at the same time, but only one write access.
+ * Utility class to execute mutually exclusive actions.
  */
-export class ReadWriteMutex {
+export class MutexLock {
 
-    private readCount = 0;
-    private writeCount = 0;
-
-    private writeLock: Deferred = new Deferred().resolve();
-    private readLock: Deferred = new Deferred().resolve();
-
-    private previousWriteAction?: Promise<void>;
+    private previousAction = Promise.resolve();
 
     /**
-     * Performs a single async write action, like initializing the workspace or processing document changes.
+     * Performs a single async action, like initializing the workspace or processing document changes.
      * Only one action will be executed at a time.
-     *
-     * If a write action is queued up while a read action is being performed, the write action will wait until all read actions have completed.
      */
-    async write(action: () => Promise<void>): Promise<void> {
-        // Lock reading first, so that consequent read requests don't have priority over this write request
-        this.lockRead();
-        // Then await that every read previous action has completed
-        await this.readLock.promise;
-        // Append the new action to the previous action. We usually don't have to wait for long, as the previous write action
+    async lock(action: () => Promise<void>): Promise<void> {
+        // Append the new action to the previous action. We usually don't have to wait for long, as the previous action
         // 1. has either completed
         // 2. has been cancelled due to the new write request
-        this.previousWriteAction = (this.previousWriteAction ?? Promise.resolve()).then(() =>
-            action().catch(err => {
+        return this.previousAction = this.previousAction.then(
+            action,
+            err => {
                 if (!isOperationCancelled(err)) {
                     console.error('Error: ', err);
                 }
-            }).finally(() => {
-                this.unlockRead();
-            })
+            }
         );
-    }
-
-    /**
-     * Call this to lock this mutex before a write operation.
-     */
-    private lockRead(): void {
-        if (this.writeCount === 0) {
-            this.writeLock.resolve();
-            this.writeLock = new Deferred();
-        }
-        this.writeCount++;
-    }
-
-    /**
-     * Call this to unlock this mutex after a write operation.
-     */
-    private unlockRead(): void {
-        this.writeCount--;
-        if (this.writeCount === 0) {
-            this.writeLock.resolve();
-        }
-    }
-
-    /**
-     * Performs a read action on the language server. Multiple read actions can be performed at a time.
-     *
-     * If a read action is queued up while a write action is being performed, the read action will wait until the write action has completed.
-     */
-    async read<T>(action: () => Promise<T>): Promise<T> {
-        // Wait one tick for any write request to arrive
-        await delayNextTick();
-        // Await that writing has completed
-        await this.writeLock.promise;
-        // Then lock writing
-        this.lockWrite();
-        return action().finally(() => this.unlockWrite());
-    }
-
-    /**
-     * Call this to lock this mutex before a read operation.
-     */
-    private lockWrite(): void {
-        if (this.readCount === 0) {
-            this.readLock.resolve();
-            this.readLock = new Deferred();
-        }
-        this.readCount++;
-    }
-
-    /**
-     * Call this to lock this mutex after a read operation.
-     */
-    private unlockWrite(): void {
-        this.readCount--;
-        if (this.readCount === 0) {
-            this.readLock.resolve();
-        }
     }
 }
 

--- a/packages/langium/test/utils/promise-util.test.ts
+++ b/packages/langium/test/utils/promise-util.test.ts
@@ -4,40 +4,23 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { Deferred, delayNextTick, ReadWriteMutex } from '../../src';
+import { Deferred, delayNextTick, MutexLock } from '../../src';
 
 describe('Mutex locking', () => {
 
-    test('Reading is possible in parallel', async () => {
-        const max = 5;
-        let counter = 0;
-        const deferred = new Deferred();
-        const popAction = async () => {
-            counter++;
-            await deferred.promise;
-        };
-        const mutex = new ReadWriteMutex();
-        for (let i = 0; i < max; i++) {
-            mutex.read(() => popAction());
-        }
-        await delayNextTick();
-        // Counter has been increased even though the promise hasn't been resolved
-        expect(counter).toBe(max);
-    });
-
-    test('Writing is not possible in parallel', async () => {
+    test('Actions are executed sequentially', async () => {
         const size = 5;
         let counter = 0;
         const pushAction = async (deferred: Deferred) => {
             counter++;
             await deferred.promise;
         };
-        const mutex = new ReadWriteMutex();
+        const mutex = new MutexLock();
         const deferredItems: Deferred[] = [];
         for (let i = 0; i < size; i++) {
             const deferred = new Deferred();
             deferredItems.push(deferred);
-            mutex.write(() => pushAction(deferred));
+            mutex.lock(() => pushAction(deferred));
         }
         for (let i = 0; i < size; i++) {
             await delayNextTick();
@@ -45,105 +28,4 @@ describe('Mutex locking', () => {
             deferredItems[i].resolve();
         }
     });
-
-    test('Reading waits for writing', async () => {
-        let counter = 0;
-        const popAction = async () => {
-            counter--;
-        };
-        const pushDeferred = new Deferred();
-        const pushAction = async () => {
-            counter++;
-            await pushDeferred.promise;
-        };
-        const mutex = new ReadWriteMutex();
-        expect(counter).toBe(0);
-        mutex.write(() => pushAction());
-        mutex.read(() => popAction());
-        await delayNextTick();
-        // Write is executing, read is waiting
-        expect(counter).toBe(1);
-        pushDeferred.resolve();
-        await delayNextTick();
-        // Read has been executing
-        expect(counter).toBe(0);
-    });
-
-    test('Writing waits for reading', async () => {
-        let counter = 0;
-        const popDeferred = new Deferred();
-        const popAction = async () => {
-            counter--;
-            await popDeferred.promise;
-        };
-        const pushAction = async () => {
-            counter++;
-        };
-        const mutex = new ReadWriteMutex();
-        expect(counter).toBe(0);
-        mutex.read(() => popAction());
-        await delayNextTick();
-        mutex.write(() => pushAction());
-        await delayNextTick();
-        // Read is executing, write is waiting
-        expect(counter).toBe(-1);
-        popDeferred.resolve();
-        await delayNextTick();
-        // Write has been executing
-        expect(counter).toBe(0);
-    });
-
-    test('Reading waits for multiple writes', async () => {
-        let counter = 0;
-        const pushDeferred1 = new Deferred();
-        const pushDeferred2 = new Deferred();
-        const popAction = async () => {
-            counter--;
-        };
-        const pushAction = async (deferred: Deferred) => {
-            counter++;
-            await deferred.promise;
-        };
-        const mutex = new ReadWriteMutex();
-        expect(counter).toBe(0);
-        mutex.write(() => pushAction(pushDeferred1));
-        mutex.read(() => popAction());
-        mutex.write(() => pushAction(pushDeferred2));
-        mutex.read(() => popAction());
-        await delayNextTick();
-        // First write is executing, reads are waiting
-        expect(counter).toBe(1);
-        pushDeferred1.resolve();
-        await delayNextTick();
-        // Second write is executed, although first read has been queued up
-        expect(counter).toBe(2);
-        pushDeferred2.resolve();
-        await delayNextTick();
-        // Both reads are executed in parallel
-        expect(counter).toBe(0);
-    });
-
-    test('Writing has priority over reading if executed in sequence', async () => {
-        let counter = 0;
-        const popAction = async () => {
-            counter--;
-        };
-        const pushDeferred = new Deferred();
-        const pushAction = async () => {
-            counter++;
-            await pushDeferred.promise;
-        };
-        const mutex = new ReadWriteMutex();
-        expect(counter).toBe(0);
-        mutex.read(() => popAction());
-        mutex.write(() => pushAction());
-        await delayNextTick();
-        // Write is executing, read is waiting
-        expect(counter).toBe(1);
-        pushDeferred.resolve();
-        await delayNextTick();
-        // Read has been executing
-        expect(counter).toBe(0);
-    });
-
 });

--- a/packages/langium/test/utils/promise-util.test.ts
+++ b/packages/langium/test/utils/promise-util.test.ts
@@ -1,0 +1,149 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { Deferred, delayNextTick, ReadWriteMutex } from '../../src';
+
+describe('Mutex locking', () => {
+
+    test('Reading is possible in parallel', async () => {
+        const max = 5;
+        let counter = 0;
+        const deferred = new Deferred();
+        const popAction = async () => {
+            counter++;
+            await deferred.promise;
+        };
+        const mutex = new ReadWriteMutex();
+        for (let i = 0; i < max; i++) {
+            mutex.read(() => popAction());
+        }
+        await delayNextTick();
+        // Counter has been increased even though the promise hasn't been resolved
+        expect(counter).toBe(max);
+    });
+
+    test('Writing is not possible in parallel', async () => {
+        const size = 5;
+        let counter = 0;
+        const pushAction = async (deferred: Deferred) => {
+            counter++;
+            await deferred.promise;
+        };
+        const mutex = new ReadWriteMutex();
+        const deferredItems: Deferred[] = [];
+        for (let i = 0; i < size; i++) {
+            const deferred = new Deferred();
+            deferredItems.push(deferred);
+            mutex.write(() => pushAction(deferred));
+        }
+        for (let i = 0; i < size; i++) {
+            await delayNextTick();
+            expect(counter).toBe(i + 1);
+            deferredItems[i].resolve();
+        }
+    });
+
+    test('Reading waits for writing', async () => {
+        let counter = 0;
+        const popAction = async () => {
+            counter--;
+        };
+        const pushDeferred = new Deferred();
+        const pushAction = async () => {
+            counter++;
+            await pushDeferred.promise;
+        };
+        const mutex = new ReadWriteMutex();
+        expect(counter).toBe(0);
+        mutex.write(() => pushAction());
+        mutex.read(() => popAction());
+        await delayNextTick();
+        // Write is executing, read is waiting
+        expect(counter).toBe(1);
+        pushDeferred.resolve();
+        await delayNextTick();
+        // Read has been executing
+        expect(counter).toBe(0);
+    });
+
+    test('Writing waits for reading', async () => {
+        let counter = 0;
+        const popDeferred = new Deferred();
+        const popAction = async () => {
+            counter--;
+            await popDeferred.promise;
+        };
+        const pushAction = async () => {
+            counter++;
+        };
+        const mutex = new ReadWriteMutex();
+        expect(counter).toBe(0);
+        mutex.read(() => popAction());
+        await delayNextTick();
+        mutex.write(() => pushAction());
+        await delayNextTick();
+        // Read is executing, write is waiting
+        expect(counter).toBe(-1);
+        popDeferred.resolve();
+        await delayNextTick();
+        // Write has been executing
+        expect(counter).toBe(0);
+    });
+
+    test('Reading waits for multiple writes', async () => {
+        let counter = 0;
+        const pushDeferred1 = new Deferred();
+        const pushDeferred2 = new Deferred();
+        const popAction = async () => {
+            counter--;
+        };
+        const pushAction = async (deferred: Deferred) => {
+            counter++;
+            await deferred.promise;
+        };
+        const mutex = new ReadWriteMutex();
+        expect(counter).toBe(0);
+        mutex.write(() => pushAction(pushDeferred1));
+        mutex.read(() => popAction());
+        mutex.write(() => pushAction(pushDeferred2));
+        mutex.read(() => popAction());
+        await delayNextTick();
+        // First write is executing, reads are waiting
+        expect(counter).toBe(1);
+        pushDeferred1.resolve();
+        await delayNextTick();
+        // Second write is executed, although first read has been queued up
+        expect(counter).toBe(2);
+        pushDeferred2.resolve();
+        await delayNextTick();
+        // Both reads are executed in parallel
+        expect(counter).toBe(0);
+    });
+
+    test('Writing has priority over reading if executed in sequence', async () => {
+        let counter = 0;
+        const popAction = async () => {
+            counter--;
+        };
+        const pushDeferred = new Deferred();
+        const pushAction = async () => {
+            counter++;
+            await pushDeferred.promise;
+        };
+        const mutex = new ReadWriteMutex();
+        expect(counter).toBe(0);
+        mutex.read(() => popAction());
+        mutex.write(() => pushAction());
+        await delayNextTick();
+        // Write is executing, read is waiting
+        expect(counter).toBe(1);
+        pushDeferred.resolve();
+        await delayNextTick();
+        // Read has been executing
+        expect(counter).toBe(0);
+    });
+
+});


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/379

This took me a whole friday afternoon, I hope it's working perfectly: The `ReadWriteMutex` allows us to better hide some of the promise magic that's happening inside of the `language-server.ts` file. The `write` method performs a **single non-parallel** write action on the workspace (for workspace changes), while `read` allows **multiple parallel** reads on the workspace (usually for answering LSP requests).

`read` will always wait for all `write` calls to be executed before executing itself. `write` will only wait for the **current** `read` call and then execute itself. Any subsequent `write` calls will automatically move up in priority, even if some `read` call happened before that. See the different test cases for more context on how this exactly works.

This change addresses the issue by wrapping the `initializeWorkspace` in a `write` call, which will be performed in the background, while we send back the answer for the initialize request.