### PR TITLE
getServices problem with more than one language; quickfix, TBD

### DIFF
--- a/packages/langium/src/service-registry.ts
+++ b/packages/langium/src/service-registry.ts
@@ -4,8 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { URI, Utils } from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { LangiumServices } from './services';
+import * as path from 'path';
 
 /**
  * The service registry provides access to the language-specific services. These are resolved
@@ -67,7 +68,8 @@ export class DefaultServiceRegistry implements ServiceRegistry {
         if (this.map === undefined) {
             throw new Error('The service registry is empty. Use `register` to register the services of a language.');
         }
-        const ext = Utils.extname(uri);
+        const ext = path.extname(uri.toString()); // works somehow
+
         const services = this.map[ext];
         if (!services) {
             throw new Error(`The service registry contains no services for the extension '${ext}'.`);


### PR DESCRIPTION
I had a problem with langium 0.4.0 and can reproduce it with the current HEAD version:

* I have multiple languages registered (like in https://github.com/langium/langium/pull/676) and I want to load built-in models (like in https://github.com/langium/langium/discussions/391).
* For the configuration with only one language everything worked fine for the build-in models (loaded via `factory.fromString` as described in https://github.com/langium/langium/discussions/391).
* For two languages I get strange errors: `Error: The service registry contains no services for the extension ''.` (empty extension).

I could track this down to `Utils.extname(uri);` not working correctly for my URI `memory://built_in_0.item`. This patch seems to help...

I am not 100% sure why it did not work - do you have an idea?