### PR TITLE
Prevent stack overflow in completion

### DIFF
--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -109,7 +109,7 @@ export class DefaultCompletionProvider implements CompletionProvider {
 
     protected completionForRule(astNode: AstNode | undefined, rule: ast.AbstractRule, acceptor: CompletionAcceptor): void {
         if (ast.isParserRule(rule)) {
-            const features = findFirstFeatures(rule.definition);
+            const features = findFirstFeatures(rule.definition, new Map(), new Set());
             features.flatMap(e => this.completionFor(astNode, e, acceptor));
         }
     }

--- a/packages/langium/src/lsp/completion/follow-element-computation.ts
+++ b/packages/langium/src/lsp/completion/follow-element-computation.ts
@@ -14,15 +14,20 @@ import { Cardinality, isArray, isOptional } from '../../grammar/grammar-util';
  * @returns Any `AbstractElement` that could be following the given feature stack.
  */
 export function findNextFeatures(featureStack: ast.AbstractElement[]): ast.AbstractElement[] {
-    return findNextFeaturesInternal(featureStack, new Map<ast.AbstractElement, Cardinality>());
+    return findNextFeaturesInternal(featureStack, new Map(), new Set());
 }
 
-export function findNextFeaturesInternal(featureStack: ast.AbstractElement[], cardinalities: Map<ast.AbstractElement, Cardinality>): ast.AbstractElement[] {
+export function findNextFeaturesInternal(featureStack: ast.AbstractElement[], cardinalities: Map<ast.AbstractElement, Cardinality>, visited: Set<ast.AbstractElement>): ast.AbstractElement[] {
     if (featureStack.length === 0) {
         return [];
     }
     const features: ast.AbstractElement[] = [];
     const feature = featureStack[0];
+    if (visited.has(feature)) {
+        return [];
+    } else {
+        visited.add(feature);
+    }
     let parent: ast.Group | undefined;
     let item = feature;
     while (item.$container) {
@@ -37,27 +42,27 @@ export function findNextFeaturesInternal(featureStack: ast.AbstractElement[], ca
     }
     // First try to iterate the same element again
     if (isArray(item.cardinality ?? cardinalities.get(item))) {
-        features.push(...findFirstFeatures(item, cardinalities));
+        features.push(...findFirstFeatures(item, cardinalities, visited));
     }
     if (parent) {
         const ownIndex = parent.elements.indexOf(item);
         // Find next elements of the same group
         if (ownIndex !== undefined && ownIndex < parent.elements.length - 1) {
-            features.push(...findNextFeaturesInGroup(parent, ownIndex + 1, cardinalities));
+            features.push(...findNextFeaturesInGroup(parent, ownIndex + 1, cardinalities, visited));
         }
         if (features.every(e => isOptional(e.cardinality ?? cardinalities.get(e)))) {
             // secondly, try to find the next elements of the parent
-            features.push(...findNextFeaturesInternal([parent], cardinalities));
+            features.push(...findNextFeaturesInternal([parent], cardinalities, visited));
         }
         if (features.every(e => isOptional(e.cardinality ?? cardinalities.get(e)))) {
             // lasty, climb the feature stack and calculate completion for previously called rules
             featureStack.shift();
-            features.push(...findNextFeaturesInternal(featureStack, cardinalities));
+            features.push(...findNextFeaturesInternal(featureStack, cardinalities, visited));
         }
     } else {
         // Climb the feature stack if this feature is the only one in a rule
         featureStack.shift();
-        features.push(...findNextFeaturesInternal(featureStack, cardinalities));
+        features.push(...findNextFeaturesInternal(featureStack, cardinalities, visited));
     }
     return features;
 }
@@ -68,27 +73,27 @@ export function findNextFeaturesInternal(featureStack: ast.AbstractElement[], ca
  * @returns A list of features that could be the first feature of the given `AbstractElement`.
  * These features contain a modified `cardinality` property. If the given `feature` is optional, the returned features will be optional as well.
  */
-export function findFirstFeatures(feature: ast.AbstractElement | undefined, cardinalities?: Map<ast.AbstractElement, Cardinality>): ast.AbstractElement[] {
+export function findFirstFeatures(feature: ast.AbstractElement | undefined, cardinalities: Map<ast.AbstractElement, Cardinality>, visited: Set<ast.AbstractElement>): ast.AbstractElement[] {
     const card = cardinalities ?? new Map();
     if (feature === undefined) {
         return [];
     } else if (ast.isGroup(feature)) {
-        return findNextFeaturesInGroup(feature, 0, card)
+        return findNextFeaturesInGroup(feature, 0, card, visited)
             .map(e => modifyCardinality(e, feature.cardinality, card));
     } else if (ast.isAlternatives(feature)) {
-        return feature.elements.flatMap(e => findFirstFeatures(e, card))
+        return feature.elements.flatMap(e => findFirstFeatures(e, card, visited))
             .map(e => modifyCardinality(e, feature.cardinality, card));
     } else if (ast.isUnorderedGroup(feature)) {
         // TODO: Do we want to continue supporting unordered groups?
         return [];
     } else if (ast.isAssignment(feature)) {
-        return findFirstFeatures(feature.terminal, card)
+        return findFirstFeatures(feature.terminal, card, visited)
             .map(e => modifyCardinality(e, feature.cardinality, card));
     } else if (ast.isAction(feature)) {
-        return findNextFeaturesInternal([feature], card)
+        return findNextFeaturesInternal([feature], card, visited)
             .map(e => modifyCardinality(e, feature.cardinality, card));
     } else if (ast.isRuleCall(feature) && ast.isParserRule(feature.rule.ref)) {
-        return findFirstFeatures(feature.rule.ref.definition, card)
+        return findFirstFeatures(feature.rule.ref.definition, card, visited)
             .map(e => modifyCardinality(e, feature.cardinality, card));
     } else {
         return [feature];
@@ -113,12 +118,12 @@ function modifyCardinality(feature: ast.AbstractElement, cardinality: Cardinalit
     return feature;
 }
 
-function findNextFeaturesInGroup(group: ast.Group, index: number, cardinalities: Map<ast.AbstractElement, Cardinality>): ast.AbstractElement[] {
+function findNextFeaturesInGroup(group: ast.Group, index: number, cardinalities: Map<ast.AbstractElement, Cardinality>, visited: Set<ast.AbstractElement>): ast.AbstractElement[] {
     const features: ast.AbstractElement[] = [];
     let firstFeature: ast.AbstractElement;
     do {
         firstFeature = group.elements[index++];
-        features.push(...findFirstFeatures(firstFeature, cardinalities));
+        features.push(...findFirstFeatures(firstFeature, cardinalities, visited));
         if (!isOptional(firstFeature?.cardinality ?? cardinalities.get(firstFeature))) {
             break;
         }

--- a/packages/langium/src/lsp/completion/rule-interpreter.ts
+++ b/packages/langium/src/lsp/completion/rule-interpreter.ts
@@ -22,7 +22,7 @@ export class RuleInterpreter {
 
     interpretRule(rule: ast.ParserRule, nodes: CstNode[], offset: number): ast.AbstractElement[] {
         let features: ast.AbstractElement[] = [];
-        let nextFeatures = findFirstFeatures(rule.definition);
+        let nextFeatures = findFirstFeatures(rule.definition, new Map(), new Set());
         let node = nodes.shift();
         while (node && nextFeatures.length > 0) {
             const n = node;
@@ -69,7 +69,7 @@ export class RuleInterpreter {
 
     ruleMatches(rule: ast.AbstractRule | undefined, node: CstNode, offset: number): MatchType {
         if (ast.isParserRule(rule)) {
-            const ruleFeatures = findFirstFeatures(rule.definition);
+            const ruleFeatures = findFirstFeatures(rule.definition, new Map(), new Set());
             const matchType = isDataTypeRule(rule) ? 'both' : 'full';
             return ruleFeatures.some(e => this.featureMatches(e, node, offset)) ? matchType : 'none';
         } else if (ast.isTerminalRule(rule)) {


### PR DESCRIPTION
Adds a `visited` set that keeps track of already seen grammar features. The stack overflow can be experienced in some parts of the langium-lox language example.