### PR TITLE
optimizing findLeafNodeAtOffset() to use a binary search algorithm

### DIFF
--- a/packages/langium/src/utils/cst-util.ts
+++ b/packages/langium/src/utils/cst-util.ts
@@ -109,12 +109,19 @@ export function findLeafNodeAtOffset(node: CstNode, offset: number): LeafCstNode
     if (isLeafCstNode(node)) {
         return node;
     } else if (isCompositeCstNode(node)) {
-        const children = node.children.filter(e => e.offset <= offset).reverse();
-        for (const child of children) {
-            const result = findLeafNodeAtOffset(child, offset);
-            if (result) {
-                return result;
+        let firstChild = 0;
+        let lastChild = node.children.length - 1;
+        while (firstChild <= lastChild) {
+            let middleChild = Math.floor((firstChild + lastChild) / 2);
+            const n = node.children[middleChild];
+            if (n.offset > offset) {
+                lastChild = middleChild - 1;
+            } else if (n.end <= offset) {
+                firstChild = middleChild + 1;
+            } else {
+                return findLeafNodeAtOffset(n, offset);
             }
+            middleChild = Math.floor((firstChild + lastChild) / 2);
         }
     }
     return undefined;


### PR DESCRIPTION
This change addresses [#630 ](https://github.com/langium/langium/issues/630) by implementing a binary search on the children of a composite CST node in O(log n) time.