### PR TITLE
Fix invalid diagnostics ranges

### DIFF
--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -447,6 +447,7 @@ export function createServicesForGrammar(config: {
     };
     const shared = inject(createDefaultSharedModule(EmptyFileSystem), generatedSharedModule, config.sharedModule);
     const services = inject(createDefaultModule({ shared }), generatedModule, config.module);
+    shared.ServiceRegistry.register(services);
     return services;
 }
 

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { Position, Range } from 'vscode-languageserver';
+import { createServicesForGrammar } from '../../src';
+import { validationHelper } from '../../src/test';
+
+// Related to https://github.com/langium/langium/issues/571
+describe('Parser error is thrown on resynced token with NaN position', () => {
+
+    const grammar = `grammar HelloWorld
+
+    entry Model:
+        (persons+=Person | greetings+=Greeting)*;
+    
+    Person:
+        'person' name=ID;
+    
+    Greeting:
+        'Hello' person=[Person:ID] '!';
+    
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+    terminal INT returns number: /[0-9]+/;
+    terminal STRING: /"[^"]*"|'[^']*'/;
+    `;
+    const services = createServicesForGrammar({
+        grammar
+    });
+
+    const validate = validationHelper(services);
+
+    test('Diagnostic is shown on at the end of the previous token', async () => {
+        const text = `person Aasdf
+        person Jo
+        
+        Hello Jo!
+        Hello `;
+
+        const validationResult = await validate(text);
+        const diagnostics = validationResult.diagnostics;
+        expect(diagnostics).toHaveLength(1);
+        const endPosition = Position.create(4, 13);
+        expect(diagnostics[0].range).toStrictEqual(Range.create(endPosition, endPosition));
+    });
+});


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/571

When Chevrotain performs error recovery, it sometime adds a "resynced" token, which doesn't have any positional information, using `NaN` everywhere. If an error is thrown on such a token, we have to use the previous token to determine the diagnostics position.