### PR TITLE
Browser context: Detect if process is undefined

### DIFF
--- a/packages/langium/src/generator/generator-node.ts
+++ b/packages/langium/src/generator/generator-node.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-const EOL = process?.platform === 'win32' ? '\r\n' : '\n';
+const EOL = (typeof process === 'undefined') ? '\n' : (process.platform === 'win32') ? '\r\n' : '\n';
 
 export type GeneratorNode = CompositeGeneratorNode | IndentNode | NewLineNode | string;
 
@@ -40,14 +40,14 @@ export class CompositeGeneratorNode {
 export class IndentNode extends CompositeGeneratorNode {
 
     indentation?: string;
-    indentImmediately  = true;
-    indentEmptyLines  = false;
+    indentImmediately = true;
+    indentEmptyLines = false;
 
     constructor(indentation?: string | number, indentImmediately = true, indentEmptyLines = false) {
         super();
-        if (typeof(indentation) === 'string') {
+        if (typeof (indentation) === 'string') {
             this.indentation = indentation;
-        } else if (typeof(indentation) === 'number') {
+        } else if (typeof (indentation) === 'number') {
             this.indentation = ''.padStart(indentation);
         }
         this.indentImmediately = indentImmediately;
@@ -59,7 +59,7 @@ export class NewLineNode {
 
     lineDelimiter: string;
 
-    ifNotEmpty  = false;
+    ifNotEmpty = false;
 
     constructor(lineDelimiter?: string, ifNotEmpty = false) {
         this.lineDelimiter = lineDelimiter ?? EOL;


### PR DESCRIPTION
Just saw this happening with a new worker. Good news: With the fix it looks good with local builds.

Side question: Should we set a formatter for vscode (see auto-corrected spaces)?