### PR TITLE
Pass target type into reference

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { AstNode, AstReflection, Reference, ReferenceInfo, isAstNode, TypeMetaData } from 'langium';
+import { AstNode, AstReflection, Reference, isAstNode, TypeMetaData } from 'langium';
 
 export type AbstractDefinition = DeclaredParameter | Definition;
 
@@ -146,18 +146,6 @@ export class ArithmeticsAstReflection implements AstReflection {
             }
             default: {
                 return false;
-            }
-        }
-    }
-
-    getReferenceType(refInfo: ReferenceInfo): string {
-        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
-        switch (referenceId) {
-            case 'FunctionCall:func': {
-                return AbstractDefinition;
-            }
-            default: {
-                throw new Error(`${referenceId} is not a valid reference id.`);
             }
         }
     }

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -29,7 +29,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -41,7 +42,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Statement"
+                "$refText": "Statement",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
@@ -64,14 +66,16 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Definition"
+              "$refText": "Definition",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Evaluation"
+              "$refText": "Evaluation",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -101,7 +105,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -120,7 +125,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "DeclaredParameter"
+                    "$refText": "DeclaredParameter",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -139,7 +145,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "DeclaredParameter"
+                        "$refText": "DeclaredParameter",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -165,7 +172,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Expression"
+                "$refText": "Expression",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -193,7 +201,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refType": "AbstractRule"
           },
           "arguments": []
         }
@@ -218,7 +227,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Expression"
+                "$refText": "Expression",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -242,7 +252,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$refText": "Addition"
+          "$refText": "Addition",
+          "$refType": "AbstractRule"
         },
         "arguments": []
       },
@@ -266,7 +277,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Multiplication"
+              "$refText": "Multiplication",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -307,7 +319,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Multiplication"
+                    "$refText": "Multiplication",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -337,7 +350,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PrimaryExpression"
+              "$refText": "PrimaryExpression",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -378,7 +392,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "PrimaryExpression"
+                    "$refText": "PrimaryExpression",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -415,7 +430,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "Expression"
+                  "$refText": "Expression",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               },
@@ -442,7 +458,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NUMBER"
+                    "$refText": "NUMBER",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -466,7 +483,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractDefinition"
+                    "$refText": "AbstractDefinition",
+                    "$refType": "AbstractType"
                   },
                   "deprecatedSyntax": false
                 }
@@ -485,7 +503,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Expression"
+                        "$refText": "Expression",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -504,7 +523,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "Expression"
+                            "$refText": "Expression",
+                            "$refType": "AbstractRule"
                           },
                           "arguments": []
                         }
@@ -592,7 +612,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Definition"
+            "$refText": "Definition",
+            "$refType": "AbstractType"
           },
           "isArray": false,
           "isRef": false
@@ -600,7 +621,8 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "DeclaredParameter"
+            "$refText": "DeclaredParameter",
+            "$refType": "AbstractType"
           },
           "isArray": false,
           "isRef": false

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { AstNode, AstReflection, Reference, ReferenceInfo, isAstNode, TypeMetaData } from 'langium';
+import { AstNode, AstReflection, Reference, isAstNode, TypeMetaData } from 'langium';
 
 export type AbstractElement = PackageDeclaration | Type;
 
@@ -111,21 +111,6 @@ export class DomainModelAstReflection implements AstReflection {
             }
             default: {
                 return false;
-            }
-        }
-    }
-
-    getReferenceType(refInfo: ReferenceInfo): string {
-        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
-        switch (referenceId) {
-            case 'Entity:superType': {
-                return Entity;
-            }
-            case 'Feature:type': {
-                return Type;
-            }
-            default: {
-                throw new Error(`${referenceId} is not a valid reference id.`);
             }
         }
     }

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -22,7 +22,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "AbstractElement"
+            "$refText": "AbstractElement",
+            "$refType": "AbstractRule"
           },
           "arguments": []
         },
