### PR TITLE
Support `workspace/executeCommand` LSP request

### DIFF
--- a/packages/langium/src/lsp/execute-command-handler.ts
+++ b/packages/langium/src/lsp/execute-command-handler.ts
@@ -1,0 +1,47 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { CancellationToken } from 'vscode-languageserver';
+import { MaybePromise } from '../utils/promise-util';
+
+export interface ExecuteCommandHandler {
+    get commands(): string[]
+    executeCommand(name: string, args: any[], cancelToken?: CancellationToken): Promise<unknown>
+}
+
+export type ExecuteCommandFunction = (args: any[], cancelToken: CancellationToken) => MaybePromise<unknown>
+
+export type ExecuteCommandAcceptor = (name: string, execute: ExecuteCommandFunction) => void;
+
+export abstract class AbstractExecuteCommandHandler implements ExecuteCommandHandler {
+
+    protected registeredCommands = new Map<string, ExecuteCommandFunction>();
+
+    get commands(): string[] {
+        return Array.from(this.registeredCommands.keys());
+    }
+
+    constructor() {
+        this.registerCommands(this.createCommandAcceptor());
+    }
+
+    async executeCommand(name: string, args: any[], cancelToken = CancellationToken.None): Promise<unknown> {
+        const command = this.registeredCommands.get(name);
+        if (command) {
+            return command(args, cancelToken);
+        } else {
+            return undefined;
+        }
+    }
+
+    protected createCommandAcceptor(): ExecuteCommandAcceptor {
+        return (name, execute) => this.registeredCommands.set(name, execute);
+    }
+
+    abstract registerCommands(acceptor: ExecuteCommandAcceptor): void;
+}

--- a/packages/langium/src/lsp/index.ts
+++ b/packages/langium/src/lsp/index.ts
@@ -10,6 +10,7 @@ export * from './completion/rule-interpreter';
 export * from './code-action';
 export * from './document-highlighter';
 export * from './document-symbol-provider';
+export * from './execute-command-handler';
 export * from './folding-range-provider';
 export * from './goto';
 export * from './hover-provider';

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -10,6 +10,7 @@ import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Grammar } from './grammar/generated/ast';
 import type { GrammarConfig } from './grammar/grammar-config';
 import type { LanguageMetaData } from './grammar/language-meta-data';
+import type { ExecuteCommandHandler } from './lsp/execute-command-handler';
 import type { CodeActionProvider } from './lsp/code-action';
 import type { CompletionProvider } from './lsp/completion/completion-provider';
 import type { RuleInterpreter } from './lsp/completion/rule-interpreter';
@@ -131,6 +132,7 @@ export type LangiumDefaultSharedServices = {
     ServiceRegistry: ServiceRegistry
     lsp: {
         Connection?: Connection,
+        ExecuteCommandHandler?: ExecuteCommandHandler,
         LanguageServer: LanguageServer
     }
     workspace: {

--- a/packages/langium/test/lsp/execute-command-handler.test.ts
+++ b/packages/langium/test/lsp/execute-command-handler.test.ts
@@ -1,0 +1,64 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createServicesForGrammar, AbstractExecuteCommandHandler, ExecuteCommandAcceptor } from '../../src';
+
+describe('AbstractExecuteCommandHandler', () => {
+
+    const grammarStub = `
+    grammar Empty
+    entry NOOP: "NOOP";
+    hidden terminal WS: /\\s+/;
+    `;
+
+    test('Registered commands are available in `commands` property', async () => {
+
+        class MultiCommandHandler extends AbstractExecuteCommandHandler {
+            registerCommands(acceptor: ExecuteCommandAcceptor): void {
+                acceptor('b', () => { /* noop */ });
+                acceptor('a', () => { /* noop */ });
+            }
+        }
+
+        const services = createServicesForGrammar({
+            grammar: grammarStub,
+            sharedModule: {
+                lsp: {
+                    ExecuteCommandHandler: () => new MultiCommandHandler()
+                }
+            }
+        });
+        const commands = services.shared.lsp.ExecuteCommandHandler!.commands;
+        expect(commands).toBeDefined();
+        expect(commands).toHaveLength(2);
+        // We don't expect any specific order, so we only test for containmnent.
+        expect(commands).toContain('a');
+        expect(commands).toContain('b');
+    });
+
+    test('Executing a command is possible and returns expected result', async () => {
+
+        class TestCommandHandler extends AbstractExecuteCommandHandler {
+            registerCommands(acceptor: ExecuteCommandAcceptor): void {
+                acceptor('execute', args => {
+                    const value = args[0];
+                    return value + 5;
+                });
+            }
+        }
+
+        const services = createServicesForGrammar({
+            grammar: grammarStub,
+            sharedModule: {
+                lsp: {
+                    ExecuteCommandHandler: () => new TestCommandHandler()
+                }
+            }
+        });
+        const commandResult = await services.shared.lsp.ExecuteCommandHandler?.executeCommand('execute', [3]);
+        expect(commandResult).toBe(8);
+    });
+});


### PR DESCRIPTION
Introduces support for the `workspace/executeCommand` which allows us to call into the language server, execute a provided command, and return the result to the caller.