### PR TITLE
Reworked scope provider API

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { AstNode, AstReflection, Reference, isAstNode, TypeMetaData } from 'langium';
+import { AstNode, AstReflection, Reference, ReferenceInfo, isAstNode, TypeMetaData } from 'langium';
 
 export type AbstractDefinition = DeclaredParameter | Definition;
 
@@ -115,8 +115,6 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
 
 export type ArithmeticsAstType = 'AbstractDefinition' | 'BinaryExpression' | 'DeclaredParameter' | 'Definition' | 'Evaluation' | 'Expression' | 'FunctionCall' | 'Module' | 'NumberLiteral' | 'Statement';
 
-export type ArithmeticsAstReference = 'FunctionCall:func';
-
 export class ArithmeticsAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
@@ -152,7 +150,8 @@ export class ArithmeticsAstReflection implements AstReflection {
         }
     }
 
-    getReferenceType(referenceId: ArithmeticsAstReference): string {
+    getReferenceType(refInfo: ReferenceInfo): string {
+        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'FunctionCall:func': {
                 return AbstractDefinition;

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { AstNode, AstReflection, Reference, isAstNode, TypeMetaData } from 'langium';
+import { AstNode, AstReflection, Reference, ReferenceInfo, isAstNode, TypeMetaData } from 'langium';
 
 export type AbstractElement = PackageDeclaration | Type;
 
@@ -86,8 +86,6 @@ export function isPackageDeclaration(item: unknown): item is PackageDeclaration 
 
 export type DomainModelAstType = 'AbstractElement' | 'DataType' | 'Domainmodel' | 'Entity' | 'Feature' | 'PackageDeclaration' | 'Type';
 
-export type DomainModelAstReference = 'Entity:superType' | 'Feature:type';
-
 export class DomainModelAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
@@ -117,7 +115,8 @@ export class DomainModelAstReflection implements AstReflection {
         }
     }
 
-    getReferenceType(referenceId: DomainModelAstReference): string {
+    getReferenceType(refInfo: ReferenceInfo): string {
+        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'Entity:superType': {
                 return Entity;

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { AstNode, AstReflection, Reference, isAstNode, TypeMetaData } from 'langium';
+import { AstNode, AstReflection, Reference, ReferenceInfo, isAstNode, TypeMetaData } from 'langium';
 
 export interface Command extends AstNode {
     readonly $container: Statemachine;
@@ -70,8 +70,6 @@ export function isTransition(item: unknown): item is Transition {
 
 export type StatemachineAstType = 'Command' | 'Event' | 'State' | 'Statemachine' | 'Transition';
 
-export type StatemachineAstReference = 'State:actions' | 'Statemachine:init' | 'Transition:event' | 'Transition:state';
-
 export class StatemachineAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
@@ -93,7 +91,8 @@ export class StatemachineAstReflection implements AstReflection {
         }
     }
 
-    getReferenceType(referenceId: StatemachineAstReference): string {
+    getReferenceType(refInfo: ReferenceInfo): string {
+        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'State:actions': {
                 return Command;

--- a/packages/langium/src/grammar/ast-reflection-interpreter.ts
+++ b/packages/langium/src/grammar/ast-reflection-interpreter.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstReflection, TypeMandatoryProperty, TypeMetaData } from '../syntax-tree';
+import { AstReflection, ReferenceInfo, TypeMandatoryProperty, TypeMetaData } from '../syntax-tree';
 import { isAstNode } from '../utils/ast-util';
 import { MultiMap } from '../utils/collections';
 import { LangiumDocuments } from '../workspace/documents';
@@ -37,7 +37,8 @@ export function interpretAstReflection(grammarOrTypes: Grammar | AstTypes, docum
         getAllTypes() {
             return allTypes;
         },
-        getReferenceType(referenceId: string): string {
+        getReferenceType(refInfo: ReferenceInfo): string {
+            const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
             const referenceType = references.get(referenceId);
             if (referenceType) {
                 return referenceType;

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { AstNode, AstReflection, Reference, TypeMetaData } from '../../syntax-tree';
+import type { AstNode, AstReflection, Reference, ReferenceInfo, TypeMetaData } from '../../syntax-tree';
 import { isAstNode } from '../../utils/ast-util';
 
 export type AbstractRule = ParserRule | TerminalRule;
@@ -455,8 +455,6 @@ export function isWildcard(item: unknown): item is Wildcard {
 
 export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'InferredType' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
 
-export type LangiumGrammarAstReference = 'Action:type' | 'AtomType:refType' | 'CrossReference:type' | 'Grammar:hiddenTokens' | 'Grammar:usedGrammars' | 'Interface:superTypes' | 'NamedArgument:parameter' | 'ParameterReference:parameter' | 'ParserRule:hiddenTokens' | 'ParserRule:returnType' | 'RuleCall:rule' | 'TerminalRuleCall:rule';
-
 export class LangiumGrammarAstReflection implements AstReflection {
 
     getAllTypes(): string[] {
@@ -515,7 +513,8 @@ export class LangiumGrammarAstReflection implements AstReflection {
         }
     }
 
-    getReferenceType(referenceId: LangiumGrammarAstReference): string {
+    getReferenceType(refInfo: ReferenceInfo): string {
+        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'Action:type': {
                 return AbstractType;

--- a/packages/langium/src/grammar/langium-grammar-scope.ts
+++ b/packages/langium/src/grammar/langium-grammar-scope.ts
@@ -6,7 +6,7 @@
 
 import { DefaultScopeComputation, DefaultScopeProvider, Scope } from '../references/scope';
 import { LangiumServices } from '../services';
-import { AstNode, AstNodeDescription } from '../syntax-tree';
+import { AstNode, AstNodeDescription, ReferenceInfo } from '../syntax-tree';
 import { findRootNode, getDocument } from '../utils/ast-util';
 import { stream, Stream } from '../utils/stream';
 import { LangiumDocument, PrecomputedScopes } from '../workspace/documents';
@@ -18,13 +18,13 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
         super(services);
     }
 
-    getScope(node: AstNode, referenceId: string): Scope {
-        const referenceType = this.reflection.getReferenceType(referenceId);
-        if (referenceType !== 'AbstractType') return super.getScope(node, referenceId);
+    getScope(context: ReferenceInfo): Scope {
+        const referenceType = this.reflection.getReferenceType(context);
+        if (referenceType !== 'AbstractType') return super.getScope(context);
 
         const scopes: Array<Stream<AstNodeDescription>> = [];
-        const precomputed = getDocument(node).precomputedScopes;
-        const rootNode = findRootNode(node);
+        const precomputed = getDocument(context.container).precomputedScopes;
+        const rootNode = findRootNode(context.container);
         if (precomputed && rootNode) {
             const allDescriptions = precomputed.get(rootNode);
             const parserRuleScopesArray: AstNodeDescription[] = [];

--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -7,11 +7,10 @@
 import { CancellationToken, CompletionItem, CompletionItemKind, CompletionList, CompletionParams } from 'vscode-languageserver';
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
 import * as ast from '../../grammar/generated/ast';
-import { getTypeNameAtElement } from '../../grammar/grammar-util';
 import { isNamed } from '../../references/naming';
 import { ScopeProvider } from '../../references/scope';
 import { LangiumServices } from '../../services';
-import { AstNode, AstNodeDescription, CstNode } from '../../syntax-tree';
+import { AstNode, AstNodeDescription, CstNode, Reference, ReferenceInfo } from '../../syntax-tree';
 import { getContainerOfType, isAstNode } from '../../utils/ast-util';
 import { findLeafNodeAtOffset, flattenCst } from '../../utils/cst-util';
 import { MaybePromise } from '../../utils/promise-util';
@@ -128,7 +127,12 @@ export class DefaultCompletionProvider implements CompletionProvider {
         const assignment = getContainerOfType(crossRef, ast.isAssignment);
         const parserRule = getContainerOfType(crossRef, ast.isParserRule);
         if (assignment && parserRule) {
-            const scope = this.scopeProvider.getScope(context, `${getTypeNameAtElement(parserRule, assignment)}:${assignment.feature}`);
+            const refInfo: ReferenceInfo = {
+                reference: {} as Reference,
+                container: context,
+                property: assignment.feature
+            };
+            const scope = this.scopeProvider.getScope(refInfo);
             const duplicateStore = new Set<string>();
             scope.getAllElements().forEach(e => {
                 if (!duplicateStore.has(e.name)) {

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { AstNode, Reference } from '../syntax-tree';
-import { Linker, getReferenceId } from '../references/linker';
+import { Linker } from '../references/linker';
 import { LangiumServices } from '../services';
 import { isAstNode, isReference } from '../utils/ast-util';
 
@@ -88,8 +88,7 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
                     if (isReference(item) && isAstNode(container)) {
-                        const refId = getReferenceId(container.$type, propName!);
-                        const reference = this.linker.buildReference(container, item.$refNode, refId, item.$refText);
+                        const reference = this.linker.buildReference(container, propName!, item.$refNode, item.$refText);
                         value[i] = reference;
                     } else if (typeof item === 'object' && item !== null) {
                         internalRevive(item);
@@ -102,8 +101,7 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 for (const [name, item] of Object.entries(value)) {
                     if (typeof item === 'object' && item !== null) {
                         if (isReference(item)) {
-                            const refId = getReferenceId(value.$type, name);
-                            const reference = this.linker.buildReference(value as AstNode, item.$refNode, refId, item.$refText);
+                            const reference = this.linker.buildReference(value as AstNode, name, item.$refNode, item.$refText);
                             value[name] = reference;
                         } else if (Array.isArray(item)) {
                             internalRevive(item, value, name);

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -96,7 +96,7 @@ export interface LinkingError extends ReferenceInfo {
  */
 export interface AstReflection {
     getAllTypes(): string[]
-    getReferenceType(referenceId: string): string
+    getReferenceType(refInfo: ReferenceInfo): string
     getTypeMetaData(type: string): TypeMetaData
     isInstance(node: unknown, type: string): boolean
     isSubtype(subtype: string, supertype: string): boolean


### PR DESCRIPTION
This changes the input arguments of the ScopeProvider service to using ReferenceInfo, enabling us to get rid of the `referenceId` concept. Instead of generating strings with colon-separated information, we use a proper object.

@msujew please look carefully into the completion provider. I guess that needs more adaptation to make it consistent with the expected API.