@@ -43,14 +44,16 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PackageDeclaration"
+              "$refText": "PackageDeclaration",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Type"
+              "$refText": "Type",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -80,7 +83,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "QualifiedName"
+                "$refText": "QualifiedName",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -96,7 +100,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AbstractElement"
+                "$refText": "AbstractElement",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
@@ -124,14 +129,16 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "DataType"
+              "$refText": "DataType",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Entity"
+              "$refText": "Entity",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -161,7 +168,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -192,7 +200,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -211,12 +220,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Entity"
+                    "$refText": "Entity",
+                    "$refType": "AbstractType"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "QualifiedName"
+                      "$refText": "QualifiedName",
+                      "$refType": "AbstractRule"
                     },
                     "arguments": []
                   },
@@ -237,7 +248,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Feature"
+                "$refText": "Feature",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
@@ -279,7 +291,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -295,12 +308,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "Type"
+                "$refText": "Type",
+                "$refType": "AbstractType"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "QualifiedName"
+                  "$refText": "QualifiedName",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               },
@@ -326,7 +341,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$refText": "ID",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -340,7 +356,8 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               }

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { AstNode, AstReflection, Reference, ReferenceInfo, isAstNode, TypeMetaData } from 'langium';
+import { AstNode, AstReflection, Reference, isAstNode, TypeMetaData } from 'langium';
 
 export interface Command extends AstNode {
     readonly $container: Statemachine;
@@ -87,27 +87,6 @@ export class StatemachineAstReflection implements AstReflection {
         switch (subtype) {
             default: {
                 return false;
-            }
-        }
-    }
-
-    getReferenceType(refInfo: ReferenceInfo): string {
-        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
-        switch (referenceId) {
-            case 'State:actions': {
-                return Command;
-            }
-            case 'Statemachine:init': {
-                return State;
-            }
-            case 'Transition:event': {
-                return Event;
-            }
-            case 'Transition:state': {
-                return State;
-            }
-            default: {
-                throw new Error(`${referenceId} is not a valid reference id.`);
             }
         }
     }

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -29,7 +29,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -48,7 +49,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Event"
+                    "$refText": "Event",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 },
@@ -71,7 +73,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Command"
+                    "$refText": "Command",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 },
@@ -91,7 +94,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "State"
+                "$refText": "State",
+                "$refType": "AbstractType"
               },
               "deprecatedSyntax": false
             }
@@ -103,7 +107,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "State"
+                "$refText": "State",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
@@ -127,7 +132,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refType": "AbstractRule"
           },
           "arguments": []
         }
@@ -149,7 +155,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refType": "AbstractRule"
           },
           "arguments": []
         }
@@ -178,7 +185,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -201,7 +209,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Command"
+                    "$refText": "Command",
+                    "$refType": "AbstractType"
                   },
                   "deprecatedSyntax": false
                 },
@@ -221,7 +230,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Transition"
+                "$refText": "Transition",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
@@ -253,7 +263,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "Event"
+                "$refText": "Event",
+                "$refType": "AbstractType"
               },
               "deprecatedSyntax": false
             }
@@ -269,7 +280,8 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "State"
+                "$refText": "State",
+                "$refType": "AbstractType"
               },
               "deprecatedSyntax": false
             }

--- a/packages/langium/src/grammar/ast-reflection-interpreter.ts
+++ b/packages/langium/src/grammar/ast-reflection-interpreter.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstReflection, ReferenceInfo, TypeMandatoryProperty, TypeMetaData } from '../syntax-tree';
+import { AstReflection, TypeMandatoryProperty, TypeMetaData } from '../syntax-tree';
 import { isAstNode } from '../utils/ast-util';
 import { MultiMap } from '../utils/collections';
 import { LangiumDocuments } from '../workspace/documents';
@@ -29,21 +29,12 @@ export function interpretAstReflection(grammarOrTypes: Grammar | AstTypes, docum
         collectedTypes = grammarOrTypes;
     }
     const allTypes = collectedTypes.interfaces.map(e => e.name).concat(collectedTypes.unions.map(e => e.name));
