### PR TITLE
Added TS option to enforce explicit override

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics-scope-provider.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-scope-provider.ts
@@ -4,18 +4,18 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstNodeDescription, DefaultScopeProvider, Scope, Stream, StreamScope } from 'langium';
+import { AstNodeDescription, DefaultScopeProvider, Scope, ScopeOptions, stream, StreamScope } from 'langium';
 
 /**
  * Special scope provider that matches symbol names regardless of lowercase or uppercase.
  */
 export class ArithmeticsScopeProvider extends DefaultScopeProvider {
 
-    protected createScope(elements: Stream<AstNodeDescription>, outerScope: Scope): Scope {
-        return new StreamScope(elements, outerScope, { caseInsensitive: true });
+    protected override createScope(elements: Iterable<AstNodeDescription>, outerScope: Scope, options?: ScopeOptions): Scope {
+        return new StreamScope(stream(elements), outerScope, { ...options, caseInsensitive: true });
     }
 
-    protected getGlobalScope(referenceType: string): Scope {
+    protected override getGlobalScope(referenceType: string): Scope {
         return new StreamScope(this.indexManager.allElements(referenceType), undefined, { caseInsensitive: true });
     }
 

--- a/examples/domainmodel/src/language-server/domain-model-rename-refactoring.ts
+++ b/examples/domainmodel/src/language-server/domain-model-rename-refactoring.ts
@@ -20,7 +20,7 @@ export class DomainModelRenameProvider extends DefaultRenameProvider {
         this.langiumDocuments = services.shared.workspace.LangiumDocuments;
     }
 
-    async rename(document: LangiumDocument, params: RenameParams): Promise<WorkspaceEdit | undefined> {
+    override async rename(document: LangiumDocument, params: RenameParams): Promise<WorkspaceEdit | undefined> {
         const changes: Record<string, TextEdit[]> = {};
         const rootNode = document.parseResult.value.$cstNode;
         if (!rootNode) return undefined;

--- a/examples/domainmodel/src/language-server/domain-model-scope.ts
+++ b/examples/domainmodel/src/language-server/domain-model-scope.ts
@@ -18,7 +18,7 @@ export class DomainModelScopeComputation extends DefaultScopeComputation {
     /**
      * Exports only types (`DataType or `Entity`) with their qualified names.
      */
-    async computeExports(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<AstNodeDescription[]> {
+    override async computeExports(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<AstNodeDescription[]> {
         const descr: AstNodeDescription[] = [];
         for (const modelNode of streamAllContents(document.parseResult.value)) {
             await interruptAndCheck(cancelToken);
@@ -35,7 +35,7 @@ export class DomainModelScopeComputation extends DefaultScopeComputation {
         return descr;
     }
 
-    async computeLocalScopes(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<PrecomputedScopes> {
+    override async computeLocalScopes(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<PrecomputedScopes> {
         const model = document.parseResult.value as Domainmodel;
         const scopes = new MultiMap<AstNode, AstNodeDescription>();
         await this.processContainer(model, scopes, document, cancelToken);

--- a/packages/generator-langium/langium-template/tsconfig.json
+++ b/packages/generator-langium/langium-template/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noImplicitReturns": true,
+    "noImplicitOverride": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
+++ b/packages/langium-vscode/src/language-server/grammar-workspace-manager.ts
@@ -33,14 +33,14 @@ export class LangiumGrammarWorkspaceManager extends DefaultWorkspaceManager {
         this.configurationProvider = services.workspace.ConfigurationProvider;
     }
 
-    async initializeWorkspace(folders: WorkspaceFolder[], cancelToken = CancellationToken.None): Promise<void> {
+    override async initializeWorkspace(folders: WorkspaceFolder[], cancelToken = CancellationToken.None): Promise<void> {
         const buildConf: WorkspaceManagerConf = await this.configurationProvider.getConfiguration(LangiumGrammarLanguageMetaData.languageId, CONFIG_KEY);
         const ignorePatterns = buildConf.ignorePatterns?.split(',')?.map(pattern => pattern.trim())?.filter(pattern => pattern.length > 0);
         this.matcher = ignorePatterns ? ignore().add(ignorePatterns) : undefined;
         return super.initializeWorkspace(folders, cancelToken);
     }
 
-    protected includeEntry(workspaceFolder: WorkspaceFolder, entry: FileSystemNode, fileExtensions: string[]): boolean {
+    protected override includeEntry(workspaceFolder: WorkspaceFolder, entry: FileSystemNode, fileExtensions: string[]): boolean {
         if (this.matcher) {
             // create path relative to workspace folder root: /user/foo/workspace/entry.txt -> entry.txt
             const relPath = path.relative(URI.parse(workspaceFolder.uri).path, entry.uri.path);

--- a/packages/langium/src/grammar/lsp/grammar-definition.ts
+++ b/packages/langium/src/grammar/lsp/grammar-definition.ts
@@ -24,7 +24,7 @@ export class LangiumGrammarDefinitionProvider extends DefaultDefinitionProvider 
         this.documents = services.shared.workspace.LangiumDocuments;
     }
 
-    protected collectLocationLinks(sourceCstNode: LeafCstNode, _params: DefinitionParams): MaybePromise<LocationLink[] | undefined> {
+    protected override collectLocationLinks(sourceCstNode: LeafCstNode, _params: DefinitionParams): MaybePromise<LocationLink[] | undefined> {
         const pathFeature: Properties<GrammarImport> = 'path';
         if (isGrammarImport(sourceCstNode.element) && findAssignment(sourceCstNode)?.feature === pathFeature) {
             const importedGrammar = resolveImport(this.documents, sourceCstNode.element);

--- a/packages/langium/src/grammar/lsp/grammar-folding-ranges.ts
+++ b/packages/langium/src/grammar/lsp/grammar-folding-ranges.ts
@@ -13,7 +13,7 @@ import { isParserRule } from '../generated/ast';
  */
 export class LangiumGrammarFoldingRangeProvider extends DefaultFoldingRangeProvider {
 
-    shouldProcessContent(node: AstNode): boolean {
+    override shouldProcessContent(node: AstNode): boolean {
         // Exclude parser rules from folding
         return !isParserRule(node);
     }

--- a/packages/langium/src/grammar/references/grammar-naming.ts
+++ b/packages/langium/src/grammar/references/grammar-naming.ts
@@ -11,7 +11,7 @@ import { isAssignment } from '../generated/ast';
 
 export class LangiumGrammarNameProvider extends DefaultNameProvider {
 
-    getName(node: AstNode): string | undefined {
+    override getName(node: AstNode): string | undefined {
         if (isAssignment(node)) {
             return node.feature;
         } else {
@@ -19,7 +19,7 @@ export class LangiumGrammarNameProvider extends DefaultNameProvider {
         }
     }
 
-    getNameNode(node: AstNode): CstNode | undefined {
+    override getNameNode(node: AstNode): CstNode | undefined {
         if (isAssignment(node)) {
             return findNodeForProperty(node.$cstNode, 'feature');
         } else {

--- a/packages/langium/src/grammar/references/grammar-references.ts
+++ b/packages/langium/src/grammar/references/grammar-references.ts
@@ -26,7 +26,7 @@ export class LangiumGrammarReferences extends DefaultReferences {
         this.documents = services.shared.workspace.LangiumDocuments;
     }
 
-    findDeclaration(sourceCstNode: CstNode): AstNode | undefined {
+    override findDeclaration(sourceCstNode: CstNode): AstNode | undefined {
         const nodeElem = sourceCstNode.element;
         const assignment = findAssignment(sourceCstNode);
         if (assignment && assignment.feature === 'feature') {
@@ -40,7 +40,7 @@ export class LangiumGrammarReferences extends DefaultReferences {
         return super.findDeclaration(sourceCstNode);
     }
 
-    protected findLocalReferences(targetNode: AstNode, includeDeclaration = false): Stream<ReferenceDescription> {
+    protected override findLocalReferences(targetNode: AstNode, includeDeclaration = false): Stream<ReferenceDescription> {
         if (isTypeAttribute(targetNode)) {
             const doc = getDocument(targetNode);
             const rootNode = doc.parseResult.value;
@@ -50,7 +50,7 @@ export class LangiumGrammarReferences extends DefaultReferences {
         }
     }
 
-    protected findGlobalReferences(targetNode: AstNode, includeDeclaration = false): Stream<ReferenceDescription> {
+    protected override findGlobalReferences(targetNode: AstNode, includeDeclaration = false): Stream<ReferenceDescription> {
         if (isTypeAttribute(targetNode)) {
             return this.findReferencesToTypeAttribute(targetNode, includeDeclaration);
         } else {

--- a/packages/langium/src/grammar/references/grammar-scope.ts
+++ b/packages/langium/src/grammar/references/grammar-scope.ts
@@ -19,7 +19,7 @@ export class LangiumGrammarScopeProvider extends DefaultScopeProvider {
         super(services);
     }
 
-    getScope(context: ReferenceInfo): Scope {
+    override getScope(context: ReferenceInfo): Scope {
         const referenceType = this.reflection.getReferenceType(context);
         if (referenceType !== 'AbstractType') return super.getScope(context);
 
@@ -65,7 +65,7 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
         this.processActionNode = processActionNodeWithNodeDescriptionProvider(services.workspace.AstNodeDescriptionProvider);
     }
 
-    protected processNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
+    protected override processNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
         if (isReturnType(node)) return;
         this.processTypeNode(node, document, scopes);
         this.processActionNode(node, document, scopes);

--- a/packages/langium/src/parser/cst-node-builder.ts
+++ b/packages/langium/src/parser/cst-node-builder.ts
@@ -143,7 +143,7 @@ export class LeafCstNodeImpl extends AbstractCstNode implements LeafCstNode {
         return this._offset + this._length;
     }
 
-    get hidden(): boolean {
+    override get hidden(): boolean {
         return this._hidden;
     }
 
@@ -231,17 +231,17 @@ class CstNodeContainer extends Array<CstNode> {
         Object.setPrototypeOf(this, CstNodeContainer.prototype);
     }
 
-    push(...items: CstNode[]): number {
+    override push(...items: CstNode[]): number {
         this.addParents(items);
         return super.push(...items);
     }
 
-    unshift(...items: CstNode[]): number {
+    override unshift(...items: CstNode[]): number {
         this.addParents(items);
         return super.unshift(...items);
     }
 
-    splice(start: number, count: number, ...items: CstNode[]): CstNode[] {
+    override splice(start: number, count: number, ...items: CstNode[]): CstNode[] {
         this.addParents(items);
         return super.splice(start, count, ...items);
     }
@@ -256,7 +256,7 @@ class CstNodeContainer extends Array<CstNode> {
 export class RootCstNodeImpl extends CompositeCstNodeImpl implements RootCstNode {
     private _text = '';
 
-    get text(): string {
+    override get text(): string {
         return this._text.substring(this.offset, this.end);
     }
 

--- a/packages/langium/src/utils/regex-util.ts
+++ b/packages/langium/src/utils/regex-util.ts
@@ -28,14 +28,14 @@ class CommentRegexVisitor extends BaseRegExpVisitor {
         this.endRegexStack = [];
     }
 
-    visitGroup(node: Group) {
+    override visitGroup(node: Group) {
         if (node.quantifier) {
             this.isStarting = false;
             this.endRegexStack = [];
         }
     }
 
-    visitCharacter(node: Character): void {
+    override visitCharacter(node: Character): void {
         const char = String.fromCharCode(node.value);
         if (!this.multiline && char === '\n') {
             this.multiline = true;
@@ -52,7 +52,7 @@ class CommentRegexVisitor extends BaseRegExpVisitor {
         }
     }
 
-    visitSet(node: Set): void {
+    override visitSet(node: Set): void {
         if (!this.multiline) {
             const set = this.regex.substring(node.loc.begin, node.loc.end);
             const regex = new RegExp(set);

--- a/packages/langium/src/utils/stream.ts
+++ b/packages/langium/src/utils/stream.ts
@@ -796,7 +796,7 @@ export class TreeStreamImpl<T>
         );
     }
 
-    iterator(): TreeIterator<T> {
+    override iterator(): TreeIterator<T> {
         const iterator = {
             state: this.startFn(),
             next: () => this.nextFn(iterator.state),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     "noUnusedLocals": true,                   /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
+    "noImplicitOverride": true,               /* Report error when a method is overridden without the `override` keyword. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
 


### PR DESCRIPTION
With TypeScript 4.3, an option to enforce the `override` keyword was introduced. Reasons for enabling this:

 - When you click on the `override` keyword, the editor jumps to the superclass declaration of that member.
 - When refactoring a method that is overridden somewhere, breaking changes can slip through without noticing if the method is implicitly overridden. Making that explicit reveals the breakage at compile time.