### PR TITLE
Add document highlighter feature for declared types

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -4,6 +4,21 @@ entry Module:
     'module' name=ID
     (statements+=Statement)*;
 
+interface A {
+    name: string
+    foo: string
+}
+
+interface B extends A {}
+
+type C = A | B;
+
+RuleA returns A: name=ID foo=ID;
+
+RuleB returns B: name=ID foo=ID;
+
+RuleC returns C: name=ID foo=ID;
+
 Statement:
     Definition | Evaluation;
 

--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -4,21 +4,6 @@ entry Module:
     'module' name=ID
     (statements+=Statement)*;
 
-interface A {
-    name: string
-    foo: string
-}
-
-interface B extends A {}
-
-type C = A | B;
-
-RuleA returns A: name=ID foo=ID;
-
-RuleB returns B: name=ID foo=ID;
-
-RuleC returns C: name=ID foo=ID;
-
 Statement:
     Definition | Evaluation;
 

--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -17,6 +17,7 @@ import { LangiumGrammarFoldingRangeProvider } from './lsp/grammar-folding-ranges
 import { LangiumGrammarFormatter } from './lsp/grammar-formatter';
 import { LangiumGrammarGoToResolver } from './lsp/grammar-goto';
 import { LangiumGrammarHoverProvider } from './lsp/grammar-hovers';