-    const references = buildReferenceTypes(collectedTypes);
     const metaData = buildTypeMetaData(collectedTypes);
     const superTypeMap = buildSupertypeMap(collectedTypes);
 
     return {
         getAllTypes() {
             return allTypes;
-        },
-        getReferenceType(refInfo: ReferenceInfo): string {
-            const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
-            const referenceType = references.get(referenceId);
-            if (referenceType) {
-                return referenceType;
-            }
-            throw new Error('Could not find reference type for ' + referenceId);
         },
         getTypeMetaData(type: string): TypeMetaData {
             return metaData.get(type) ?? {
@@ -67,20 +58,6 @@ export function interpretAstReflection(grammarOrTypes: Grammar | AstTypes, docum
             return false;
         }
     };
-}
-
-function buildReferenceTypes(astTypes: AstTypes): Map<string, string> {
-    const references = new Map<string, string>();
-    for (const interfaceType of astTypes.interfaces) {
-        for (const property of interfaceType.properties) {
-            for (const propertyAlternative of property.typeAlternatives) {
-                if (propertyAlternative.reference) {
-                    references.set(`${interfaceType.name}:${property.name}`, propertyAlternative.types[0]);
-                }
-            }
-        }
-    }
-    return references;
 }
 
 function buildTypeMetaData(astTypes: AstTypes): Map<string, TypeMetaData> {

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/array-type */
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import type { AstNode, AstReflection, Reference, ReferenceInfo, TypeMetaData } from '../../syntax-tree';
+import type { AstNode, AstReflection, Reference, TypeMetaData } from '../../syntax-tree';
 import { isAstNode } from '../../utils/ast-util';
 
 export type AbstractRule = ParserRule | TerminalRule;
@@ -509,51 +509,6 @@ export class LangiumGrammarAstReflection implements AstReflection {
             }
             default: {
                 return false;
-            }
-        }
-    }
-
-    getReferenceType(refInfo: ReferenceInfo): string {
-        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
-        switch (referenceId) {
-            case 'Action:type': {
-                return AbstractType;
-            }
-            case 'AtomType:refType': {
-                return AbstractType;
-            }
-            case 'CrossReference:type': {
-                return AbstractType;
-            }
-            case 'Grammar:hiddenTokens': {
-                return AbstractRule;
-            }
-            case 'Grammar:usedGrammars': {
-                return Grammar;
-            }
-            case 'Interface:superTypes': {
-                return AbstractType;
-            }
-            case 'NamedArgument:parameter': {
-                return Parameter;
-            }
-            case 'ParameterReference:parameter': {
-                return Parameter;
-            }
-            case 'ParserRule:hiddenTokens': {
-                return AbstractRule;
-            }
-            case 'ParserRule:returnType': {
-                return AbstractType;
-            }
-            case 'RuleCall:rule': {
-                return AbstractRule;
-            }
-            case 'TerminalRuleCall:rule': {
-                return TerminalRule;
-            }
-            default: {
-                throw new Error(`${referenceId} is not a valid reference id.`);
             }
         }
     }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "ID"
+                    "$refText": "ID",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -57,12 +58,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "Grammar"
+                        "$refText": "Grammar",
+                        "$refType": "AbstractType"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$refText": "ID"
+                          "$refText": "ID",
+                          "$refType": "AbstractRule"
                         },
                         "arguments": []
                       },
@@ -83,12 +86,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "Grammar"
+                            "$refText": "Grammar",
+                            "$refType": "AbstractType"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refType": "AbstractRule"
                             },
                             "arguments": []
                           },
@@ -127,12 +132,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractRule"
+                            "$refText": "AbstractRule",
+                            "$refType": "AbstractType"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refType": "AbstractRule"
                             },
                             "arguments": []
                           },
@@ -153,12 +160,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                             "terminal": {
                               "$type": "CrossReference",
                               "type": {
-                                "$refText": "AbstractRule"
+                                "$refText": "AbstractRule",
+                                "$refType": "AbstractType"
                               },
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$refText": "ID"
+                                  "$refText": "ID",
+                                  "$refType": "AbstractRule"
                                 },
                                 "arguments": []
                               },
@@ -188,7 +197,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "GrammarImport"
+                "$refText": "GrammarImport",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
@@ -204,7 +214,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractRule"
+                    "$refText": "AbstractRule",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -216,7 +227,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Interface"
+                    "$refText": "Interface",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -228,7 +240,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Type"
+                    "$refText": "Type",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -261,7 +274,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -280,7 +294,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractType"
+                    "$refText": "AbstractType",
+                    "$refType": "AbstractType"
                   },
                   "deprecatedSyntax": false
                 }
