### PR TITLE
Make workspace initialization cancellable

### DIFF
--- a/packages/langium/src/utils/promise-util.ts
+++ b/packages/langium/src/utils/promise-util.ts
@@ -84,23 +84,36 @@ export async function interruptAndCheck(token: CancellationToken): Promise<void>
 export class MutexLock {
 
     private previousAction = Promise.resolve();
+    private previousTokenSource = new CancellationTokenSource();
 
     /**
      * Performs a single async action, like initializing the workspace or processing document changes.
      * Only one action will be executed at a time.
+     *
+     * When another action is queued up, the token provided for the action will be cancelled.
+     * Assuming the action makes use of this token, the next action only has to wait for the current action to finish cancellation.
      */
-    async lock(action: () => Promise<void>): Promise<void> {
+    lock(action: (token: CancellationToken) => Promise<void>): Promise<void> {
+        this.cancel();
+        const tokenSource = new CancellationTokenSource();
+        this.previousTokenSource = tokenSource;
         // Append the new action to the previous action. We usually don't have to wait for long, as the previous action
         // 1. has either completed
-        // 2. has been cancelled due to the new write request
+        // 2. has been cancelled
         return this.previousAction = this.previousAction.then(
-            action,
-            err => {
+            () => action(tokenSource.token).catch(err => {
                 if (!isOperationCancelled(err)) {
                     console.error('Error: ', err);
                 }
-            }
+            })
         );
+    }
+
+    /**
+     * Cancels the currently executed action
+     */
+    cancel(): void {
+        this.previousTokenSource.cancel();
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/555

The `MutexLock#lock` method now gives each caller a cancellation token that they can use to abort execution. The token is cancelled whenever another action requests the lock.