+import { LangiumGrammarDocumentHighlighter } from './lsp/grammar-document-highlighter';
 
 export type LangiumGrammarAddedServices = {
     validation: {
@@ -38,7 +39,8 @@ export const LangiumGrammarModule: Module<LangiumGrammarServices, PartialLangium
         Formatter: () => new LangiumGrammarFormatter(),
         HoverProvider: (services) => new LangiumGrammarHoverProvider(services),
         GoToResolver: (services) => new LangiumGrammarGoToResolver(services),
-        ReferenceFinder: (services) => new LangiumGrammarReferenceFinder(services)
+        ReferenceFinder: (services) => new LangiumGrammarReferenceFinder(services),
+        DocumentHighlighter: (services) => new LangiumGrammarDocumentHighlighter(services)
     },
     references: {
         ScopeComputation: (services) => new LangiumGrammarScopeComputation(services),

--- a/packages/langium/src/grammar/lsp/grammar-document-highlighter.ts
+++ b/packages/langium/src/grammar/lsp/grammar-document-highlighter.ts
@@ -1,0 +1,84 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { DocumentHighlight, DocumentHighlightKind } from 'vscode-languageserver';
+import { DefaultDocumentHighlighter } from '../../lsp/document-highlighter';
+import { LangiumServices } from '../../services';
+import { AstNode, CstNode, LeafCstNode } from '../../syntax-tree';
+import { getContainerOfType, getDocument, streamAst } from '../../utils/ast-util';
+import { findLeafNodeAtOffset } from '../../utils/cst-util';
+import { equalURI } from '../../utils/uri-utils';
+import { AstNodeLocator } from '../../workspace/ast-node-locator';
+import { LangiumDocument, LangiumDocuments } from '../../workspace/documents';
+import { Interface, isAssignment, isInterface, isParserRule, isTypeAttribute, ParserRule, Type } from '../generated/ast';
+import { collectChildrenTypes } from '../type-system/types-util';
+
+export class LangiumGrammarDocumentHighlighter extends DefaultDocumentHighlighter {
+
+    readonly astNodeLocator: AstNodeLocator;
+    readonly langiumDocuments: LangiumDocuments;
+
+    constructor(services: LangiumServices) {
+        super(services);
+        this.astNodeLocator = services.workspace.AstNodeLocator;
+        this.langiumDocuments = services.shared.workspace.LangiumDocuments;
+    }
+
+    protected getHighlights(selectedNode: LeafCstNode, document: LangiumDocument<AstNode>, rootNode: CstNode): DocumentHighlight[] | undefined {
+        const targetAstNode = this.references.findDeclaration(selectedNode)?.element;
+        if (targetAstNode) {
+            const highlights: Array<[CstNode, DocumentHighlightKind]> = [];
+            if (equalURI(getDocument(targetAstNode).uri), document.uri) {
+                highlights.push([selectedNode, super.getHighlightKind(selectedNode)]);
+            }
+            if (isTypeAttribute(targetAstNode)) {
+                const interfaces: Set<Interface | Type> = new Set<Interface | Type>();
+                const interfaceNode = getContainerOfType(targetAstNode, isInterface);
+                if (interfaceNode) {
+                    interfaces.add(interfaceNode);
+                }
+
+                const childrenInterfaces = collectChildrenTypes(interfaceNode!, this.references, this.langiumDocuments, this.astNodeLocator);
+                childrenInterfaces.forEach(child => interfaces.add(child));
+
+                const parserRules: ParserRule[] = [];
+
+                interfaces.forEach(i => {
+                    const rules = streamAst(getDocument(targetAstNode).parseResult.value).filter(x => isParserRule(x) && x.returnType?.ref === i);
+                    rules.forEach(rule => {
+                        if (isParserRule(rule)) {
+                            parserRules.push(rule);
+                        }
+                    });
+                });
+
+                parserRules.forEach(rule => {
+                    if (isParserRule(rule)) {
+                        const assignments = streamAst(rule).filter(x => isAssignment(x) && x.feature === selectedNode.text);
+                        assignments.forEach(assignment => {
+                            if (assignment.$cstNode) {
+                                const leaf = findLeafNodeAtOffset(assignment.$cstNode, assignment.$cstNode.offset);
+                                console.log(leaf);
+                                if (leaf) {
+                                    highlights.push([leaf, super.getHighlightKind(leaf)]);
+                                }
+                            }
+                        });
+                    }
+                });
+                return highlights.map(([node, kind]) => DocumentHighlight.create(node.range, kind));
+            } else {
+                return super.getHighlights(selectedNode, document, rootNode);
+            }
+        } else {
+            const element = selectedNode.element;
+            if (isAssignment(element)) {
+                console.log('assignment');
+            }
+        }
+        return undefined;
+    }
+}

--- a/packages/langium/src/grammar/lsp/grammar-document-highlighter.ts
+++ b/packages/langium/src/grammar/lsp/grammar-document-highlighter.ts
@@ -8,9 +8,8 @@ import { DocumentHighlight } from 'vscode-languageserver';
 import { DefaultDocumentHighlighter } from '../../lsp/document-highlighter';
 import { LangiumServices } from '../../services';
 import { AstNode, CstNode, LeafCstNode } from '../../syntax-tree';
-import { extractRootNode, getContainerOfType, getDocument, streamAst } from '../../utils/ast-util';
+import { extractRootNode, getContainerOfType, getDocument, getLocalParserRulesAndActionsWithReturnType, streamAst } from '../../utils/ast-util';
 import { findLeafNodeAtOffset } from '../../utils/cst-util';
-import { Stream } from '../../utils/stream';
 import { equalURI } from '../../utils/uri-utils';
 import { AstNodeLocator } from '../../workspace/ast-node-locator';
 import { LangiumDocument, LangiumDocuments } from '../../workspace/documents';
@@ -115,12 +114,4 @@ export class LangiumGrammarDocumentHighlighter extends DefaultDocumentHighlighte
         }
         return undefined;
     }
-}
-
-function getLocalParserRulesAndActionsWithReturnType(document: LangiumDocument<AstNode>, returnType: Interface | Type): Array<ParserRule | Action>{
-    const rootNode = document.parseResult.value;
-    const rules = streamAst(rootNode)
-        .filter(node => (isParserRule(node) && node.returnType?.ref === returnType)
-    || (isAction(node) && node.type?.ref === returnType)) as Stream<ParserRule | Action>;
-    return rules.toArray();
 }

--- a/packages/langium/src/grammar/lsp/grammar-document-highlighter.ts
+++ b/packages/langium/src/grammar/lsp/grammar-document-highlighter.ts
@@ -1,20 +1,21 @@
 /******************************************************************************
- * Copyright 2021 TypeFox GmbH
- * This program and the accompanying materials are made available under the
- * terms of the MIT License, which is available in the project root.
- ******************************************************************************/
+* Copyright 2021 TypeFox GmbH
+* This program and the accompanying materials are made available under the
+* terms of the MIT License, which is available in the project root.
+******************************************************************************/
 
