### PR TITLE
Code Action: Adds Missing 'return' to Parser Rule

### DIFF
--- a/packages/langium/src/grammar/lsp/grammar-code-actions.ts
+++ b/packages/langium/src/grammar/lsp/grammar-code-actions.ts
@@ -115,6 +115,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         return undefined;
     }
 
+    private fixInvalidReturnsInfers(diagnostic: Diagnostic, document: LangiumDocument): CodeAction | undefined {
         const data = diagnostic.data as DocumentSegment;
         if (data) {
             const text = document.textDocument.getText(data.range);

--- a/packages/langium/src/grammar/lsp/grammar-code-actions.ts
+++ b/packages/langium/src/grammar/lsp/grammar-code-actions.ts
@@ -7,6 +7,7 @@
 import { CodeActionKind, Diagnostic } from 'vscode-languageserver';
 import { CodeActionParams } from 'vscode-languageserver-protocol';
 import { CodeAction, Command, Position, TextEdit } from 'vscode-languageserver-types';
+import { AstNode } from '../..';
 import { CodeActionProvider } from '../../lsp/code-action';
 import { getContainerOfType } from '../../utils/ast-util';
 import { findLeafNodeAtOffset } from '../../utils/cst-util';

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -100,4 +100,18 @@ describe('Langium grammar validation', () => {
             code: IssueCodes.SuperfluousInfer
         });
     });
+
+    test('Missing return should be added to parser rule', async () => {
+        const validationResult = await validate(`
+        grammar T
+        interface T { a: string }
+        T: 't' a=ID;
+        terminal ID returns string: /[a-z]+/;
+        `);
+        expectError(validationResult, /The type 'T' is already explicitly declared and cannot be inferred./, {
+            node: validationResult.document.parseResult.value.rules[0],
+            property: {name: 'name'},
+            code: IssueCodes.MissingReturns
+        });
+    });
 });


### PR DESCRIPTION
Closes one of the points of #442.

Adds return T to rule for general error The type 'T' is already explicitly declared and cannot be inferred. From https://github.com/langium/langium/issues/449.

![Sep-23-2022 15-09-18](https://user-images.githubusercontent.com/5070304/191968492-255562fd-7d99-4079-a682-cec9441e1c6e.gif)
