### PR TITLE
Extend validation options

### DIFF
--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -27,10 +27,12 @@ export interface AstNode {
     readonly $document?: LangiumDocument;
 }
 
+type SpecificNodeProperties<N extends AstNode> = keyof Omit<N, keyof AstNode | number | symbol>;
+
 /**
  * The property names of a given AST node type.
  */
-export type Properties<N extends AstNode> = keyof Omit<N, keyof AstNode | number | symbol>
+export type Properties<N extends AstNode> = SpecificNodeProperties<N> extends never ? string : SpecificNodeProperties<N>
 
 /**
  * A cross-reference in the AST. Cross-references may or may not be successfully resolved.

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -12,17 +12,19 @@ import { isOperationCancelled, MaybePromise } from '../utils/promise-util';
 
 export type DiagnosticInfo<N extends AstNode, P = Properties<N>> = {
     /** The AST node to which the diagnostic is attached. */
-    node: N,
+    node: N;
     /** If a property name is given, the diagnostic is restricted to the corresponding text region. */
-    property?: P,
+    property?: P;
+    /** If the value of a keyword is given, the diagnostic will appear at its corresponding text region */
+    keyword?: string;
     /** In case of a multi-value property (array), an index can be given to select a specific element. */
-    index?: number,
+    index?: number;
     /** If you want to create a diagnostic independent to any property, use the range property. */
-    range?: Range,
+    range?: Range;
     /** The diagnostic's code, which usually appear in the user interface. */
-    code?: integer | string,
+    code?: integer | string;
     /** An optional property to describe the error code. */
-    codeDescription?: CodeDescription,
+    codeDescription?: CodeDescription;
     /** Additional metadata about the diagnostic. */
     tags?: DiagnosticTag[];
     /** An array of related diagnostic information, e.g. when symbol-names within a scope collide all definitions can be marked via this property. */


### PR DESCRIPTION
Brought up in discussion https://github.com/langium/langium/discussions/458#discussioncomment-3364456. If we apply `Properties<AstNode>` the resulting type will be `never`, which isn't really helpful. This change makes it return `string` if we find that the node type given is `AstNode`, so that the user is free to enter any property.

Also extends the validation options to include the `keyword` option. This allows to show validations on keywords without needing to wrap them in an assignment like `keyword?='hello'`.