### PR TITLE
Various improvements to CST behavior

### DIFF
--- a/packages/langium/src/grammar/grammar-config.ts
+++ b/packages/langium/src/grammar/grammar-config.ts
@@ -5,12 +5,20 @@
  ******************************************************************************/
 
 import { LangiumServices } from '../services';
+import { DefaultNameRegexp } from '../utils/cst-util';
 import { isMultilineComment } from '../utils/regex-util';
 import { isTerminalRule } from './generated/ast';
 import { isCommentTerminal, terminalRegex } from './grammar-util';
 
 export interface GrammarConfig {
+    /**
+     * Lists all rule names which are classified as multiline comment rules
+     */
     multilineCommentRules: string[]
+    /**
+     * A regular expression which matches characters of names
+     */
+    nameRegexp: RegExp
 }
 
 export function createGrammarConfig(services: LangiumServices): GrammarConfig {
@@ -21,5 +29,8 @@ export function createGrammarConfig(services: LangiumServices): GrammarConfig {
             rules.push(rule.name);
         }
     }
-    return { multilineCommentRules: rules };
+    return {
+        multilineCommentRules: rules,
+        nameRegexp: DefaultNameRegexp
+    };
 }

--- a/packages/langium/src/grammar/references/grammar-references.ts
+++ b/packages/langium/src/grammar/references/grammar-references.ts
@@ -26,12 +26,15 @@ export class LangiumGrammarReferences extends DefaultReferences {
     }
 
     findDeclaration(sourceCstNode: CstNode): CstNode | undefined {
-        const nodeElem = findRelevantNode(sourceCstNode);
-        if (isAssignment(nodeElem)) {
-            return this.findAssignmentDeclaration(nodeElem);
-        } else if (isAction(nodeElem) && nodeElem.feature === sourceCstNode.text) {
-            // Only search for a special declaration if the cst node is the feature property of the action
-            return this.findActionDeclaration(nodeElem);
+        const nodeElem = sourceCstNode.element;
+        const assignment = findAssignment(sourceCstNode);
+        if (assignment && assignment.feature === 'feature') {
+            // Only search for a special declaration if the cst node is the feature property of the action/assignment
+            if (isAssignment(nodeElem)) {
+                return this.findAssignmentDeclaration(nodeElem);
+            } else if (isAction(nodeElem)) {
+                return this.findActionDeclaration(nodeElem);
+            }
         }
         return super.findDeclaration(sourceCstNode);
     }

--- a/packages/langium/src/grammar/references/grammar-references.ts
+++ b/packages/langium/src/grammar/references/grammar-references.ts
@@ -8,13 +8,13 @@ import { DefaultReferences } from '../../references/references';
 import { LangiumServices } from '../../services';
 import { AstNode, CstNode } from '../../syntax-tree';
 import { getContainerOfType, getDocument, streamAst } from '../../utils/ast-util';
-import { findRelevantNode, toDocumentSegment } from '../../utils/cst-util';
+import { toDocumentSegment } from '../../utils/cst-util';
 import { stream, Stream } from '../../utils/stream';
 import { equalURI } from '../../utils/uri-utils';
 import { ReferenceDescription } from '../../workspace/ast-descriptions';
 import { LangiumDocuments } from '../../workspace/documents';
 import { Action, Assignment, Interface, isAction, isAssignment, isInterface, isParserRule, isType, isTypeAttribute, ParserRule, Type, TypeAttribute } from '../generated/ast';
-import { extractAssignments, findNodeForFeature, getActionAtElement } from '../grammar-util';
+import { extractAssignments, findAssignment, findNodeForFeature, getActionAtElement } from '../grammar-util';
 import { collectChildrenTypes, collectSuperTypes } from '../type-system/types-util';
 
 export class LangiumGrammarReferences extends DefaultReferences {

--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -13,7 +13,7 @@ import { ScopeProvider } from '../../references/scope';
 import { LangiumServices } from '../../services';
 import { AstNode, AstNodeDescription, CstNode } from '../../syntax-tree';
 import { getContainerOfType, isAstNode } from '../../utils/ast-util';
-import { findLeafNodeAtOffset, findRelevantNode, flattenCst } from '../../utils/cst-util';
+import { findLeafNodeAtOffset, flattenCst } from '../../utils/cst-util';
 import { MaybePromise } from '../../utils/promise-util';
 import { stream } from '../../utils/stream';
 import { LangiumDocument } from '../../workspace/documents';
@@ -85,7 +85,7 @@ export class DefaultCompletionProvider implements CompletionProvider {
                     } else {
                         return e;
                     }
-                }).forEach(e => this.completionFor(findRelevantNode(node), e, acceptor));
+                }).forEach(e => this.completionFor(node.element, e, acceptor));
             } else {
                 // The entry rule is the first parser rule
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/langium/src/lsp/document-highlighter.ts
+++ b/packages/langium/src/lsp/document-highlighter.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import { CancellationToken, DocumentHighlight, DocumentHighlightParams } from 'vscode-languageserver';
+import { GrammarConfig } from '../grammar/grammar-config';
 import { NameProvider } from '../references/naming';
 import { References } from '../references/references';
 import { LangiumServices } from '../services';
@@ -31,10 +32,12 @@ export interface DocumentHighlighter {
 export class DefaultDocumentHighlighter implements DocumentHighlighter {
     protected readonly references: References;
     protected readonly nameProvider: NameProvider;
+    protected readonly grammarConfig: GrammarConfig;
 
     constructor(services: LangiumServices) {
         this.references = services.references.References;
         this.nameProvider = services.references.NameProvider;
+        this.grammarConfig = services.parser.GrammarConfig;
     }
 
     findHighlights(document: LangiumDocument, params: DocumentHighlightParams): MaybePromise<DocumentHighlight[] | undefined> {
@@ -42,7 +45,7 @@ export class DefaultDocumentHighlighter implements DocumentHighlighter {
         if (!rootNode) {
             return undefined;
         }
-        const selectedNode = findDeclarationNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position));
+        const selectedNode = findDeclarationNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position), this.grammarConfig.nameRegexp);
         if (!selectedNode) {
             return undefined;
         }

--- a/packages/langium/src/lsp/document-highlighter.ts
+++ b/packages/langium/src/lsp/document-highlighter.ts
@@ -9,7 +9,7 @@ import { NameProvider } from '../references/naming';
 import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { getDocument } from '../utils/ast-util';
-import { findLeafNodeAtOffset } from '../utils/cst-util';
+import { findDeclarationNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { equalURI } from '../utils/uri-utils';
 import { ReferenceDescription } from '../workspace/ast-descriptions';
@@ -42,7 +42,7 @@ export class DefaultDocumentHighlighter implements DocumentHighlighter {
         if (!rootNode) {
             return undefined;
         }
-        const selectedNode = findLeafNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position));
+        const selectedNode = findDeclarationNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position));
         if (!selectedNode) {
             return undefined;
         }

