### PR TITLE
Changed semantic token for fragments

### DIFF
--- a/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
+++ b/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
@@ -7,7 +7,7 @@
 import { SemanticTokenTypes } from 'vscode-languageserver';
 import { AstNode } from '../../syntax-tree';
 import { AbstractSemanticTokenProvider, SemanticTokenAcceptor } from '../../lsp/semantic-token-provider';
-import { isAction, isAssignment, isAtomType, isParameter, isParameterReference, isReturnType } from '../generated/ast';
+import { isAction, isAssignment, isAtomType, isParameter, isParameterReference, isReturnType, isRuleCall } from '../generated/ast';
 
 export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenProvider {
 
@@ -52,6 +52,14 @@ export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenPr
                 feature: 'parameter',
                 type: SemanticTokenTypes.parameter
             });
+        } else if (isRuleCall(node)) {
+            if (node.rule.ref?.fragment) {
+                acceptor({
+                    node,
+                    feature: 'rule',
+                    type: SemanticTokenTypes.type
+                });
+            }
         }
     }
 


### PR DESCRIPTION

Changed the semantic token for fragments inside of a Parser Rule.

I chose `SemanticTokenTypes.type` to have something similar to the color we have in `type A = B  |  C`

Closes #602 

<img width="246" alt="Screenshot 2022-09-06 at 10 09 46" src="https://user-images.githubusercontent.com/44747557/188585752-2287a174-0351-4409-a6cf-c00811152d37.png">
<img width="257" alt="Screenshot 2022-09-06 at 10 09 59" src="https://user-images.githubusercontent.com/44747557/188585784-9225ce70-f60d-4610-8adc-63ef1e7384c7.png">