-import { DocumentHighlight, DocumentHighlightKind } from 'vscode-languageserver';
+import { DocumentHighlight } from 'vscode-languageserver';
 import { DefaultDocumentHighlighter } from '../../lsp/document-highlighter';
 import { LangiumServices } from '../../services';
 import { AstNode, CstNode, LeafCstNode } from '../../syntax-tree';
-import { getContainerOfType, getDocument, streamAst } from '../../utils/ast-util';
+import { extractRootNode, getContainerOfType, getDocument, streamAst } from '../../utils/ast-util';
 import { findLeafNodeAtOffset } from '../../utils/cst-util';
+import { Stream } from '../../utils/stream';
 import { equalURI } from '../../utils/uri-utils';
 import { AstNodeLocator } from '../../workspace/ast-node-locator';
 import { LangiumDocument, LangiumDocuments } from '../../workspace/documents';
-import { Interface, isAssignment, isInterface, isParserRule, isTypeAttribute, ParserRule, Type } from '../generated/ast';
-import { collectChildrenTypes } from '../type-system/types-util';
+import { Action, Assignment, Interface, isAction, isAssignment, isGroup, isInterface, isParserRule, isTypeAttribute, ParserRule, Type, TypeAttribute } from '../generated/ast';
+import { collectChildrenTypes, collectSuperTypes, findAttributeLeafNodeInInterface } from '../type-system/types-util';
 
 export class LangiumGrammarDocumentHighlighter extends DefaultDocumentHighlighter {
 
@@ -28,57 +29,98 @@ export class LangiumGrammarDocumentHighlighter extends DefaultDocumentHighlighte
     }
 
     protected getHighlights(selectedNode: LeafCstNode, document: LangiumDocument<AstNode>, rootNode: CstNode): DocumentHighlight[] | undefined {
+        const highlights: DocumentHighlight[] = [];
         const targetAstNode = this.references.findDeclaration(selectedNode)?.element;
         if (targetAstNode) {
-            const highlights: Array<[CstNode, DocumentHighlightKind]> = [];
             if (equalURI(getDocument(targetAstNode).uri), document.uri) {
-                highlights.push([selectedNode, super.getHighlightKind(selectedNode)]);
+                const highlight = DocumentHighlight.create(selectedNode.range, super.getHighlightKind(selectedNode));
+                highlights.push(highlight);
             }
             if (isTypeAttribute(targetAstNode)) {
-                const interfaces: Set<Interface | Type> = new Set<Interface | Type>();
-                const interfaceNode = getContainerOfType(targetAstNode, isInterface);
-                if (interfaceNode) {
-                    interfaces.add(interfaceNode);
-                }
-
-                const childrenInterfaces = collectChildrenTypes(interfaceNode!, this.references, this.langiumDocuments, this.astNodeLocator);
-                childrenInterfaces.forEach(child => interfaces.add(child));
-
-                const parserRules: ParserRule[] = [];
-
-                interfaces.forEach(i => {
-                    const rules = streamAst(getDocument(targetAstNode).parseResult.value).filter(x => isParserRule(x) && x.returnType?.ref === i);
-                    rules.forEach(rule => {
-                        if (isParserRule(rule)) {
-                            parserRules.push(rule);
-                        }
-                    });
-                });
-
-                parserRules.forEach(rule => {
-                    if (isParserRule(rule)) {
-                        const assignments = streamAst(rule).filter(x => isAssignment(x) && x.feature === selectedNode.text);
-                        assignments.forEach(assignment => {
-                            if (assignment.$cstNode) {
-                                const leaf = findLeafNodeAtOffset(assignment.$cstNode, assignment.$cstNode.offset);
-                                console.log(leaf);
-                                if (leaf) {
-                                    highlights.push([leaf, super.getHighlightKind(leaf)]);
-                                }
-                            }
-                        });
-                    }
-                });
-                return highlights.map(([node, kind]) => DocumentHighlight.create(node.range, kind));
+                highlights.push(...this.getHighlightsFromTypeAttribute(targetAstNode, selectedNode));
+                return highlights;
             } else {
                 return super.getHighlights(selectedNode, document, rootNode);
             }
         } else {
             const element = selectedNode.element;
             if (isAssignment(element)) {
-                console.log('assignment');
+                highlights.push(...this.getHighlightsFromAssignment(element, selectedNode));
+                return highlights;
             }
         }
         return undefined;
     }
