### PR TITLE
Renamed 'preprocess' phase to clarify document lifecycle

### DIFF
--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -12,7 +12,7 @@ import { CompositeCstNodeImpl } from '../parser/cst-node-builder';
 import { IParserConfig } from '../parser/parser-config';
 import { LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumServices, LangiumSharedServices, PartialLangiumServices, PartialLangiumSharedServices } from '../services';
 import { AstNode, AstNodeDescription, CstNode } from '../syntax-tree';
-import { extractRootNode, getContainerOfType, getDocument, Mutable, streamAllContents } from '../utils/ast-util';
+import { findRootNode, getContainerOfType, getDocument, Mutable, streamAllContents } from '../utils/ast-util';
 import { MultiMap } from '../utils/collections';
 import { streamCst } from '../utils/cst-util';
 import { escapeRegExp } from '../utils/regex-util';
@@ -520,7 +520,7 @@ export function processTypeNodeWithNodeLocator(astNodeLocator: AstNodeLocator): 
  */
 export function processActionNodeWithNodeDescriptionProvider(descriptions: AstNodeDescriptionProvider): (node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes) => void {
     return (node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes) => {
-        const container = extractRootNode(node);
+        const container = findRootNode(node);
         if (container && ast.isAction(node) && node.inferredType) {
             const typeName = getActionType(node);
             if(typeName) {
@@ -528,4 +528,13 @@ export function processActionNodeWithNodeDescriptionProvider(descriptions: AstNo
             }
         }
     };
+}
+
+export function extractAssignments(element: ast.AbstractElement): ast.Assignment[] {
+    if (ast.isAssignment(element)) {
+        return [element];
+    } if (ast.isAlternatives(element) || ast.isGroup(element) || ast.isUnorderedGroup(element)) {
+        return element.elements.flatMap(e => extractAssignments(e));
+    }
+    return [];
 }

--- a/packages/langium/src/grammar/langium-grammar-scope.ts
+++ b/packages/langium/src/grammar/langium-grammar-scope.ts
@@ -7,7 +7,7 @@
 import { DefaultScopeComputation, DefaultScopeProvider, Scope } from '../references/scope';
 import { LangiumServices } from '../services';
 import { AstNode, AstNodeDescription } from '../syntax-tree';
-import { extractRootNode, getDocument } from '../utils/ast-util';
+import { findRootNode, getDocument } from '../utils/ast-util';
 import { stream, Stream } from '../utils/stream';
 import { LangiumDocument, PrecomputedScopes } from '../workspace/documents';
 import { isReturnType } from './generated/ast';
@@ -24,7 +24,7 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
 
         const scopes: Array<Stream<AstNodeDescription>> = [];
         const precomputed = getDocument(node).precomputedScopes;
-        const rootNode = extractRootNode(node);
+        const rootNode = findRootNode(node);
         if (precomputed && rootNode) {
             const allDescriptions = precomputed.get(rootNode);
             const parserRuleScopesArray: AstNodeDescription[] = [];

--- a/packages/langium/src/grammar/references/grammar-references.ts
+++ b/packages/langium/src/grammar/references/grammar-references.ts
@@ -7,14 +7,14 @@
 import { DefaultReferences } from '../../references/references';
 import { LangiumServices } from '../../services';
 import { AstNode, CstNode } from '../../syntax-tree';
-import { extractAssignments, getContainerOfType, getDocument, streamAst } from '../../utils/ast-util';
+import { getContainerOfType, getDocument, streamAst } from '../../utils/ast-util';
 import { findRelevantNode, toDocumentSegment } from '../../utils/cst-util';
 import { stream, Stream } from '../../utils/stream';
 import { equalURI } from '../../utils/uri-utils';
 import { ReferenceDescription } from '../../workspace/ast-descriptions';
 import { LangiumDocuments } from '../../workspace/documents';
 import { Action, Assignment, Interface, isAction, isAssignment, isInterface, isParserRule, isType, isTypeAttribute, ParserRule, Type, TypeAttribute } from '../generated/ast';
-import { findNodeForFeature, getActionAtElement } from '../grammar-util';
+import { extractAssignments, findNodeForFeature, getActionAtElement } from '../grammar-util';
 import { collectChildrenTypes, collectSuperTypes } from '../type-system/types-util';
 
 export class LangiumGrammarReferences extends DefaultReferences {

--- a/packages/langium/src/grammar/type-system/type-validator.ts
+++ b/packages/langium/src/grammar/type-system/type-validator.ts
@@ -5,14 +5,13 @@
  ******************************************************************************/
 
 import { Grammar, Interface, ParserRule, Type } from '../generated/ast';
-import { getRuleType } from '../grammar-util';
+import { extractAssignments, getRuleType } from '../grammar-util';
 import { MultiMap } from '../../utils/collections';
 import { collectDeclaredTypes } from './declared-types';
 import { collectInferredTypes } from './inferred-types';
 import { AstTypes, collectAllAstResources, distictAndSorted, Property, PropertyType, propertyTypeArrayToString, InterfaceType, UnionType, AstResources } from './types-util';
 import { stream } from '../../utils/stream';
 import { ValidationAcceptor } from '../../validation/validation-registry';
-import { extractAssignments } from '../../utils/ast-util';
 
 export function validateTypesConsistency(grammar: Grammar, accept: ValidationAcceptor): void {
     function applyErrorToRuleNodes(nodes: readonly ParserRule[], typeName: string): (errorMessage: string) => void {

--- a/packages/langium/src/references/scope.ts
+++ b/packages/langium/src/references/scope.ts
@@ -147,7 +147,7 @@ export class DefaultScopeProvider implements ScopeProvider {
 }
 
 /**
- * Language-specific service for precomputing the scope for a document. This service is executed as part of the _preprocessing_ phase in the `DocumentBuilder`.
+ * Language-specific service for precomputing the scope for a document. This service is executed as the second phase in the `DocumentBuilder`.
  */
 export interface ScopeComputation {
     /**
@@ -156,7 +156,7 @@ export interface ScopeComputation {
      * to determine which target nodes are visible in the context of a specific cross-reference.
      *
      * _Note:_ You should not resolve any cross-references in this service method. Cross-reference
-     * resolution depends on the preprocessing phase to be completed.
+     * resolution depends on the scope computation phase to be completed.
      *
      * @param document The document in which to compute scopes.
      * @param cancelToken Indicates when to cancel the current operation.

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -42,19 +42,45 @@ export interface LangiumDocument<T extends AstNode = AstNode> {
  * smaller state values are finished as well.
  */
 export enum DocumentState {
-    /** The text content has changed and needs to be parsed again. */
+    /**
+     * The text content has changed and needs to be parsed again. The AST held by this outdated
+     * document instance is no longer valid.
+     */
     Changed = 0,
-    /** An AST has been created from the text content. */
+    /**
+     * An AST has been created from the text content. The document structure can be traversed,
+     * but cross-references cannot be resolved yet. If necessary, the structure can be manipulated
+     * at this stage as a preprocessing step.
+     */
     Parsed = 1,
-    /** The `IndexManager` service has processed AST nodes of this document. */
+    /**
+     * The `IndexManager` service has processed AST nodes of this document. This means the
+     * exported symbols are available in the global scope and can be resolved from other documents.
+     */
     IndexedContent = 2,
-    /** Pre-processing steps such as scope precomputation have been executed. */
-    Processed = 3,
-    /** The `Linker` service has processed this document. */
+    /**
+     * The `ScopeComputation` service has processed this document. This means the local symbols
+     * are stored in a MultiMap so they can be looked up by the `ScopeProvider` service.
+     * Once a document has reached this state, you may follow every reference - it will lazily
+     * resolve its `ref` property and yield either the target AST node or `undefined` in case
+     * the target is not in scope.
+     */
+    ComputedScopes = 3,
+    /**
+     * The `Linker` service has processed this document. All outgoing references have been
+     * resolved or marked as erroneous.
+     */
     Linked = 4,
-    /** The `IndexManager` service has processed AST node references of this document. */
+    /**
+     * The `IndexManager` service has processed AST node references of this document. This is
+     * necessary to determine which documents are affected by a change in one of the workspace
+     * documents.
+     */
     IndexedReferences = 5,
-    /** The `DocumentValidator` service has processed this document. */
+    /**
+     * The `DocumentValidator` service has processed this document. The language server listens
+     * to the results of this phase and sends diagnostics to the client.
+     */
     Validated = 6
 }
 


### PR DESCRIPTION
In the initial draft of the document lifecycle, I named the second phase "preprocessing" because I thought users could extend this with additional processing such as type computation. But this does not work: if you extended the `process` method in DefaultDocumentBuilder, you could resolve local references by calling the `super` implementation first, but there was no guarantee that resolving references in _other_ documents worked because they might not have run through this phase yet (all documents requiring a rebuild are processed sequentially in each phase).

Additional processing should be implemented on user side by adding build listeners to the document builder. We might also consider adding an explicit type computation phase sitting between scope computation and linking.