--- a/packages/langium/src/lsp/goto.ts
+++ b/packages/langium/src/lsp/goto.ts
@@ -10,7 +10,7 @@ import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { CstNode } from '../syntax-tree';
 import { getDocument } from '../utils/ast-util';
-import { findLeafNodeAtOffset } from '../utils/cst-util';
+import { findDeclarationNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 
@@ -47,7 +47,7 @@ export class DefaultGoToResolverProvider implements GoToResolver {
         const rootNode = document.parseResult.value;
         if (rootNode.$cstNode) {
             const cst = rootNode.$cstNode;
-            const sourceCstNode = findLeafNodeAtOffset(cst, document.textDocument.offsetAt(params.position));
+            const sourceCstNode = findDeclarationNodeAtOffset(cst, document.textDocument.offsetAt(params.position));
             if (sourceCstNode) {
                 return this.collectLocationLinks(sourceCstNode, params);
             }

--- a/packages/langium/src/lsp/goto.ts
+++ b/packages/langium/src/lsp/goto.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import { CancellationToken, DefinitionParams, LocationLink } from 'vscode-languageserver';
+import { GrammarConfig } from '../grammar/grammar-config';
 import { NameProvider } from '../references/naming';
 import { References } from '../references/references';
 import { LangiumServices } from '../services';
@@ -37,17 +38,19 @@ export class DefaultGoToResolverProvider implements GoToResolver {
 
     protected readonly nameProvider: NameProvider;
     protected readonly references: References;
+    protected readonly grammarConfig: GrammarConfig;
 
     constructor(services: LangiumServices) {
         this.nameProvider = services.references.NameProvider;
         this.references = services.references.References;
+        this.grammarConfig = services.parser.GrammarConfig;
     }
 
     goToDefinition(document: LangiumDocument, params: DefinitionParams): MaybePromise<LocationLink[] | undefined> {
         const rootNode = document.parseResult.value;
         if (rootNode.$cstNode) {
             const cst = rootNode.$cstNode;
-            const sourceCstNode = findDeclarationNodeAtOffset(cst, document.textDocument.offsetAt(params.position));
+            const sourceCstNode = findDeclarationNodeAtOffset(cst, document.textDocument.offsetAt(params.position), this.grammarConfig.nameRegexp);
             if (sourceCstNode) {
                 return this.collectLocationLinks(sourceCstNode, params);
             }

--- a/packages/langium/src/lsp/hover-provider.ts
+++ b/packages/langium/src/lsp/hover-provider.ts
@@ -9,7 +9,7 @@ import { GrammarConfig } from '../grammar/grammar-config';
 import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { AstNode } from '../syntax-tree';
-import { findCommentNode, findLeafNodeAtOffset } from '../utils/cst-util';
+import { findCommentNode, findDeclarationNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 
@@ -38,7 +38,7 @@ export abstract class AstNodeHoverProvider implements HoverProvider {
         const rootNode = document.parseResult?.value?.$cstNode;
         if (rootNode) {
             const offset = document.textDocument.offsetAt(params.position);
-            const cstNode = findLeafNodeAtOffset(rootNode, offset);
+            const cstNode = findDeclarationNodeAtOffset(rootNode, offset);
             if (cstNode && cstNode.offset + cstNode.length > offset) {
                 const targetNode = this.references.findDeclaration(cstNode);
                 if (targetNode) {

--- a/packages/langium/src/lsp/reference-finder.ts
+++ b/packages/langium/src/lsp/reference-finder.ts
@@ -13,6 +13,7 @@ import { isReference } from '../utils/ast-util';
 import { findDeclarationNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
+import { GrammarConfig } from '../grammar/grammar-config';
 
 /**
  * Language-specific service for handling find references requests.
@@ -30,10 +31,12 @@ export interface ReferenceFinder {
 export class DefaultReferenceFinder implements ReferenceFinder {
     protected readonly nameProvider: NameProvider;
     protected readonly references: References;
+    protected readonly grammarConfig: GrammarConfig;
 
     constructor(services: LangiumServices) {
         this.nameProvider = services.references.NameProvider;
         this.references = services.references.References;
+        this.grammarConfig = services.parser.GrammarConfig;
     }
 
     findReferences(document: LangiumDocument, params: ReferenceParams): MaybePromise<Location[]> {
@@ -42,7 +45,7 @@ export class DefaultReferenceFinder implements ReferenceFinder {
             return [];
         }
 
-        const selectedNode = findDeclarationNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position));
+        const selectedNode = findDeclarationNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position), this.grammarConfig.nameRegexp);
         if (!selectedNode) {
             return [];
         }

--- a/packages/langium/src/lsp/reference-finder.ts
+++ b/packages/langium/src/lsp/reference-finder.ts
@@ -10,7 +10,7 @@ import { References } from '../references/references';
 import { AstNode, LeafCstNode } from '../syntax-tree';
 import { LangiumServices } from '../services';
 import { isReference } from '../utils/ast-util';
-import { findLeafNodeAtOffset } from '../utils/cst-util';
+import { findDeclarationNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 
@@ -42,7 +42,7 @@ export class DefaultReferenceFinder implements ReferenceFinder {
             return [];
         }
 
-        const selectedNode = findLeafNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position));
+        const selectedNode = findDeclarationNodeAtOffset(rootNode, document.textDocument.offsetAt(params.position));
         if (!selectedNode) {
             return [];
         }

--- a/packages/langium/src/lsp/rename-refactoring.ts
+++ b/packages/langium/src/lsp/rename-refactoring.ts
@@ -9,7 +9,7 @@ import { isNamed, NameProvider } from '../references/naming';
 import { References } from '../references/references';
 import { LangiumServices } from '../services';
 import { CstNode } from '../syntax-tree';
-import { findLeafNodeAtOffset } from '../utils/cst-util';
+import { findDeclarationNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 import { ReferenceFinder } from './reference-finder';
@@ -52,7 +52,7 @@ export class DefaultRenameHandler implements RenameHandler {
         const rootNode = document.parseResult.value.$cstNode;
         if (!rootNode) return undefined;
         const offset = document.textDocument.offsetAt(params.position);
-        const leafNode = findLeafNodeAtOffset(rootNode, offset);
+        const leafNode = findDeclarationNodeAtOffset(rootNode, offset);
         if (!leafNode) return undefined;
         const targetNode = this.references.findDeclaration(leafNode) ?? leafNode;
         const options = { onlyLocal: false, includeDeclaration: true };
@@ -77,7 +77,7 @@ export class DefaultRenameHandler implements RenameHandler {
         const rootNode = doc.parseResult.value.$cstNode;
         const offset = doc.textDocument.offsetAt(position);
         if (rootNode && offset) {
-            const leafNode = findLeafNodeAtOffset(rootNode, offset);
+            const leafNode = findDeclarationNodeAtOffset(rootNode, offset);
             if (!leafNode) {
                 return undefined;
             }

--- a/packages/langium/src/lsp/signature-help-provider.ts
+++ b/packages/langium/src/lsp/signature-help-provider.ts
@@ -6,7 +6,7 @@
 
 import { CancellationToken, SignatureHelp, SignatureHelpOptions, SignatureHelpParams } from 'vscode-languageserver';
 import { AstNode } from '../syntax-tree';
-import { findLeafNodeAtOffset, findRelevantNode } from '../utils/cst-util';
+import { findLeafNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
 import { LangiumDocument } from '../workspace/documents';
 
@@ -31,10 +31,7 @@ export abstract class AbstractSignatureHelpProvider implements SignatureHelpProv
         if (cst) {
             const sourceCstNode = findLeafNodeAtOffset(cst, document.textDocument.offsetAt(params.position));
             if (sourceCstNode) {
-                const element = findRelevantNode(sourceCstNode);
-                if (element) {
-                    return this.getSignatureFromElement(element, cancelToken);
-                }
+                return this.getSignatureFromElement(sourceCstNode.element, cancelToken);
             }
         }
         return undefined;

--- a/packages/langium/src/references/references.ts
+++ b/packages/langium/src/references/references.ts
@@ -8,7 +8,7 @@ import { findAssignment } from '../grammar/grammar-util';
 import { LangiumServices } from '../services';
 import { AstNode, CstNode, Reference } from '../syntax-tree';
 import { getDocument, isReference, streamAst, streamReferences } from '../utils/ast-util';
-import { findRelevantNode, toDocumentSegment } from '../utils/cst-util';
+import { toDocumentSegment } from '../utils/cst-util';
 import { stream, Stream } from '../utils/stream';
 import { equalURI } from '../utils/uri-utils';
 import { ReferenceDescription } from '../workspace/ast-descriptions';
@@ -55,7 +55,7 @@ export class DefaultReferences implements References {
     findDeclaration(sourceCstNode: CstNode): CstNode | undefined {
         if (sourceCstNode) {
             const assignment = findAssignment(sourceCstNode);
-            const nodeElem = findRelevantNode(sourceCstNode);
+            const nodeElem = sourceCstNode.element;
             if (assignment && nodeElem) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const reference = (nodeElem as any)[assignment.feature] as unknown;

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -143,10 +143,10 @@ export interface CstNode extends DocumentSegment {
  * A composite CST node has children, but no directly associated token.
  */
 export interface CompositeCstNode extends CstNode {
-    children: CstNode[];
+    readonly children: CstNode[];
 }
 
-export function isCompositeCstNode(node: CstNode): node is CompositeCstNode {
+export function isCompositeCstNode(node: unknown): node is CompositeCstNode {
     return typeof node === 'object' && !!node && 'children' in node;
 }
 
@@ -157,6 +157,14 @@ export interface LeafCstNode extends CstNode {
     readonly tokenType: TokenType;
 }
 
-export function isLeafCstNode(node: CstNode): node is LeafCstNode {
+export function isLeafCstNode(node: unknown): node is LeafCstNode {
     return typeof node === 'object' && !!node && 'tokenType' in node;
+}
+
+export interface RootCstNode extends CompositeCstNode {
+    readonly fullText: string
+}
+
+export function isRootCstNode(node: unknown): node is RootCstNode {
+    return isCompositeCstNode(node) && 'fullText' in node;
 }

--- a/packages/langium/test/lsp/go-to/goto-definition.test.ts
+++ b/packages/langium/test/lsp/go-to/goto-definition.test.ts
@@ -30,7 +30,7 @@ interface A {
 }
 
 X returns A:
-    <|>na<|>me=ID;
+    <|>na<|>me<|>=ID;
 `.trim();
 
 const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
@@ -82,6 +82,14 @@ describe('GoToResolver', () => {
         await gotoDefinition({
             text,
             index: 5,
+            rangeIndex: 2
+        });
+    });
+
+    test('Assignment name in parser rule X must find property name in interface A from end of location', async () => {
+        await gotoDefinition({
+            text,
+            index: 6,
             rangeIndex: 2
         });
     });

--- a/packages/langium/test/lsp/hover.test.ts
+++ b/packages/langium/test/lsp/hover.test.ts
@@ -9,7 +9,15 @@ import { expectHover } from '../../src/test';
 import { expectFunction } from '../fixture';
 
 const text = `
-  grammar g
+  /**
+   * I am a grammar file comment
+   */
+  // This is just a single line comment
+  /**
+   * Hi I am a grammar JSDoc comment
+   */
+  // Another single line comment
+  grammar <|>g
   /**
    * Hi I am Rule 'X'
    */
@@ -22,10 +30,18 @@ const hover = expectHover(grammarServices, expectFunction);
 
 describe('Hover', () => {
 
-    test('Hovering over X definition shows the comment hovering', async () => {
+    test('Hovering over the root node should also provide the documentation', async () => {
         await hover({
             text,
             index: 0,
+            hover: 'Hi I am a grammar JSDoc comment'
+        });
+    });
+
+    test('Hovering over X definition shows the comment hovering', async () => {
+        await hover({
+            text,
+            index: 1,
             hover: "Hi I am Rule 'X'"
         });
     });
@@ -33,7 +49,7 @@ describe('Hover', () => {
     test('Hovering over X reference shows the comment hovering', async () => {
         await hover({
             text,
-            index: 1,
+            index: 2,
             hover: "Hi I am Rule 'X'"
         });
     });


### PR DESCRIPTION
Improves the behavior of different LSP services, which operate directly on the CST

* Improves comment finding capabilities if the comment is appended to the root of the document
* Align some off-by-one errors in LSP services to expectations of vscode. When working with names/IDs, vscode expects that they are still found when the cursor is at the end of the token. However, in Langium, we tried to work with the next token, which lead to some unexpected behavior.
  * document highlight
  * renaming
  * go to declaration
  * hover
  * reference finding