### PR TITLE
Prevent unused token creation

### DIFF
--- a/packages/langium-cli/src/generator/highlighting/monarch-generator.ts
+++ b/packages/langium-cli/src/generator/highlighting/monarch-generator.ts
@@ -7,7 +7,7 @@
 import * as langium from 'langium';
 import {
     getTerminalParts, isCommentTerminal, isRegexToken, isTerminalRule, CompositeGeneratorNode, NL,
-    processGeneratorNode, TerminalRule, escapeRegExp
+    processGeneratorNode, TerminalRule, escapeRegExp, isWhitespaceRegExp
 } from 'langium';
 import { terminalRegex } from 'langium/lib/grammar/internal-grammar-util';
 import { LangiumLanguageConfig } from '../../package';
@@ -335,7 +335,7 @@ function getWhitespaceRules(grammar: langium.Grammar): Rule[] {
         if(isTerminalRule(rule) && isRegexToken(rule.definition)) {
             const regex = new RegExp(terminalRegex(rule));
 
-            if(!isCommentTerminal(rule) && !regex.test(' ')) {
+            if(!isCommentTerminal(rule) && !isWhitespaceRegExp(regex)) {
                 // skip rules that are not comments or whitespace
                 continue;
             }
@@ -419,7 +419,7 @@ function getTerminalRules(grammar: langium.Grammar): Rule[] {
         if (isTerminalRule(rule) && !isCommentTerminal(rule) && isRegexToken(rule.definition)) {
             const regex = new RegExp(terminalRegex(rule));
 
-            if (regex.test(' ')) {
+            if (isWhitespaceRegExp(regex)) {
                 // disallow terminal rules that match whitespace
                 continue;
             }

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -310,10 +310,9 @@ export function processTypeNodeWithNodeLocator(astNodeLocator: AstNodeLocator): 
 }
 
 /**
- * Add synthetic Interface in case of explicitly inferred type:<br>
+ * Add synthetic Interface in case of explicitly inferred type:
+ *
  * case: `{infer Action}`
- * @param astNodeLocator AstNodeLocator
- * @returns scope populator
  */
 export function processActionNodeWithNodeDescriptionProvider(descriptions: AstNodeDescriptionProvider): (node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes) => void {
     return (node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes) => {

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -13,7 +13,7 @@ import { AstNode, Reference } from '../syntax-tree';
 import { getContainerOfType, getDocument, streamAllContents } from '../utils/ast-util';
 import { MultiMap } from '../utils/collections';
 import { toDocumentSegment } from '../utils/cst-util';
-import { findNodeForKeyword, findNameAssignment, findNodeForProperty, getEntryRule } from '../utils/grammar-util';
+import { findNodeForKeyword, findNameAssignment, findNodeForProperty, getAllReachableRules } from '../utils/grammar-util';
 import { Stream, stream } from '../utils/stream';
 import { relativeURI } from '../utils/uri-util';
 import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from '../validation/validation-registry';
@@ -531,33 +531,16 @@ export class LangiumGrammarValidator {
     }
 
     checkGrammarForUnusedRules(grammar: ast.Grammar, accept: ValidationAcceptor): void {
-        const entry = getEntryRule(grammar);
-        if (entry) {
-            const visitedSet = new Set<string>();
-            this.ruleDfs(entry, visitedSet);
-            visitedSet.add(entry.name);
+        const reachableRules = getAllReachableRules(grammar, true);
 
-            for (const rule of grammar.rules) {
-                if (ast.isTerminalRule(rule) && rule.hidden || isEmptyRule(rule)) {
-                    continue;
-                }
-                if (!visitedSet.has(rule.name)) {
-                    accept('hint', 'This rule is declared but never referenced.', { node: rule, property: 'name', tags: [DiagnosticTag.Unnecessary] });
-                }
+        for (const rule of grammar.rules) {
+            if (ast.isTerminalRule(rule) && rule.hidden || isEmptyRule(rule)) {
+                continue;
+            }
+            if (!reachableRules.has(rule)) {
+                accept('hint', 'This rule is declared but never referenced.', { node: rule, property: 'name', tags: [DiagnosticTag.Unnecessary] });
             }
         }
-    }
-
-    private ruleDfs(rule: ast.AbstractRule, visitedSet: Set<string>): void {
-        streamAllContents(rule).forEach(node => {
-            if (ast.isRuleCall(node) || ast.isTerminalRuleCall(node)) {
-                const refRule = node.rule.ref;
-                if (refRule && !visitedSet.has(refRule.name)) {
-                    visitedSet.add(refRule.name);
-                    this.ruleDfs(refRule, visitedSet);
-                }
-            }
-        });
     }
 
     checkRuleName(rule: ast.AbstractRule, accept: ValidationAcceptor): void {

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -51,7 +51,8 @@ export function createParser<T extends BaseParser>(grammar: Grammar, parser: T, 
 
 function buildRules(parserContext: ParserContext, grammar: Grammar): void {
     const reachable = getAllReachableRules(grammar, false);
-    for (const rule of stream(grammar.rules).filter(isParserRule).filter(rule => reachable.has(rule))) {
+    const parserRules = stream(grammar.rules).filter(isParserRule).filter(rule => reachable.has(rule));
+    for (const rule of parserRules) {
         const ctx: RuleContext = {
             ...parserContext,
             consume: 1,

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -11,7 +11,7 @@ import { AstNode } from '../syntax-tree';
 import { assertUnreachable, ErrorWithLocation } from '../utils/errors';
 import { stream } from '../utils/stream';
 import { Cardinality, getTypeName } from '../grammar/internal-grammar-util';
-import { findNameAssignment } from '../utils/grammar-util';
+import { findNameAssignment, getAllReachableRules } from '../utils/grammar-util';
 
 type RuleContext = {
     optional: number,
@@ -50,7 +50,8 @@ export function createParser<T extends BaseParser>(grammar: Grammar, parser: T, 
 }
 
 function buildRules(parserContext: ParserContext, grammar: Grammar): void {
-    for (const rule of stream(grammar.rules).filter(isParserRule)) {
+    const reachable = getAllReachableRules(grammar, false);
+    for (const rule of stream(grammar.rules).filter(isParserRule).filter(rule => reachable.has(rule))) {
         const ctx: RuleContext = {
             ...parserContext,
             consume: 1,

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -5,25 +5,31 @@
  ******************************************************************************/
 
 import { Lexer, TokenPattern, TokenType, TokenVocabulary } from 'chevrotain';
-import { Grammar, isKeyword, isParserRule, isTerminalRule, Keyword, TerminalRule } from '../grammar/generated/ast';
+import { AbstractRule, Grammar, isKeyword, isParserRule, isTerminalRule, Keyword, TerminalRule } from '../grammar/generated/ast';
 import { terminalRegex } from '../grammar/internal-grammar-util';
 import { streamAllContents } from '../utils/ast-util';
-import { getCaseInsensitivePattern, partialMatches } from '../utils/regex-util';
-import { stream } from '../utils/stream';
+import { getAllReachableRules } from '../utils/grammar-util';
+import { getCaseInsensitivePattern, isWhitespaceRegExp, partialMatches } from '../utils/regex-util';
+import { Stream, stream } from '../utils/stream';
+
+export interface TokenBuilderOptions {
+    caseInsensitive?: boolean
+}
 
 export interface TokenBuilder {
-    buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenVocabulary;
+    buildTokens(grammar: Grammar, options?: TokenBuilderOptions): TokenVocabulary;
 }
 
 export class DefaultTokenBuilder implements TokenBuilder {
 
-    buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenVocabulary {
-        const terminalTokens: TokenType[] = this.buildTerminalTokens(grammar);
-        const tokens: TokenType[] = this.buildKeywordTokens(grammar, terminalTokens, options);
+    buildTokens(grammar: Grammar, options?: TokenBuilderOptions): TokenVocabulary {
+        const reachableRules = stream(getAllReachableRules(grammar, false));
+        const terminalTokens: TokenType[] = this.buildTerminalTokens(reachableRules);
+        const tokens: TokenType[] = this.buildKeywordTokens(reachableRules, terminalTokens, options);
 
         terminalTokens.forEach(terminalToken => {
             const pattern = terminalToken.PATTERN;
-            if (typeof pattern === 'object' && pattern && 'test' in pattern && pattern.test(' ')) {
+            if (typeof pattern === 'object' && pattern && 'test' in pattern && isWhitespaceRegExp(pattern)) {
                 tokens.unshift(terminalToken);
             } else {
                 tokens.push(terminalToken);
@@ -32,29 +38,23 @@ export class DefaultTokenBuilder implements TokenBuilder {
         return tokens;
     }
 
-    protected buildTerminalTokens(grammar: Grammar): TokenType[] {
-        return grammar.rules.filter(isTerminalRule).filter(e => !e.fragment)
-            .map(terminal => this.buildTerminalToken(terminal));
+    protected buildTerminalTokens(rules: Stream<AbstractRule>): TokenType[] {
+        return rules.filter(isTerminalRule).filter(e => !e.fragment)
+            .map(terminal => this.buildTerminalToken(terminal)).toArray();
     }
 
     protected buildTerminalToken(terminal: TerminalRule): TokenType {
-        let group: string | undefined;
         const regex = terminalRegex(terminal);
+        const token: TokenType = { name: terminal.name, PATTERN: new RegExp(regex) };
         if (terminal.hidden) {
             // Only skip tokens that are able to accept whitespace
-            group = new RegExp(regex).test(' ') ? Lexer.SKIPPED : 'hidden';
-        }
-
-        const token = { name: terminal.name, GROUP: group, PATTERN: new RegExp(regex) };
-        if (!group) {
-            // 'undefined' is not a valid value for `GROUP`; therefore, we have to delete it
-            delete token.GROUP;
+            token.GROUP = isWhitespaceRegExp(regex) ? Lexer.SKIPPED : 'hidden';
         }
         return token;
     }
 
-    protected buildKeywordTokens(grammar: Grammar, terminalTokens: TokenType[], options?: { caseInsensitive?: boolean }): TokenType[] {
-        return stream(grammar.rules)
+    protected buildKeywordTokens(rules: Stream<AbstractRule>, terminalTokens: TokenType[], options?: TokenBuilderOptions): TokenType[] {
+        return rules
             // We filter by parser rules, since keywords in terminal rules get transformed into regex and are not actual tokens
             .filter(isParserRule)
             .flatMap(rule => streamAllContents(rule).filter(isKeyword))
@@ -79,7 +79,7 @@ export class DefaultTokenBuilder implements TokenBuilder {
     }
 
     protected findLongerAlt(keyword: Keyword, terminalTokens: TokenType[]): TokenType[] {
-        return terminalTokens.reduce((longerAlts: TokenType[], token: TokenType) => {
+        return terminalTokens.reduce((longerAlts: TokenType[], token) => {
             const pattern = token?.PATTERN as RegExp;
             if (pattern?.source && partialMatches('^' + pattern.source + '$', keyword.value)) {
                 longerAlts.push(token);

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -27,6 +27,42 @@ export function getEntryRule(grammar: ast.Grammar): ast.ParserRule | undefined {
 }
 
 /**
+ * Returns all rules that can be reached from the entry point of the specified grammar.
+ *
+ * @param grammar The grammar that contains all rules
+ * @param allTerminals Whether or not to include terminals that are referenced only by other terminals
+ * @returns A list of referenced parser and terminal rules. If the grammar contains no entry rule,
+ *      this function returns all rules of the specified grammar.
+ */
+export function getAllReachableRules(grammar: ast.Grammar, allTerminals: boolean): Set<ast.AbstractRule> {
+    const ruleNames = new Set<string>();
+    const entryRule = getEntryRule(grammar);
+    if (!entryRule) {
+        return new Set(grammar.rules);
+    }
+    ruleDfs(entryRule, ruleNames, allTerminals);
+    const rules = new Set<ast.AbstractRule>();
+    for (const rule of grammar.rules) {
+        if (ruleNames.has(rule.name) || (ast.isTerminalRule(rule) && rule.hidden)) {
+            rules.add(rule);
+        }
+    }
+    return rules;
+}
+
+function ruleDfs(rule: ast.AbstractRule, visitedSet: Set<string>, allTerminals: boolean): void {
+    visitedSet.add(rule.name);
+    streamAllContents(rule).forEach(node => {
+        if (ast.isRuleCall(node) || (allTerminals && ast.isTerminalRuleCall(node))) {
+            const refRule = node.rule.ref;
+            if (refRule && !visitedSet.has(refRule.name)) {
+                ruleDfs(refRule, visitedSet, allTerminals);
+            }
+        }
+    });
+}
+
+/**
  * Determines the grammar expression used to parse a cross-reference (usually a reference to a terminal rule).
  * A cross-reference can declare this expression explicitly in the form `[Type : Terminal]`, but if `Terminal`
  * is omitted, this function attempts to infer it from the name of the referenced `Type` (using `findNameAssignment`).

--- a/packages/langium/src/utils/regex-util.ts
+++ b/packages/langium/src/utils/regex-util.ts
@@ -110,6 +110,11 @@ export function isMultilineComment(regex: RegExp | string): boolean {
     }
 }
 
+export function isWhitespaceRegExp(value: RegExp | string): boolean {
+    const regexp = typeof value === 'string' ? new RegExp(value) : value;
+    return regexp.test(' ');
+}
+
 export function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -655,7 +655,7 @@ describe('expression rules with inferred and declared interfaces', () => {
         const toSubstring = (o: {toString: () => string}) => {
             // this specialized 'toString' function uses the default 'toString' that is  producing the
             //  code generation output, and strips everything not belonging to the actual interface/type declaration
-            const sRep = o.toString();
+            const sRep = o.toString().replace(/\r/g, '');
             return sRep.substring(
                 0, 1 + (sRep.includes('interface') ? sRep.indexOf('}') : Math.min(sRep.indexOf(';') ))
             );


### PR DESCRIPTION
When creating a language from multiple grammars, we often have unused rules within then. Right now, the token builder and other associated services always create _all tokens_ that can be found within the grammar. This change addresses this by only looking at rules and terminals which are actually used either directly or transitively by the entry rule.