### PR TITLE
Inititialize LSP services with client capabilities

### DIFF
--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -33,7 +33,7 @@ export const LangiumGrammarModule: Module<LangiumGrammarServices, PartialLangium
     lsp: {
         FoldingRangeProvider: (services) => new LangiumGrammarFoldingRangeProvider(services),
         CodeActionProvider: () => new LangiumGrammarCodeActionProvider(),
-        SemanticTokenProvider: () => new LangiumGrammarSemanticTokenProvider(),
+        SemanticTokenProvider: (services) => new LangiumGrammarSemanticTokenProvider(services),
         Formatter: () => new LangiumGrammarFormatter(),
         HoverProvider: (services) => new LangiumGrammarHoverProvider(services),
         GoToResolver: (services) => new LangiumGrammarGoToResolver(services)

--- a/packages/langium/src/lsp/code-action.ts
+++ b/packages/langium/src/lsp/code-action.ts
@@ -4,11 +4,12 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, CodeAction, CodeActionParams, Command } from 'vscode-languageserver';
+import { CancellationToken, CodeAction, CodeActionClientCapabilities, CodeActionParams, Command } from 'vscode-languageserver';
+import { InitializableService } from '../services';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 
-export interface CodeActionProvider {
+export interface CodeActionProvider extends InitializableService<CodeActionClientCapabilities> {
     /**
      * Handle a code action request.
      *

--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -4,13 +4,13 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, CompletionItem, CompletionItemKind, CompletionList, CompletionParams } from 'vscode-languageserver';
+import { CancellationToken, CompletionClientCapabilities, CompletionItem, CompletionItemKind, CompletionList, CompletionParams } from 'vscode-languageserver';
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
 import * as ast from '../../grammar/generated/ast';
 import { getTypeNameAtElement } from '../../grammar/grammar-util';
 import { isNamed } from '../../references/naming';
 import { ScopeProvider } from '../../references/scope';
-import { LangiumServices } from '../../services';
+import { InitializableService, LangiumServices } from '../../services';
 import { AstNode, AstNodeDescription, CstNode } from '../../syntax-tree';
 import { getContainerOfType, isAstNode } from '../../utils/ast-util';
 import { findLeafNodeAtOffset, findRelevantNode, flattenCst } from '../../utils/cst-util';
@@ -25,7 +25,7 @@ export type CompletionAcceptor = (value: string | AstNode | AstNodeDescription, 
 /**
  * Language-specific service for handling completion requests.
  */
-export interface CompletionProvider {
+export interface CompletionProvider extends InitializableService<CompletionClientCapabilities> {
     /**
      * Handle a completion request.
      *

--- a/packages/langium/src/lsp/document-highlighter.ts
+++ b/packages/langium/src/lsp/document-highlighter.ts
@@ -4,10 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams } from 'vscode-languageserver';
+import { CancellationToken, DocumentHighlight, DocumentHighlightClientCapabilities, DocumentHighlightKind, DocumentHighlightParams } from 'vscode-languageserver';
 import { NameProvider } from '../references/naming';
 import { References } from '../references/references';
-import { LangiumServices } from '../services';
+import { InitializableService, LangiumServices } from '../services';
 import { AstNode, CstNode, Reference } from '../syntax-tree';
 import { findLocalReferences, getDocument } from '../utils/ast-util';
 import { findLeafNodeAtOffset } from '../utils/cst-util';
@@ -18,7 +18,7 @@ import { LangiumDocument } from '../workspace/documents';
 /**
  * Language-specific service for handling document highlight requests.
  */
-export interface DocumentHighlighter {
+export interface DocumentHighlighter extends InitializableService<DocumentHighlightClientCapabilities> {
     /**
      * Handle a document highlight request.
      *

--- a/packages/langium/src/lsp/document-symbol-provider.ts
+++ b/packages/langium/src/lsp/document-symbol-provider.ts
@@ -4,9 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, DocumentSymbol, DocumentSymbolParams, SymbolKind } from 'vscode-languageserver';
+import { CancellationToken, DocumentSymbol, DocumentSymbolClientCapabilities, DocumentSymbolParams, SymbolKind } from 'vscode-languageserver';
 import { NameProvider } from '../references/naming';
-import { LangiumServices } from '../services';
+import { InitializableService, LangiumServices } from '../services';
 import { AstNode } from '../syntax-tree';
 import { streamContents } from '../utils/ast-util';
 import { MaybePromise } from '../utils/promise-util';
@@ -15,7 +15,7 @@ import { LangiumDocument } from '../workspace/documents';
 /**
  * Language-specific service for handling document symbols requests.
  */
-export interface DocumentSymbolProvider {
+export interface DocumentSymbolProvider extends InitializableService<DocumentSymbolClientCapabilities> {
     /**
      * Handle a document symbols request.
      *

--- a/packages/langium/src/lsp/folding-range-provider.ts
+++ b/packages/langium/src/lsp/folding-range-provider.ts
@@ -4,8 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, FoldingRange, FoldingRangeKind, FoldingRangeParams } from 'vscode-languageserver';
-import { LangiumServices } from '../services';
+import { CancellationToken, FoldingRange, FoldingRangeClientCapabilities, FoldingRangeKind, FoldingRangeParams } from 'vscode-languageserver';
+import { InitializableService, LangiumServices } from '../services';
 import { AstNode, CstNode } from '../syntax-tree';
 import { streamAllContents } from '../utils/ast-util';
 import { flattenCst } from '../utils/cst-util';
@@ -15,7 +15,7 @@ import { LangiumDocument } from '../workspace/documents';
 /**
  * Language-specific service for handling folding range requests.
  */
-export interface FoldingRangeProvider {
+export interface FoldingRangeProvider extends InitializableService<FoldingRangeClientCapabilities> {
     /**
      * Handle a folding range request.
      *

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -4,21 +4,27 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, DocumentFormattingParams, DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams, FormattingOptions, Range, TextEdit } from 'vscode-languageserver';
+import { CancellationToken, DocumentFormattingClientCapabilities, DocumentFormattingParams, DocumentOnTypeFormattingClientCapabilities, DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingParams, DocumentRangeFormattingClientCapabilities, DocumentRangeFormattingParams, FormattingOptions, Range, TextEdit } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { findKeywordNode, findNodeForFeature, isCompositeCstNode, isLeafCstNode } from '..';
-import { findKeywordNodes, findNodesForFeature } from '../grammar/grammar-util';
-import { AstNode, CstNode, Properties } from '../syntax-tree';
+import { findKeywordNode, findKeywordNodes, findNodeForFeature, findNodesForFeature } from '../grammar/grammar-util';
+import { InitializableService } from '../services';
+import { AstNode, CstNode, isCompositeCstNode, isLeafCstNode, Properties } from '../syntax-tree';
 import { streamAllContents } from '../utils/ast-util';
 import { getInteriorNodes, getNextNode } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { DONE_RESULT, EMPTY_STREAM, Stream, StreamImpl, TreeStreamImpl } from '../utils/stream';
 import { LangiumDocument } from '../workspace/documents';
 
+export interface FormatterClientCapabilities {
+    formatting?: DocumentFormattingClientCapabilities
+    rangeFormatting?: DocumentRangeFormattingClientCapabilities
+    onTypeFormatting?: DocumentOnTypeFormattingClientCapabilities
+}
+
 /**
  * Language specific service for handling formatting related LSP requests.
  */
-export interface Formatter {
+export interface Formatter extends InitializableService<FormatterClientCapabilities> {
     /**
      * Handles full document formatting.
      */

--- a/packages/langium/src/lsp/goto.ts
+++ b/packages/langium/src/lsp/goto.ts
@@ -4,10 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, DefinitionParams, LocationLink } from 'vscode-languageserver';
+import { CancellationToken, DefinitionClientCapabilities, DefinitionParams, LocationLink } from 'vscode-languageserver';
 import { NameProvider } from '../references/naming';
 import { References } from '../references/references';
-import { LangiumServices } from '../services';
+import { InitializableService, LangiumServices } from '../services';
 import { CstNode } from '../syntax-tree';
 import { getDocument } from '../utils/ast-util';
 import { findLeafNodeAtOffset } from '../utils/cst-util';
@@ -17,7 +17,7 @@ import { LangiumDocument } from '../workspace/documents';
 /**
  * Language-specific service for handling go to definition requests.
  */
-export interface GoToResolver {
+export interface GoToResolver extends InitializableService<DefinitionClientCapabilities> {
     /**
      * Handle a go to definition request.
      *

--- a/packages/langium/src/lsp/hover-provider.ts
+++ b/packages/langium/src/lsp/hover-provider.ts
@@ -4,10 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, Hover, HoverParams } from 'vscode-languageserver';
+import { CancellationToken, Hover, HoverClientCapabilities, HoverParams } from 'vscode-languageserver';
 import { GrammarConfig } from '../grammar/grammar-config';
 import { References } from '../references/references';
-import { LangiumServices } from '../services';
+import { InitializableService, LangiumServices } from '../services';
 import { AstNode } from '../syntax-tree';
 import { findCommentNode, findLeafNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
@@ -16,7 +16,7 @@ import { LangiumDocument } from '../workspace/documents';
 /**
  * Language-specific service for handling hover requests.
  */
-export interface HoverProvider {
+export interface HoverProvider extends InitializableService<HoverClientCapabilities> {
     /**
      * Handle a hover request.
      *

--- a/packages/langium/src/lsp/reference-finder.ts
+++ b/packages/langium/src/lsp/reference-finder.ts
@@ -4,11 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, Location, Range, ReferenceParams } from 'vscode-languageserver';
+import { CancellationToken, Location, Range, ReferenceClientCapabilities, ReferenceParams } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import { NameProvider } from '../references/naming';
 import { References } from '../references/references';
-import { LangiumServices } from '../services';
+import { InitializableService, LangiumServices } from '../services';
 import { AstNode, CstNode } from '../syntax-tree';
 import { getDocument, isReference } from '../utils/ast-util';
 import { findLeafNodeAtOffset, flattenCst } from '../utils/cst-util';
@@ -18,7 +18,7 @@ import { LangiumDocument } from '../workspace/documents';
 /**
  * Language-specific service for handling find references requests.
  */
-export interface ReferenceFinder {
+export interface ReferenceFinder extends InitializableService<ReferenceClientCapabilities> {
     /**
      * Handle a find references request.
      *

--- a/packages/langium/src/lsp/rename-refactoring.ts
+++ b/packages/langium/src/lsp/rename-refactoring.ts
@@ -4,11 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, Range, RenameParams, TextDocumentPositionParams, TextEdit, WorkspaceEdit } from 'vscode-languageserver';
+import { CancellationToken, Range, RenameClientCapabilities, RenameParams, TextDocumentPositionParams, TextEdit, WorkspaceEdit } from 'vscode-languageserver';
 import { Position } from 'vscode-languageserver-textdocument';
 import { isNamed, NameProvider } from '../references/naming';
 import { References } from '../references/references';
-import { LangiumServices } from '../services';
+import { InitializableService, LangiumServices } from '../services';
 import { CstNode } from '../syntax-tree';
 import { findLeafNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
@@ -18,7 +18,7 @@ import { ReferenceFinder } from './reference-finder';
 /**
  * Language-specific service for handling rename requests and prepare rename requests.
  */
-export interface RenameHandler {
+export interface RenameHandler extends InitializableService<RenameClientCapabilities> {
     /**
      * Handle a rename request.
      *

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -33,7 +33,7 @@ import type { ScopeComputation, ScopeProvider } from './references/scope';
 import type { JsonSerializer } from './serializer/json-serializer';
 import type { ServiceRegistry } from './service-registry';
 import type { AstReflection } from './syntax-tree';
-import type { MutexLock } from './utils/promise-util';
+import type { MaybePromise, MutexLock } from './utils/promise-util';
 import type { DocumentValidator } from './validation/document-validator';
 import type { ValidationRegistry } from './validation/validation-registry';
 import type { AstNodeDescriptionProvider, ReferenceDescriptionProvider } from './workspace/ast-descriptions';
@@ -74,6 +74,15 @@ export type LangiumLspServices = {
     SemanticTokenProvider?: SemanticTokenProvider
     RenameHandler: RenameHandler
     Formatter?: Formatter
+}
+
+export interface InitializableService<T extends object> {
+    /**
+     * Initializes the service with client (IDE) related capabilities.
+     *
+     * This method is only executed if Langium is running as part of a language server.
+     */
+    initialize?(clientCapabilities?: T): MaybePromise<void>
 }
 
 /**

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -4,11 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CancellationToken, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { CancellationToken, Diagnostic, DiagnosticSeverity, PublishDiagnosticsClientCapabilities } from 'vscode-languageserver';
 import { Range } from 'vscode-languageserver-textdocument';
 import { findNodeForFeature } from '../grammar/grammar-util';
 import { LanguageMetaData } from '../grammar/language-meta-data';
-import { LangiumServices } from '../services';
+import { InitializableService, LangiumServices } from '../services';
 import { AstNode } from '../syntax-tree';
 import { streamAst } from '../utils/ast-util';
 import { tokenToRange } from '../utils/cst-util';
@@ -19,7 +19,7 @@ import { DiagnosticInfo, ValidationAcceptor, ValidationRegistry } from './valida
 /**
  * Language-specific service for validating `LangiumDocument`s.
  */
-export interface DocumentValidator {
+export interface DocumentValidator extends InitializableService<PublishDiagnosticsClientCapabilities> {
     /**
      * Validates the whole specified document.
      * @param document specified document to validate


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/552

This PR became larger than expected:

1. Fixes the issue described in https://github.com/langium/langium/issues/552 by keeping a token builder for each open document.
2. Gives each LSP service an `initialize` method that can be used to optimize behavior based on frontend (editor) capabilities.
3. Based on 2, if the frontend does not support multi line tokens, split each semantic token into multiple tokens, one for each line. Addresses an issue brought up in https://github.com/langium/langium/discussions/524