@@ -299,7 +314,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "AbstractType"
+                        "$refText": "AbstractType",
+                        "$refType": "AbstractType"
                       },
                       "deprecatedSyntax": false
                     }
@@ -313,7 +329,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "SchemaType"
+              "$refText": "SchemaType",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -344,7 +361,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TypeAttribute"
+                "$refText": "TypeAttribute",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
@@ -380,7 +398,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -402,7 +421,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TypeAlternatives"
+              "$refText": "TypeAlternatives",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -434,7 +454,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AtomType"
+                "$refText": "AtomType",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -453,7 +474,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AtomType"
+                    "$refText": "AtomType",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -488,7 +510,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "PrimitiveType"
+                        "$refText": "PrimitiveType",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -513,7 +536,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractType"
+                            "$refText": "AbstractType",
+                            "$refType": "AbstractType"
                           },
                           "deprecatedSyntax": false
                         }
@@ -541,7 +565,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Keyword"
+                "$refText": "Keyword",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -608,7 +633,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -620,7 +646,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TypeAlternatives"
+              "$refText": "TypeAlternatives",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -647,14 +674,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParserRule"
+              "$refText": "ParserRule",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalRule"
+              "$refText": "TerminalRule",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -684,7 +713,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$refText": "STRING",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -736,7 +766,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleNameAndParams"
+              "$refText": "RuleNameAndParams",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -769,12 +800,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractType"
+                            "$refText": "AbstractType",
+                            "$refType": "AbstractType"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refType": "AbstractRule"
                             },
                             "arguments": []
                           },
@@ -788,7 +821,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "PrimitiveType"
+                            "$refText": "PrimitiveType",
+                            "$refType": "AbstractRule"
                           },
                           "arguments": []
                         }
@@ -804,7 +838,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "InferredType"
+                    "$refText": "InferredType",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": [
                     {
@@ -847,12 +882,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "AbstractRule"
+                        "$refText": "AbstractRule",
+                        "$refType": "AbstractType"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$refText": "ID"
+                          "$refText": "ID",
+                          "$refType": "AbstractRule"
                         },
                         "arguments": []
                       },
@@ -873,12 +910,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractRule"
+                            "$refText": "AbstractRule",
+                            "$refType": "AbstractType"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$refText": "ID",
+                              "$refType": "AbstractRule"
                             },
                             "arguments": []
                           },
@@ -909,7 +948,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Alternatives"
+                "$refText": "Alternatives",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -947,7 +987,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "guardCondition": {
                   "$type": "ParameterReference",
                   "parameter": {
-                    "$refText": "imperative"
+                    "$refText": "imperative",
+                    "$refType": "Parameter"
                   }
                 },
                 "elements": [
@@ -964,7 +1005,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "value": {
                     "$type": "ParameterReference",
                     "parameter": {
-                      "$refText": "imperative"
+                      "$refText": "imperative",
+                      "$refType": "Parameter"
                     }
                   }
                 },
@@ -984,7 +1026,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -1011,7 +1054,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -1033,7 +1077,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Parameter"
+                        "$refText": "Parameter",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -1052,7 +1097,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "Parameter"
+                            "$refText": "Parameter",
+                            "$refType": "AbstractRule"
                           },
                           "arguments": []
                         }
@@ -1088,7 +1134,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$refText": "ID",
+            "$refType": "AbstractRule"
           },
           "arguments": []
         }
