### PR TITLE
Enable debugging Langium as downstream user

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,7 @@
         },
         {
             "name": "Attach to Language Server",
-            "type": "pwa-node",
+            "type": "node",
             "port": 6009,
             "request": "attach",
             "skipFiles": [
@@ -63,7 +63,7 @@
         },
         {
             "name": "Bootstrap",
-            "type": "pwa-node",
+            "type": "node",
             "request": "launch",
             "runtimeArgs": [
                 "${workspaceFolder}/packages/langium-cli/lib/langium",
@@ -82,7 +82,7 @@
         },
         {
             "name": "Generate Domainmodel",
-            "type": "pwa-node",
+            "type": "node",
             "request": "launch",
             "runtimeExecutable": "node",
             "runtimeArgs": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,10 @@ In `.vscode/launch.json` of your language project add the following launch confi
         ],
         "sourceMaps": true,
         "outFiles": [
-            "${workspaceFolder}/out/**/*.js"
+            "${workspaceFolder}/out/**/*.js",
+            "${workspaceFolder}/node_modules/langium"
         ],
-        "type": "pwa-node"
+        "type": "node"
     }
 ```
 With the above configuration you can attach the debugger to the language server which effectively means you are able to debug your local version of Langium.

--- a/packages/generator-langium/langium-template/.vscode/launch.json
+++ b/packages/generator-langium/langium-template/.vscode/launch.json
@@ -15,7 +15,7 @@
         },
         {
             "name": "Attach to Language Server",
-            "type": "pwa-node",
+            "type": "node",
             "port": 6009,
             "request": "attach",
             "skipFiles": [
@@ -23,7 +23,8 @@
             ],
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
+                "${workspaceFolder}/out/**/*.js",
+                "${workspaceFolder}/node_modules/langium"
             ]
         }
     ]


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/572

Also changes from the deprecated `pwa-node` to `node`.