### PR TITLE
Added utility method to create a scope from AST nodes

### DIFF
--- a/packages/langium/src/utils/stream.ts
+++ b/packages/langium/src/utils/stream.ts
@@ -126,6 +126,12 @@ export interface Stream<T> extends Iterable<T> {
     filter(predicate: (value: T) => unknown): Stream<T>;
 
     /**
+     * Returns the elements of the stream that are _non-nullable_, which means they are neither `undefined`
+     * nor `null`.
+     */
+    nonNullable(): Stream<NonNullable<T>>;
+
+    /**
      * Calls the specified callback function for all elements in the stream. The return value of the
      * callback function is the accumulated result, and is provided as an argument in the next call to
      * the callback function.
@@ -431,6 +437,10 @@ export class StreamImpl<S, T> implements Stream<T> {
                 return DONE_RESULT;
             }
         );
+    }
+
+    nonNullable(): Stream<NonNullable<T>> {
+        return this.filter(e => e !== undefined && e !== null) as Stream<NonNullable<T>>;
     }
 
     reduce<U>(callbackfn: (previousValue: U | T, currentValue: T) => U, initialValue?: U): U | T | undefined {


### PR DESCRIPTION
This makes the process of customizing a scope provider simpler: you can get a scope just by calling a method with a collection of elements you got from the AST.