### PR TITLE
Removed inferred type union validation

### DIFF
--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -22,7 +22,6 @@ import * as ast from './generated/ast';
 import { isParserRule, isRuleCall } from './generated/ast';
 import { getTypeName, isDataTypeRule, isOptionalCardinality, resolveImport, resolveTransitiveImports, terminalRegex } from './internal-grammar-util';
 import type { LangiumGrammarServices } from './langium-grammar-module';
-import { collectInferredTypes } from './type-system/inferred-types';
 import { applyErrorToAssignment, collectAllInterfaces, InterfaceInfo, validateTypesConsistency } from './type-system/type-validator';
 
 export class LangiumGrammarValidationRegistry extends ValidationRegistry {
@@ -447,18 +446,20 @@ export class LangiumGrammarValidator {
             interfaceType.superTypes.forEach((superType, i) => {
                 if (superType.ref && ast.isType(superType.ref)) {
                     accept('error', 'Interfaces cannot extend union types.', { node: interfaceType, property: 'superTypes', index: i });
-                } else if(superType.ref && ast.isParserRule(superType.ref)) {
-                    // collect just the beginning of whatever inferred types this standalone rule produces
-                    // looking to exclude anything that would be a union down the line
-                    const inferred = collectInferredTypes([superType.ref as ast.ParserRule], []);
-                    if(inferred.unions.length > 0) {
-                        // inferred union type also cannot be extended
-                        accept('error', `An interface cannot extend a union type, which was inferred from parser rule ${superType.ref.name}.`, { node: interfaceType, property: 'superTypes', index: i });
-                    } else {
-                        // otherwise we'll allow it, but issue a warning against basing declared off of inferred types
-                        accept('warning', 'Extending an interface by a parser rule gives an ambiguous type, instead of the expected declared type.', { node: interfaceType, property: 'superTypes', index: i });
-                    }
                 }
+                // TODO: needs to be reimplemented once the type system has been refactored
+                // else if(superType.ref && ast.isParserRule(superType.ref)) {
+                //     // collect just the beginning of whatever inferred types this standalone rule produces
+                //     // looking to exclude anything that would be a union down the line
+                //     const inferred = collectInferredTypes([superType.ref as ast.ParserRule], []);
+                //     if(inferred.unions.length > 0) {
+                //         // inferred union type also cannot be extended
+                //         accept('error', `An interface cannot extend a union type, which was inferred from parser rule ${superType.ref.name}.`, { node: interfaceType, property: 'superTypes', index: i });
+                //     } else {
+                //         // otherwise we'll allow it, but issue a warning against basing declared off of inferred types
+                //         accept('warning', 'Extending an interface by a parser rule gives an ambiguous type, instead of the expected declared type.', { node: interfaceType, property: 'superTypes', index: i });
+                //     }
+                // }
             });
         }
     }

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -6,7 +6,7 @@
 
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { Assignment, Grammar, ParserRule } from '../../src/grammar/generated/ast';
-import { expectError, expectWarning, validationHelper } from '../../src/test';
+import { expectError, validationHelper } from '../../src/test';
 import { IssueCodes } from '../../src/grammar/langium-grammar-validator';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