@@ -1113,7 +1160,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ConditionalBranch"
+              "$refText": "ConditionalBranch",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -1143,7 +1191,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ConditionalBranch"
+                        "$refText": "ConditionalBranch",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -1176,7 +1225,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "UnorderedGroup"
+              "$refText": "UnorderedGroup",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -1201,7 +1251,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Disjunction"
+                    "$refText": "Disjunction",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -1217,7 +1268,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractToken"
+                    "$refText": "AbstractToken",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 },
@@ -1247,7 +1299,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Group"
+              "$refText": "Group",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -1277,7 +1330,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Group"
+                        "$refText": "Group",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -1310,7 +1364,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AbstractToken"
+              "$refText": "AbstractToken",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -1333,7 +1388,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractToken"
+                    "$refText": "AbstractToken",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 },
@@ -1364,14 +1420,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AbstractTokenWithCardinality"
+              "$refText": "AbstractTokenWithCardinality",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Action"
+              "$refText": "Action",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -1400,14 +1458,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "Assignment"
+                  "$refText": "Assignment",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               },
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "AbstractTerminal"
+                  "$refText": "AbstractTerminal",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               }
@@ -1476,12 +1536,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractType"
+                    "$refText": "AbstractType",
+                    "$refType": "AbstractType"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "ID"
+                      "$refText": "ID",
+                      "$refType": "AbstractRule"
                     },
                     "arguments": []
                   },
@@ -1495,7 +1557,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "InferredType"
+                    "$refText": "InferredType",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": [
                     {
@@ -1525,7 +1588,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "FeatureName"
+                    "$refText": "FeatureName",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -1581,42 +1645,48 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$refText": "Keyword",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$refText": "RuleCall",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedElement"
+              "$refText": "ParenthesizedElement",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedKeyword"
+              "$refText": "PredicatedKeyword",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedRuleCall"
+              "$refText": "PredicatedRuleCall",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedGroup"
+              "$refText": "PredicatedGroup",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -1639,7 +1709,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "STRING"
+            "$refText": "STRING",
+            "$refType": "AbstractRule"
           },
           "arguments": []
         }
@@ -1664,12 +1735,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractRule"
+                "$refText": "AbstractRule",
+                "$refType": "AbstractType"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               },
@@ -1690,7 +1763,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NamedArgument"
+                    "$refText": "NamedArgument",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -1709,7 +1783,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "NamedArgument"
+                        "$refText": "NamedArgument",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -1749,12 +1824,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Parameter"
+                    "$refText": "Parameter",
+                    "$refType": "AbstractType"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "ID"
+                      "$refText": "ID",
+                      "$refType": "AbstractRule"
                     },
                     "arguments": []
                   },
@@ -1780,7 +1857,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Disjunction"
+                "$refText": "Disjunction",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -1835,7 +1913,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Conjunction"
+              "$refText": "Conjunction",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -1862,7 +1941,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Conjunction"
+                    "$refText": "Conjunction",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -1892,7 +1972,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Negation"
+              "$refText": "Negation",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -1919,7 +2000,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Negation"
+                    "$refText": "Negation",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -1949,7 +2031,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Atom"
+              "$refText": "Atom",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -1974,7 +2057,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Negation"
+                    "$refText": "Negation",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -2003,21 +2087,24 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParameterReference"
+              "$refText": "ParameterReference",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedCondition"
+              "$refText": "ParenthesizedCondition",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "LiteralCondition"
+              "$refText": "LiteralCondition",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -2047,7 +2134,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Disjunction"
+              "$refText": "Disjunction",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -2074,12 +2162,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$refText": "Parameter"
+            "$refText": "Parameter",
+            "$refType": "AbstractType"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$refText": "ID",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -2123,7 +2213,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$refText": "STRING",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -2167,12 +2258,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractRule"
+                "$refText": "AbstractRule",
+                "$refType": "AbstractType"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               },
@@ -2193,7 +2286,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NamedArgument"
+                    "$refText": "NamedArgument",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -2212,7 +2306,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "NamedArgument"
+                        "$refText": "NamedArgument",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -2274,7 +2369,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "FeatureName"
+                "$refText": "FeatureName",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -2308,7 +2404,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AssignableTerminal"
+                "$refText": "AssignableTerminal",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -2335,28 +2432,32 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$refText": "Keyword",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$refText": "RuleCall",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedAssignableElement"
+              "$refText": "ParenthesizedAssignableElement",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "CrossReference"
+              "$refText": "CrossReference",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -2386,7 +2487,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AssignableAlternatives"
+              "$refText": "AssignableAlternatives",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -2416,7 +2518,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AssignableTerminal"
+              "$refText": "AssignableTerminal",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -2446,7 +2549,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "AssignableTerminal"
+                        "$refText": "AssignableTerminal",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -2494,7 +2598,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractType"
+                "$refText": "AbstractType",
+                "$refType": "AbstractType"
               },
               "deprecatedSyntax": false
             }
