### PR TITLE
Fixed terminal rule for NUMBER in arithmetics example

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -35,7 +35,7 @@ PrimaryExpression infers Expression:
 
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
-terminal NUMBER returns number: /[0-9]+(\.[0-9])?/;
+terminal NUMBER returns number: /[0-9]+(\.[0-9]*)?/;
 
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -559,7 +559,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "[0-9]+(\\\\.[0-9])?"
+        "regex": "[0-9]+(\\\\.[0-9]*)?"
       },
       "fragment": false,
       "hidden": false


### PR DESCRIPTION
Fixed an error in the Regex for the the terminal rule NUMBER in the arithmetics example.

The previous regex would only match numbers with a maximum of 1 decimal:
<img width="695" alt="Screenshot 2022-09-27 at 15 32 54" src="https://user-images.githubusercontent.com/44747557/192544250-499c6c19-c448-479e-ae57-8683de4c2ef9.png">

 The new regex matches numbers with any amount of decimals. Also matches no decimals even if the dot is present (ex: `1.`)