+
+    protected getHighlightsFromTypeAttribute(typeAttribute: TypeAttribute, selectedNode: LeafCstNode): DocumentHighlight[] {
+        const highlights: DocumentHighlight[] = [];
+        const interfaceNode = getContainerOfType(typeAttribute, isInterface);
+        const document = extractRootNode(typeAttribute)!.$document!;
+        const interfaces = collectChildrenTypes(interfaceNode!, this.references, this.langiumDocuments, this.astNodeLocator);
+        const targetRules: Array<ParserRule | Action>= [];
+        interfaces.forEach(interf => {
+            const rules = getLocalParserRulesAndActionsWithReturnType(document, interf);
+            targetRules.push(...rules);
+        });
+        targetRules.forEach(rule => {
+            const ruleNode = isAction(rule) ? getContainerOfType(rule, isGroup) : rule;
+            if (ruleNode) {
+                const highlight = this.getHighlightForAssignment(ruleNode, selectedNode);
+                if (highlight) {
+                    highlights.push(highlight);
+                }
+            }
+        });
+        return highlights;
+    }
+
+    protected getHighlightsFromAssignment(element: Assignment, selectedNode: LeafCstNode): DocumentHighlight[] {
+        const highlights: DocumentHighlight[] = [];
+        const rootNode = extractRootNode(element);
+        const document = rootNode!.$document;
+        const parserRule = getContainerOfType(element, isParserRule);
+        const groupNode = getContainerOfType(element, isGroup);
+        const targetInterfaces: Interface[] = [];
+        if (parserRule?.returnType?.ref) {
+            targetInterfaces.push(...collectSuperTypes(parserRule.returnType.ref as Interface | Type));
+        }
+        if (groupNode) {
+            const action = groupNode.elements.find(el => isAction(el)) as Action | undefined;
+            if (action?.type?.ref) {
+                targetInterfaces.push(...collectSuperTypes(action.type.ref as Interface | Type));
+            }
+        }
+        for (const interf of targetInterfaces) {
+            const typeAttribute = findAttributeLeafNodeInInterface(interf, selectedNode.text);
+            if (typeAttribute) {
+                const partialHighlights = this.getHighlights(typeAttribute, document!, rootNode!.$cstNode!);
+                if (partialHighlights) {
+                    highlights.push(...partialHighlights);
+                }
+                break;
+            }
+        }
+        return highlights;
+    }
+
+    protected getHighlightForAssignment(rule: AstNode, selectedNode: LeafCstNode): DocumentHighlight | undefined {
+        const assignment = streamAst(rule).find(node => isAssignment(node) && node.feature === selectedNode.text);
+        if (isAssignment(assignment)) {
+            if (assignment.$cstNode) {
+                const leaf = findLeafNodeAtOffset(assignment.$cstNode, assignment.$cstNode.offset);
+                if (leaf) {
+                    return DocumentHighlight.create(leaf.range, super.getHighlightKind(leaf));
+                }
+            }
+        }
+        return undefined;
+    }
+}
+
+function getLocalParserRulesAndActionsWithReturnType(document: LangiumDocument<AstNode>, returnType: Interface | Type): Array<ParserRule | Action>{
+    const rootNode = document.parseResult.value;
+    const rules = streamAst(rootNode)
+        .filter(node => (isParserRule(node) && node.returnType?.ref === returnType)
+    || (isAction(node) && node.type?.ref === returnType)) as Stream<ParserRule | Action>;
+    return rules.toArray();
 }

--- a/packages/langium/src/grammar/lsp/grammar-reference-finder.ts
+++ b/packages/langium/src/grammar/lsp/grammar-reference-finder.ts
@@ -6,7 +6,6 @@
 
 import { Location, ReferenceParams } from 'vscode-languageserver';
 import { DefaultReferenceFinder } from '../../lsp';
-import { References } from '../../references/references';
 import { LangiumServices } from '../../services';
 import { AstNode, LeafCstNode } from '../../syntax-tree';
 import { extractAssignments, extractRootNode, getContainerOfType } from '../../utils/ast-util';