@@ -14,18 +14,19 @@ const validate = validationHelper<Grammar>(services.grammar);
 
 describe('Langium grammar validation', () => {
 
-    test('Declared interfaces warn when extending inferred interfaces', async () => {
-        const validationResult = await validate(`
-        InferredT: prop=ID;
+    // TODO: needs to be reimplemented once the type system has been refactored
+    // test('Declared interfaces warn when extending inferred interfaces', async () => {
+    //     const validationResult = await validate(`
+    //     InferredT: prop=ID;
 
-        interface DeclaredExtendsInferred extends InferredT {}`);
+    //     interface DeclaredExtendsInferred extends InferredT {}`);
 
-        // should get a warning when basing declared types on inferred types
-        expectWarning(validationResult, /Extending an interface by a parser rule gives an ambiguous type, instead of the expected declared type./, {
-            node: validationResult.document.parseResult.value.interfaces[0],
-            property: {name: 'superTypes'}
-        });
-    });
+    //     // should get a warning when basing declared types on inferred types
+    //     expectWarning(validationResult, /Extending an interface by a parser rule gives an ambiguous type, instead of the expected declared type./, {
+    //         node: validationResult.document.parseResult.value.interfaces[0],
+    //         property: {name: 'superTypes'}
+    //     });
+    // });
 
     test('Parser rule should not assign fragments', async () => {
         // arrange
@@ -46,42 +47,44 @@ describe('Langium grammar validation', () => {
         });
     });
 
-    test('Declared interfaces cannot extend inferred unions directly', async () => {
-        const validationResult = await validate(`
-        InferredUnion: InferredI1 | InferredI2;
+    // TODO: needs to be reimplemented once the type system has been refactored
+    // test('Declared interfaces cannot extend inferred unions directly', async () => {
+    //     const validationResult = await validate(`
+    //     InferredUnion: InferredI1 | InferredI2;
 
-        InferredI1: prop1=ID;
-        InferredI2: prop2=ID;
-        
-        interface DeclaredExtendsUnion extends InferredUnion {}
-        `);
+    //     InferredI1: prop1=ID;
+    //     InferredI2: prop2=ID;
 
-        // should get an error on DeclaredExtendsUnion, since it cannot extend an inferred union
-        expectError(validationResult, /An interface cannot extend a union type, which was inferred from parser rule InferredUnion./, {
-            node: validationResult.document.parseResult.value.interfaces[0],
-            property: {name: 'superTypes'}
-        });
-    });
+    //     interface DeclaredExtendsUnion extends InferredUnion {}
+    //     `);
 
-    test('Declared interfaces cannot extend inferred unions via indirect inheritance', async () => {
+    //     // should get an error on DeclaredExtendsUnion, since it cannot extend an inferred union
+    //     expectError(validationResult, /An interface cannot extend a union type, which was inferred from parser rule InferredUnion./, {
+    //         node: validationResult.document.parseResult.value.interfaces[0],
+    //         property: {name: 'superTypes'}
+    //     });
+    // });
 
-        const validationResult = await validate(`
-        InferredUnion: InferredI1 | InferredI2;
+    // TODO: needs to be reimplemented once the type system has been refactored
+    // test('Declared interfaces cannot extend inferred unions via indirect inheritance', async () => {
 
-        InferredI1: prop1=ID;
-        InferredI2: prop2=ID;
+    //     const validationResult = await validate(`
+    //     InferredUnion: InferredI1 | InferredI2;
 
-        Intermediary: InferredUnion;
+    //     InferredI1: prop1=ID;
+    //     InferredI2: prop2=ID;
 
-        interface DeclaredExtendsInferred extends Intermediary {}
-        `);
+    //     Intermediary: InferredUnion;
 
-        // same error, but being sure that this holds when an inferred type extends another inferred type
-        expectError(validationResult, /An interface cannot extend a union type, which was inferred from parser rule Intermediary./, {
-            node: validationResult.document.parseResult.value.interfaces[0],
-            property: {name: 'superTypes'}
-        });
-    });
+    //     interface DeclaredExtendsInferred extends Intermediary {}
+    //     `);
+
+    //     // same error, but being sure that this holds when an inferred type extends another inferred type
+    //     expectError(validationResult, /An interface cannot extend a union type, which was inferred from parser rule Intermediary./, {
+    //         node: validationResult.document.parseResult.value.interfaces[0],
+    //         property: {name: 'superTypes'}
+    //     });
+    // });
 
     test('Actions cannot redefine declared types', async () => {
         const validationResult = await validate(`


### PR DESCRIPTION
Closes #680 

The validation for inferred type union was not working as expected.

For now I disabled it by commenting out the necessary lines in order to not lose @montymxb 's work. This should be reimplemented when we are through with the type system modifications.