### PR TITLE
Check previous token has valid position data

### DIFF
--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -255,8 +255,8 @@ export class LangiumGrammarValidator {
         }
         // Collect type/interface definitions from imported grammars
         resolveTransitiveImports(this.documents, grammar).forEach((grammar) => {
-            grammar.types.forEach((type) => types.add(type.name));
-            grammar.interfaces.forEach((iface) => types.add(iface.name));
+            grammar.types.forEach(type => types.add(type.name));
+            grammar.interfaces.forEach(iface => types.add(iface.name));
         });
 
         for (const rule of grammar.rules.filter(ast.isParserRule)) {

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -82,7 +82,7 @@ export class DefaultDocumentValidator implements DocumentValidator {
                     } else {
                         // No valid prev token. Might be empty document or containing only hidden tokens.
                         // Point to document start
-                        range = Range.create(0,0,0,0);
+                        range = Range.create(0, 0, 0, 0);
                     }
                 }
             } else {

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -76,8 +76,14 @@ export class DefaultDocumentValidator implements DocumentValidator {
                 // We can simply append our diagnostic to that token
                 if ('previousToken' in parserError) {
                     const token = (parserError as MismatchedTokenException).previousToken;
-                    const position = Position.create(token.endLine! - 1, token.endColumn!);
-                    range = Range.create(position, position);
+                    if(!isNaN(token.startOffset)) {
+                        const position = Position.create(token.endLine! - 1, token.endColumn!);
+                        range = Range.create(position, position);
+                    } else {
+                        // No valid prev token. Might be empty document or containing only hidden tokens.
+                        // Point to document start
+                        range = Range.create(0,0,0,0);
+                    }
                 }
             } else {
                 range = tokenToRange(parserError.token);

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -51,6 +51,6 @@ describe('Parser error is thrown on resynced token with NaN position', () => {
         const validationResult = await validate('');
         const diagnostics = validationResult.diagnostics;
         expect(diagnostics).toHaveLength(1);
-        expect(diagnostics[0].range).toStrictEqual(Range.create(0,0,0,0));
+        expect(diagnostics[0].range).toStrictEqual(Range.create(0, 0, 0, 0));
     });
 });

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -14,7 +14,7 @@ describe('Parser error is thrown on resynced token with NaN position', () => {
     const grammar = `grammar HelloWorld
 
     entry Model:
-        (persons+=Person | greetings+=Greeting)*;
+        (persons+=Person | greetings+=Greeting)+;
     
     Person:
         'person' name=ID;
@@ -45,5 +45,12 @@ describe('Parser error is thrown on resynced token with NaN position', () => {
         expect(diagnostics).toHaveLength(1);
         const endPosition = Position.create(4, 13);
         expect(diagnostics[0].range).toStrictEqual(Range.create(endPosition, endPosition));
+    });
+
+    test('Diagnostic is shown at document start when document is empty', async () => {
+        const validationResult = await validate('');
+        const diagnostics = validationResult.diagnostics;
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].range).toStrictEqual(Range.create(0,0,0,0));
     });
 });


### PR DESCRIPTION
In empty or only hidden token documents there are no valid previous tokens to find.
This PR handles this cases by just setting the diagnostic range to the document start.

Fixes #571 