### PR TITLE
Fix terminal regex builder

### DIFF
--- a/packages/langium/src/grammar/grammar-util.ts
+++ b/packages/langium/src/grammar/grammar-util.ts
@@ -255,13 +255,13 @@ function abstractElementToRegex(element: ast.AbstractElement): string {
         if (!rule) {
             throw new Error('Missing rule reference.');
         }
-        return withCardinality(terminalRegex(rule), element.cardinality, true);
+        return withCardinality(terminalRegex(rule), element.cardinality);
     } else if (ast.isNegatedToken(element)) {
         return negateTokenToRegex(element);
     } else if (ast.isUntilToken(element)) {
         return untilTokenToRegex(element);
     } else if (ast.isRegexToken(element)) {
-        return withCardinality(element.regex, element.cardinality, true);
+        return withCardinality(element.regex, element.cardinality, false);
     } else if (ast.isWildcard(element)) {
         return withCardinality(WILDCARD, element.cardinality);
     } else {
@@ -270,7 +270,7 @@ function abstractElementToRegex(element: ast.AbstractElement): string {
 }
 
 function terminalAlternativesToRegex(alternatives: ast.TerminalAlternatives): string {
-    return withCardinality(`(${alternatives.elements.map(abstractElementToRegex).join('|')})`, alternatives.cardinality);
+    return withCardinality(alternatives.elements.map(abstractElementToRegex).join('|'), alternatives.cardinality);
 }
 
 function terminalGroupToRegex(group: ast.TerminalGroup): string {
@@ -282,25 +282,25 @@ function untilTokenToRegex(until: ast.UntilToken): string {
 }
 
 function negateTokenToRegex(negate: ast.NegatedToken): string {
-    return withCardinality(`(?!${abstractElementToRegex(negate.terminal)})${WILDCARD}*?`, negate.cardinality, true);
+    return withCardinality(`(?!${abstractElementToRegex(negate.terminal)})${WILDCARD}*?`, negate.cardinality);
 }
 
 function characterRangeToRegex(range: ast.CharacterRange): string {
     if (range.right) {
-        return withCardinality(`[${keywordToRegex(range.left)}-${keywordToRegex(range.right)}]`, range.cardinality);
+        return withCardinality(`[${keywordToRegex(range.left)}-${keywordToRegex(range.right)}]`, range.cardinality, false);
     }
-    return withCardinality(keywordToRegex(range.left), range.cardinality, true);
+    return withCardinality(keywordToRegex(range.left), range.cardinality, false);
 }
 
 function keywordToRegex(keyword: ast.Keyword): string {
     return escapeRegExp(keyword.value);
 }
 
-function withCardinality(regex: string, cardinality?: string, wrap = false): string {
+function withCardinality(regex: string, cardinality?: string, wrap = true): string {
+    if (wrap) {
+        regex = `(${regex})`;
+    }
     if (cardinality) {
-        if (wrap) {
-            regex = `(${regex})`;
-        }
         return `${regex}${cardinality}`;
     }
     return regex;

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -145,7 +145,7 @@ describe('TerminalRule to regex', () => {
     test('Should create combined regexes', async () => {
         const terminal = await getTerminal('terminal X: /x/ /y/;');
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('xy');
+        expect(regex).toBe('(xy)');
     });
 
     test('Should create optional alternatives with keywords', async () => {
@@ -160,7 +160,7 @@ describe('TerminalRule to regex', () => {
         terminal Y: 'a';
         `, 'X');
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('aa');
+        expect(regex).toBe('((a)(a))');
     });
 
     test('Should create negated token', async () => {


### PR DESCRIPTION
Fixes an issue brought up in https://github.com/langium/langium/discussions/638. The issue was that we weren't surrounding some items with parenthesis, so that mixed regexes sometimes didn't work as expected. The new approach is a bit more conversative (adds parenthesis even if they might not be necessary) in favor of being also always correct.