### PR TITLE
Remove grammar imports on rule embedding

### DIFF
--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -85,6 +85,8 @@ function embedReferencedRules(grammar: Grammar, map: Map<Grammar, AbstractRule[]
             grammar.rules.push(...rules);
         }
     }
+    // Remove all imports, as their contents are now available in the grammar
+    grammar.imports = [];
 }
 
 async function buildAll(config: LangiumConfig): Promise<Map<string, LangiumDocument>> {


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/671

This is an issue which has accidentally been introduced in https://github.com/langium/langium/pull/546. When trying to validate the parser of a grammar with imports, the AST reflection interpreter will try to resolve the imports of the grammar. However, this is not necessary, since all imports have already been resolved at this point. Instead, it will just crash the langium-cli process.

This change removes all imports once they have been embedded, making this a non-issue.