### PR TITLE
Run GitHub Actions on all pull requests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Right now, GH actions are only executed for pushes directly on our repo. In order for actions to run on pull requests from forks, some modification in our workflows file is needed.