### PR TITLE
Semantic token provider API improvements

### DIFF
--- a/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
+++ b/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
@@ -15,48 +15,48 @@ export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenPr
         if (isAssignment(node)) {
             acceptor({
                 node,
-                feature: 'feature',
+                property: 'feature',
                 type: SemanticTokenTypes.property
             });
         } else if (isAction(node)) {
             if (node.feature) {
                 acceptor({
                     node,
-                    feature: 'feature',
+                    property: 'feature',
                     type: SemanticTokenTypes.property
                 });
             }
         } else if (isReturnType(node)) {
             acceptor({
                 node,
-                feature: 'name',
+                property: 'name',
                 type: SemanticTokenTypes.type
             });
         } else if (isAtomType(node)) {
             if (node.primitiveType || node.refType) {
                 acceptor({
                     node,
-                    feature: 'primitiveType' in node ? 'primitiveType' : 'refType',
+                    property: node.primitiveType ? 'primitiveType' : 'refType',
                     type: SemanticTokenTypes.type
                 });
             }
         } else if (isParameter(node)) {
             acceptor({
                 node,
-                feature: 'name',
+                property: 'name',
                 type: SemanticTokenTypes.parameter
             });
         } else if (isParameterReference(node)) {
             acceptor({
                 node,
-                feature: 'parameter',
+                property: 'parameter',
                 type: SemanticTokenTypes.parameter
             });
         } else if (isRuleCall(node)) {
             if (node.rule.ref?.fragment) {
                 acceptor({
                     node,
-                    feature: 'rule',
+                    property: 'rule',
                     type: SemanticTokenTypes.type
                 });
             }

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -76,7 +76,7 @@ export function findNodesForProperty(node: CstNode | undefined, property: string
  *        the node with the specified index is returned.
  */
 export function findNodeForProperty(node: CstNode | undefined, property: string | undefined, index?: number): CstNode | undefined {
-    if (!node ||!property) {
+    if (!node || !property) {
         return undefined;
     }
     const nodes = findNodesForPropertyInternal(node, property, node.element, true);
@@ -199,23 +199,23 @@ export function findNameAssignment(type: ast.AbstractType | ast.InferredType): a
     return findNameAssignmentInternal(type, new Map());
 }
 
-function findNameAssignmentInternal(type: ast.AbstractType, cashed: Map<ast.AbstractType, ast.Assignment | undefined>): ast.Assignment | undefined {
+function findNameAssignmentInternal(type: ast.AbstractType, cache: Map<ast.AbstractType, ast.Assignment | undefined>): ast.Assignment | undefined {
     function go(node: AstNode, refType: ast.AbstractType): ast.Assignment | undefined {
         let childAssignment: ast.Assignment | undefined = undefined;
         const parentAssignment = getContainerOfType(node, ast.isAssignment);
         // No parent assignment implies unassigned rule call
         if (!parentAssignment) {
-            childAssignment = findNameAssignmentInternal(refType, cashed);
+            childAssignment = findNameAssignmentInternal(refType, cache);
         }
-        cashed.set(type, childAssignment);
+        cache.set(type, childAssignment);
         return childAssignment;
     }
 
-    if (cashed.has(type)) return cashed.get(type);
-    cashed.set(type, undefined);
+    if (cache.has(type)) return cache.get(type);
+    cache.set(type, undefined);
     for (const node of streamAllContents(type)) {
         if (ast.isAssignment(node) && node.feature.toLowerCase() === 'name') {
-            cashed.set(type, node);
+            cache.set(type, node);
             return node;
         } else if (ast.isRuleCall(node) && ast.isParserRule(node.rule.ref)) {
             return go(node, node.rule.ref);


### PR DESCRIPTION
Renames `feature` to `property`. Also addresses a concern about the `index` property. If the property is omitted, the implementation will always highlight all nodes. Previously, it only highlighted the first occurrence of the node.