@@ -2527,7 +2632,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "CrossReferenceableTerminal"
+                    "$refText": "CrossReferenceableTerminal",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -2561,14 +2667,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$refText": "Keyword",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$refText": "RuleCall",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -2598,7 +2706,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Alternatives"
+              "$refText": "Alternatives",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -2649,7 +2758,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Alternatives"
+                "$refText": "Alternatives",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -2680,14 +2790,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "PrimitiveType"
+                "$refText": "PrimitiveType",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             },
             {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "ID",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -2743,7 +2855,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ID"
+                        "$refText": "ID",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -2760,7 +2873,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ID"
+                        "$refText": "ID",
+                        "$refType": "AbstractRule"
                       },
                       "arguments": []
                     }
@@ -2779,7 +2893,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "ReturnType"
+                            "$refText": "ReturnType",
+                            "$refType": "AbstractRule"
                           },
                           "arguments": []
                         }
@@ -2802,7 +2917,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalAlternatives"
+                "$refText": "TerminalAlternatives",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -2847,7 +2963,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalGroup"
+              "$refText": "TerminalGroup",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -2874,7 +2991,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "TerminalGroup"
+                    "$refText": "TerminalGroup",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -2904,7 +3022,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalToken"
+              "$refText": "TerminalToken",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -2927,7 +3046,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "TerminalToken"
+                    "$refText": "TerminalToken",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 },
@@ -2958,7 +3078,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalTokenElement"
+              "$refText": "TerminalTokenElement",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -3007,49 +3128,56 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "CharacterRange"
+              "$refText": "CharacterRange",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalRuleCall"
+              "$refText": "TerminalRuleCall",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedTerminalElement"
+              "$refText": "ParenthesizedTerminalElement",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "NegatedToken"
+              "$refText": "NegatedToken",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "UntilToken"
+              "$refText": "UntilToken",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RegexToken"
+              "$refText": "RegexToken",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Wildcard"
+              "$refText": "Wildcard",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -3079,7 +3207,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalAlternatives"
+              "$refText": "TerminalAlternatives",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
@@ -3120,12 +3249,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "TerminalRule"
+                "$refText": "TerminalRule",
+                "$refType": "AbstractType"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$refText": "ID",
+                  "$refType": "AbstractRule"
                 },
                 "arguments": []
               },
@@ -3169,7 +3300,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalTokenElement"
+                "$refText": "TerminalTokenElement",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -3211,7 +3343,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalTokenElement"
+                "$refText": "TerminalTokenElement",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -3249,7 +3382,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "RegexLiteral"
+                "$refText": "RegexLiteral",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -3317,7 +3451,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Keyword"
+                "$refText": "Keyword",
+                "$refType": "AbstractRule"
               },
               "arguments": []
             }
@@ -3336,7 +3471,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Keyword"
+                    "$refText": "Keyword",
+                    "$refType": "AbstractRule"
                   },
                   "arguments": []
                 }
@@ -3427,14 +3563,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PrimitiveType"
+              "$refText": "PrimitiveType",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$refText": "ID",
+              "$refType": "AbstractRule"
             },
             "arguments": []
           }
@@ -3505,7 +3643,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Interface"
+            "$refText": "Interface",
+            "$refType": "AbstractType"
           },
           "isArray": false,
           "isRef": false
@@ -3513,7 +3652,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Type"
+            "$refText": "Type",
+            "$refType": "AbstractType"
           },
           "isArray": false,
           "isRef": false
@@ -3521,7 +3661,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Action"
+            "$refText": "Action",
+            "$refType": "AbstractType"
           },
           "isArray": false,
           "isRef": false
@@ -3529,7 +3670,8 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "ParserRule"
+            "$refText": "ParserRule",
+            "$refType": "AbstractType"
           },
           "isArray": false,
           "isRef": false