@@ -78,7 +77,7 @@ export class LangiumGrammarReferenceFinder extends DefaultReferenceFinder {
 
             const targetRules: Array<ParserRule | Action> = [];
             interfaces.forEach(interf => {
-                targetRules.push(...getParserRulesAndActionsWithReturnType(interf, this.references, this.langiumDocuments, this.astNodeLocator));
+                targetRules.push(...this.references.getParserRulesAndActionsWithReturnType(interf));
             });
 
             targetRules.forEach(rule => {
@@ -96,19 +95,6 @@ export class LangiumGrammarReferenceFinder extends DefaultReferenceFinder {
         }
         return refs;
     }
-}
-
-function getParserRulesAndActionsWithReturnType(returnType: Interface | Type, references: References, langiumDocuments: LangiumDocuments, astNodeLocator: AstNodeLocator): Array<ParserRule | Action> {
-    const rules: Array<ParserRule |  Action> = [];
-    const refs = references.findReferences(returnType);
-    refs.forEach(ref => {
-        const doc = langiumDocuments.getOrCreateDocument(ref.sourceUri);
-        const astNode = astNodeLocator.getAstNode(doc, ref.sourcePath);
-        if (isParserRule(astNode) || isAction(astNode)) {
-            rules.push(astNode);
-        }
-    });
-    return rules;
 }
 
 function getLocationOfAssignment(assignment: Assignment): Location | undefined {

--- a/packages/langium/src/grammar/lsp/grammar-reference-finder.ts
+++ b/packages/langium/src/grammar/lsp/grammar-reference-finder.ts
@@ -1,20 +1,20 @@
 /******************************************************************************
- * Copyright 2021 TypeFox GmbH
- * This program and the accompanying materials are made available under the
- * terms of the MIT License, which is available in the project root.
- ******************************************************************************/
+* Copyright 2021 TypeFox GmbH
+* This program and the accompanying materials are made available under the
+* terms of the MIT License, which is available in the project root.
+******************************************************************************/
 
 import { Location, ReferenceParams } from 'vscode-languageserver';
 import { DefaultReferenceFinder } from '../../lsp';
+import { References } from '../../references/references';
 import { LangiumServices } from '../../services';
 import { AstNode, LeafCstNode } from '../../syntax-tree';
 import { extractAssignments, extractRootNode, getContainerOfType } from '../../utils/ast-util';
 import { findLeafNodeAtOffset } from '../../utils/cst-util';
-import { ReferenceDescription } from '../../workspace/ast-descriptions';
 import { AstNodeLocator } from '../../workspace/ast-node-locator';
 import { LangiumDocument, LangiumDocuments } from '../../workspace/documents';
-import { AbstractType, Action, Assignment, Interface, isAction, isAssignment, isGroup, isInterface, isParserRule, isType, isTypeAttribute, ParserRule, TypeAttribute } from '../generated/ast';
-import { collectChildrenTypes, collectSuperTypes } from '../type-system/types-util';
+import { Action, Assignment, Interface, isAction, isAssignment, isGroup, isInterface, isParserRule, isTypeAttribute, ParserRule, Type, TypeAttribute } from '../generated/ast';
+import { collectChildrenTypes, collectSuperTypes, findAttributeLeafNodeInInterface } from '../type-system/types-util';
 
 export class LangiumGrammarReferenceFinder extends DefaultReferenceFinder {
     readonly astNodeLocator: AstNodeLocator;
@@ -49,110 +49,78 @@ export class LangiumGrammarReferenceFinder extends DefaultReferenceFinder {
         const refs: Location[] = [];
         const parserRule = getContainerOfType(targetAstNode, isParserRule);
         const groupNode = getContainerOfType(targetAstNode, isGroup);
+        const interfaces: Interface[] = [];
 
         if (parserRule?.returnType?.ref) {
-            const interfaces = this.getInterfacesFromAssignment(parserRule.returnType.ref);
-            interfaces.forEach(interfaceNode => {
-                const leafNode = this.findLeafNodeInInterface(interfaceNode,selectedNode.text);
-                if (leafNode) {
-                    refs.push(...this.getReferences(leafNode, params, document));
-                }
-            });
+            interfaces.push(...collectSuperTypes(parserRule.returnType.ref as Interface | Type));
         }
-
         if (groupNode) {
-            const action = groupNode.elements.find(el => isAction(el));
-            if (isAction(action)) {
-                const ref = action.type?.ref;
-                if (ref) {
-                    const interfaces = this.getInterfacesFromAssignment(ref);
-                    interfaces.forEach(interfaceNode => {
-                        const leafNode = this.findLeafNodeInInterface(interfaceNode,selectedNode.text);
-                        if (leafNode) {
-                            refs.push(...this.getReferences(leafNode, params, document));
-                        }
-                    });
-                }
-
+            const action = groupNode.elements.find(el => isAction(el)) as Action | undefined;
+            if (action?.type?.ref) {
+                interfaces.push(...collectSuperTypes(action.type.ref as Interface | Type));
             }
         }
-
+        for (const interf of interfaces) {
+            const leaf = findAttributeLeafNodeInInterface(interf, selectedNode.text);
+            if (leaf) {
+                refs.push(...this.getReferences(leaf, params, document));
+                break;
+            }
+        }
         return refs;
-    }
-
-    findLeafNodeInInterface(interfaceNode: Interface, text: string): LeafCstNode | undefined {
-        const attribute = interfaceNode.attributes.find(a => a.name === text);
-        if (attribute) {
-            const cstNode = attribute.$cstNode;
-            if (cstNode) {
-                const leafNode = findLeafNodeAtOffset(cstNode, cstNode.offset);
-                if (leafNode) {
-                    return leafNode;
-                }
-            }
-        }
-        return undefined;
-    }
-
-    getInterfacesFromAssignment(ref: AbstractType): Set<Interface> {
-        let interfaces: Set<Interface> = new Set<Interface>();
-        if (isInterface(ref)) {
-            interfaces = collectSuperTypes(ref);
-            interfaces.add(ref);
-        } else if (isType(ref)) {
-            interfaces = collectSuperTypes(ref);
-        }
-        return interfaces;
     }
 
     getReferencesFromTypeAttribute(typeAttributeNode: TypeAttribute, selectedNode: LeafCstNode): Location[] {
         const refs: Location[] = [];
         const interfaceNode = getContainerOfType(typeAttributeNode, isInterface);
         if (interfaceNode) {
-            const collectedTypes = collectChildrenTypes(interfaceNode, this.references, this.langiumDocuments, this.astNodeLocator);
-            collectedTypes.add(interfaceNode);
+            const interfaces = collectChildrenTypes(interfaceNode, this.references, this.langiumDocuments, this.astNodeLocator);
 
-            const referencesToTypes = new Set<ReferenceDescription>();
-            collectedTypes.forEach(collectedType => {
-                const refs = this.references.findReferences(collectedType);
-                for (const ref of refs) {
-                    referencesToTypes.add(ref);
-                }
+            const targetRules: Array<ParserRule | Action> = [];
+            interfaces.forEach(interf => {
+                targetRules.push(...getParserRulesAndActionsWithReturnType(interf, this.references, this.langiumDocuments, this.astNodeLocator));
             });
 
-            const parserRules = this.findParserRulesFromReferences(referencesToTypes);
-
-            parserRules.forEach(rule => {
+            targetRules.forEach(rule => {
                 const assignment = isParserRule(rule) ?
-                    extractAssignments(rule.definition).find(assignment => assignment.feature === selectedNode.text)
-                    : extractAssignments(getContainerOfType(rule, isGroup)!).find(assignment => assignment.feature === selectedNode.text);
+                    extractAssignments(rule.definition).find(assignment => assignment.feature === selectedNode.text) :
+                    extractAssignments(getContainerOfType(rule, isGroup)!).find(assignment => assignment.feature === selectedNode.text);
 
                 if (assignment) {
-                    const cstNode = assignment.$cstNode;
-                    if (cstNode) {
-                        const leaf = findLeafNodeAtOffset(cstNode, cstNode.offset);
-                        if (leaf) {
-                            const rootNode = extractRootNode(leaf.element);
-                            if (rootNode) {
-                                refs.push(Location.create(rootNode.$document!.uri.toString(), leaf.range));
-                            }
-                        }
+                    const location = getLocationOfAssignment(assignment);
+                    if (location) {
+                        refs.push(location);
                     }
                 }
             });
         }
         return refs;
     }
-
-    findParserRulesFromReferences(referencesToTypes: Set<ReferenceDescription>): Set<ParserRule | Action> {
-        const parserRules: Set<ParserRule | Action> = new Set<ParserRule | Action>();
-        referencesToTypes.forEach(ref => {
-            const doc = this.langiumDocuments.getOrCreateDocument(ref.sourceUri);
-            const astNode = this.astNodeLocator.getAstNode(doc, ref.sourcePath);
-            if (isParserRule(astNode) || isAction(astNode)) {
-                parserRules.add(astNode);
-            }
-        });
-        return parserRules;
-    }
 }
+
+function getParserRulesAndActionsWithReturnType(returnType: Interface | Type, references: References, langiumDocuments: LangiumDocuments, astNodeLocator: AstNodeLocator): Array<ParserRule | Action> {
+    const rules: Array<ParserRule |  Action> = [];
+    const refs = references.findReferences(returnType);
+    refs.forEach(ref => {
+        const doc = langiumDocuments.getOrCreateDocument(ref.sourceUri);
+        const astNode = astNodeLocator.getAstNode(doc, ref.sourcePath);
+        if (isParserRule(astNode) || isAction(astNode)) {
+            rules.push(astNode);
+        }
+    });
+    return rules;
+}
+
+function getLocationOfAssignment(assignment: Assignment): Location | undefined {
+    if (assignment.$cstNode) {
+        const leaf = findLeafNodeAtOffset(assignment.$cstNode, assignment.$cstNode.offset);
+        if (leaf) {
+            const rootNode = extractRootNode(leaf.element);
+            if (rootNode) {
+                return Location.create(rootNode.$document!.uri.toString(), leaf.range);
+            }
+        }
+    }
+    return undefined;
+}
+

--- a/packages/langium/src/lsp/document-highlighter.ts
+++ b/packages/langium/src/lsp/document-highlighter.ts
@@ -8,7 +8,7 @@ import { CancellationToken, DocumentHighlight, DocumentHighlightClientCapabiliti
 import { NameProvider } from '../references/naming';
 import { References } from '../references/references';
 import { InitializableService, LangiumServices } from '../services';
-import { AstNode, CstNode, Reference } from '../syntax-tree';
+import { AstNode, CstNode, LeafCstNode, Reference } from '../syntax-tree';
 import { findLocalReferences, getDocument } from '../utils/ast-util';
 import { findLeafNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
@@ -46,6 +46,11 @@ export class DefaultDocumentHighlighter implements DocumentHighlighter {
         if (!selectedNode) {
             return undefined;
         }
+        const highlights = this.getHighlights(selectedNode, document, rootNode);
+        return highlights;
+    }
+
+    protected getHighlights(selectedNode: LeafCstNode, document: LangiumDocument, rootNode: CstNode): DocumentHighlight[] | undefined {
         const targetAstNode = this.references.findDeclaration(selectedNode)?.element;
         if (targetAstNode) {
             const refs: Array<[CstNode, DocumentHighlightKind]> = [];
@@ -62,6 +67,7 @@ export class DefaultDocumentHighlighter implements DocumentHighlighter {
                 DocumentHighlight.create(node.range, kind)
             );
         }
+
         return undefined;
     }
 

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import * as ast from '../grammar/generated/ast';
+import { Action, Interface, isAction, isParserRule, ParserRule, Type } from '../grammar/generated/ast';
 import { AstNode, AstNodeDescription, LinkingError, Reference, ReferenceInfo } from '../syntax-tree';
 import { DONE_RESULT, Stream, stream, StreamImpl, TreeStream, TreeStreamImpl } from '../utils/stream';
 import { LangiumDocument } from '../workspace/documents';
@@ -224,4 +225,12 @@ export function extractAssignments(element: ast.AbstractElement): ast.Assignment
         return element.elements.flatMap(e => extractAssignments(e));
     }
     return [];
+}
+
+export function getLocalParserRulesAndActionsWithReturnType(document: LangiumDocument<AstNode>, returnType: Interface | Type): Array<ParserRule | Action>{
+    const rootNode = document.parseResult.value;
+    const rules = streamAst(rootNode)
+        .filter(node => (isParserRule(node) && node.returnType?.ref === returnType)
+    || (isAction(node) && node.type?.ref === returnType)) as Stream<ParserRule | Action>;
+    return rules.toArray();
 }

--- a/packages/langium/test/lsp/document-highlighter.test.ts
+++ b/packages/langium/test/lsp/document-highlighter.test.ts
@@ -1,0 +1,112 @@
+/******************************************************************************
+ * Copyright 2021 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createLangiumGrammarServices } from '../../src';
+import { expectDocumentHighlights } from '../../src/test';
+
+const grammarServices = createLangiumGrammarServices().grammar;
+const findHighlights = expectDocumentHighlights(grammarServices);
+
+describe('findHighlights', () => {
+    test('Must highlight occurrences of parser rule name in assignments', async () => {
+        const grammar = `grammar test
+        hidden terminal WS: /\\s+/;
+        terminal ID: /\\w+/;
+        
+        entry EntryRule: value=<|Ru<|>leA|>;
+        
+        <|Ru<|>leA|>: name=ID;
+
+        RuleB: foo=<|Ru<|>leA|>
+        `;
+
+        await findHighlights({
+            text: grammar
+        });
+    });
+
+    test('Must highlight terminal in assignments', async () => {
+        const grammar = `grammar test
+        hidden terminal WS: /\\s+/;
+        terminal <|I<|>D|>: /\\w+/;
+            
+        RuleA: name=<|I<|>D|>;
+        `;
+
+        await findHighlights({
+            text: grammar
+        });
+    });
+
+    test('Must highlight interface name in type, return types, and actions', async () => {
+        const grammar = `grammar test
+        hidden terminal WS: /\\s+/;
+        terminal ID: /\\w+/;
+        
+        interface <|<|>A|> {
+            name: string
+        }
+
+        type B = <|<|>A|>;
+
+        RuleA returns <|<|>A|>: name=ID;
+
+        ActionRule: {<|<|>A|>} name=ID;
+        `;
+
+        await findHighlights({
+            text: grammar
+        });
+    });
+
+    test('Must highlight occurrences of property in parser rule returning target type', async () => {
+        const grammar = `grammar test
+        hidden terminal WS: /\\s+/;
+        terminal ID: /\\w+/;
+        
+        interface A {
+            <|na<|>me|>: string
+        }
+
+        RuleA returns A: <|na<|>me|>=ID;
+
+        RuleB : name=ID;
+
+        ActionRule: {A} <|na<|>me|>=ID;
+        `;
+
+        await findHighlights({
+            text: grammar
+        });
+    });
+
+    test('Must highlight occurrences of property in rules returning children types', async () => {
+        const grammar = `grammar test
+        hidden terminal WS: /\\s+/;
+        terminal ID: /\\w+/;
+        
+        interface A {
+            <|na<|>me|>: string
+        }
+
+        interface B extends A {}
+
+        type C = A;
+
+        RuleA returns A: <|na<|>me|>=ID;
+
+        RuleB returns B: <|na<|>me|>=ID;
+
+        RuleC returns C: <|na<|>me|>=ID;
+
+        ActionRule: {A} 'A' <|na<|>me|>=ID | {B} 'B' <|na<|>me|>=ID | {C} 'C' <|na<|>me|>=ID;
+        `;
+
+        await findHighlights({
+            text: grammar
+        });
+    });
+});


### PR DESCRIPTION
* Added Document Highlighter feature for interface properties and assignment in parser rules having a return type.

* A few utility functions to access related types

* Minor refactoring of the reference finder service to use new utility functions

## Utility functions
We should discuss the location of these utility functions and their name. There might already be existing functions that achieve the same thing but couldn't find them...
* `collectChildrenTypes` in `type-util.ts`. 
    * From a given `Interface` returns a `Set<Interface | Type>` of all interfaces and types extending the given interface (includes said interface).
* `collectSuperTypes` in `type-util.ts`. 
    * Starting from a given interface, returns a `Set<Interface>` containing all super types (and super types of super types, and so on) including the given interface
* `findAttributeLeafNodeInInterface` in `type-util.ts`. 
    * Gets the `LeafCstNode` of a type attribute inside of a given interface.
* `getParserRulesAndActionsWithReturnType` in `references.ts`. 
    * Gets all `ParserRule` and `Action` that have a given return type
    * Terrible name
    * Had to modify the `References` interface... probably a bad idea
* `getLocalParserRulesAndActionsWithReturnType` in `ast-util.ts`
    * Gets all `ParserRule` and `Action` with a given return type in a given document
    * Terrible name
    * Might be better placed somewhere else since functions in `ast-util.ts` seem to be more generic