--- a/packages/langium/src/grammar/references/grammar-scope.ts
+++ b/packages/langium/src/grammar/references/grammar-scope.ts
@@ -11,7 +11,7 @@ import { AstNode, AstNodeDescription, ReferenceInfo } from '../../syntax-tree';
 import { findRootNode, getDocument } from '../../utils/ast-util';
 import { stream, Stream } from '../../utils/stream';
 import { LangiumDocument, PrecomputedScopes } from '../../workspace/documents';
-import { isReturnType } from '../generated/ast';
+import { AbstractType, isReturnType, ParserRule } from '../generated/ast';
 import { processActionNodeWithNodeDescriptionProvider, processTypeNodeWithNodeLocator } from '../internal-grammar-util';
 
 export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
@@ -20,8 +20,8 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
     }
 
     getScope(context: ReferenceInfo): Scope {
-        const referenceType = this.reflection.getReferenceType(context);
-        if (referenceType !== 'AbstractType') return super.getScope(context);
+        const referenceType = context.targetType;
+        if (referenceType !== AbstractType) return super.getScope(context);
 
         const scopes: Array<Stream<AstNodeDescription>> = [];
         const precomputed = getDocument(context.container).precomputedScopes;
@@ -32,7 +32,7 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
             const scopesArray: AstNodeDescription[] = [];
             if (allDescriptions.length > 0) {
                 for (const description of allDescriptions) {
-                    if (this.reflection.isSubtype(description.type, 'ParserRule')) {
+                    if (this.reflection.isSubtype(description.type, ParserRule)) {
                         parserRuleScopesArray.push(description);
                     } else if (this.reflection.isSubtype(description.type, referenceType)) {
                         scopesArray.push(description);

--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -8,7 +8,7 @@ import { CancellationToken, CompletionItem, CompletionItemKind, CompletionList, 
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
 import * as ast from '../../grammar/generated/ast';
 import { GrammarConfig } from '../../grammar/grammar-config';
-import { getExplicitRuleType } from '../../grammar/internal-grammar-util';
+import { getExplicitRuleType, getTypeName } from '../../grammar/internal-grammar-util';
 import { LangiumCompletionParser } from '../../parser/langium-parser';
 import { NameProvider } from '../../references/naming';
 import { ScopeProvider } from '../../references/scope-provider';
@@ -202,7 +202,8 @@ export class DefaultCompletionProvider implements CompletionProvider {
             const refInfo: ReferenceInfo = {
                 reference: {} as Reference,
                 container: context,
-                property: assignment.feature
+                property: assignment.feature,
+                targetType: getTypeName(crossRef.feature.type.ref!)
             };
             try {
                 const scope = this.scopeProvider.getScope(refInfo);

--- a/packages/langium/src/references/linker.ts
+++ b/packages/langium/src/references/linker.ts
@@ -231,10 +231,9 @@ export class DefaultLinker implements Linker {
         if (document.state < DocumentState.ComputedScopes) {
             console.warn(`Attempted reference resolution before document reached ComputedScopes state (${document.uri}).`);
         }
-        const referenceType = this.reflection.getReferenceType(refInfo);
         return {
             ...refInfo,
-            message: `Could not resolve reference to ${referenceType} named '${refInfo.reference.$refText}'.`,
+            message: `Could not resolve reference to ${refInfo.targetType} named '${refInfo.reference.$refText}'.`,
             targetDescription
         };
     }

--- a/packages/langium/src/references/scope-provider.ts
+++ b/packages/langium/src/references/scope-provider.ts
@@ -116,22 +116,22 @@ export class DefaultScopeProvider implements ScopeProvider {
 
     getScope(context: ReferenceInfo): Scope {
         const scopes: Array<Stream<AstNodeDescription>> = [];
-        const referenceType = this.reflection.getReferenceType(context);
+        const { targetType, container } = context;
 
-        const precomputed = getDocument(context.container).precomputedScopes;
+        const precomputed = getDocument(container).precomputedScopes;
         if (precomputed) {
-            let currentNode: AstNode | undefined = context.container;
+            let currentNode: AstNode | undefined = container;
             do {
                 const allDescriptions = precomputed.get(currentNode);
                 if (allDescriptions.length > 0) {
                     scopes.push(stream(allDescriptions).filter(
-                        desc => this.reflection.isSubtype(desc.type, referenceType)));
+                        desc => this.reflection.isSubtype(desc.type, targetType)));
                 }
                 currentNode = currentNode.$container;
             } while (currentNode);
         }
 
-        let result: Scope = this.getGlobalScope(referenceType);
+        let result: Scope = this.getGlobalScope(targetType);
         for (let i = scopes.length - 1; i >= 0; i--) {
             result = this.createScope(scopes[i], result);
         }

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -55,7 +55,10 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 }
                 // If it is a reference, just return the name
                 if (isReference(item)) {
-                    return { $refText: item.$refText } as Reference; // surprisingly this cast works at the time of writing, although $refNode is absent
+                    return {
+                        $refText: item.$refText,
+                        $refType: item.$refType
+                    } as Reference; // surprisingly this cast works at the time of writing, although $refNode is absent
                 }
                 let newItem: Record<string, unknown> | unknown[];
                 // If it is an array, replicate the array.
@@ -88,7 +91,13 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
                     if (isReference(item) && isAstNode(container)) {
-                        const reference = this.linker.buildReference(container, propName!, item.$refNode, item.$refText);
+                        const reference = this.linker.buildReference({
+                            node: container,
+                            property: propName!,
+                            refText: item.$refText,
+                            refType: item.$refType,
+                            refNode: item.$refNode
+                        });
                         value[i] = reference;
                     } else if (typeof item === 'object' && item !== null) {
                         internalRevive(item);
@@ -101,7 +110,13 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 for (const [name, item] of Object.entries(value)) {
                     if (typeof item === 'object' && item !== null) {
                         if (isReference(item)) {
-                            const reference = this.linker.buildReference(value as AstNode, name, item.$refNode, item.$refText);
+                            const reference = this.linker.buildReference({
+                                node: value as AstNode,
+                                property: name,
+                                refText: item.$refText,
+                                refType: item.$refType,
+                                refNode: item.$refNode
+                            });
                             value[name] = reference;
                         } else if (Array.isArray(item)) {
                             internalRevive(item, value, name);

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -55,6 +55,8 @@ export interface Reference<T extends AstNode = AstNode> {
     readonly $refNode: CstNode;
     /** The actual text used to look up in the surrounding scope */
     readonly $refText: string;
+    /** The type that this reference targets */
+    readonly $refType: string;
     /** The node description for the AstNode returned by `ref`  */
     readonly $nodeDescription?: AstNodeDescription;
 }
@@ -83,6 +85,7 @@ export interface ReferenceInfo {
     reference: Reference
     container: AstNode
     property: string
+    targetType: string
     index?: number
 }
 

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -103,7 +103,6 @@ export interface LinkingError extends ReferenceInfo {
  */
 export interface AstReflection {
     getAllTypes(): string[]
-    getReferenceType(refInfo: ReferenceInfo): string
     getTypeMetaData(type: string): TypeMetaData
     isInstance(node: unknown, type: string): boolean
     isSubtype(subtype: string, supertype: string): boolean

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -181,13 +181,13 @@ export function streamReferences(node: AstNode): Stream<ReferenceInfo> {
                 const value = (node as GenericAstNode)[property];
                 if (isReference(value)) {
                     state.keyIndex++;
-                    return { done: false, value: { reference: value, container: node, property } };
+                    return { done: false, value: { reference: value, container: node, property, targetType: value.$refType } };
                 } else if (Array.isArray(value)) {
                     while (state.arrayIndex < value.length) {
                         const index = state.arrayIndex++;
                         const element = value[index];
                         if (isReference(element)) {
-                            return { done: false, value: { reference: element, container: node, property, index } };
+                            return { done: false, value: { reference: element, container: node, property, index, targetType: element.$refType } };
                         }
                     }
                     state.arrayIndex = 0;


### PR DESCRIPTION
In a few cases we had issues resolving to the expected type of a reference. This is due to `AstReflection.getReferenceType` not always working correctly in cases such as fragments.

This change stores the target type on the reference when it is created, removing the need for `getReferenceType` altogether.