### PR TITLE
Support customizable lexer infrastructure

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -40,6 +40,7 @@ import { DefaultLangiumDocumentFactory, DefaultLangiumDocuments, DefaultTextDocu
 import { FileSystemProvider } from './workspace/file-system-provider';
 import { DefaultIndexManager } from './workspace/index-manager';
 import { DefaultWorkspaceManager } from './workspace/workspace-manager';
+import { DefaultLexer } from './parser/lexer';
 
 /**
  * Context required for creating the default language-specific dependency injection module.
@@ -59,7 +60,8 @@ export function createDefaultModule(context: DefaultModuleContext): Module<Langi
             LangiumParser: (services) => createLangiumParser(services),
             CompletionParser: (services) => createCompletionParser(services),
             ValueConverter: () => new DefaultValueConverter(),
-            TokenBuilder: () => new DefaultTokenBuilder()
+            TokenBuilder: () => new DefaultTokenBuilder(),
+            Lexer: (services) => new DefaultLexer(services)
         },
         lsp: {
             CompletionProvider: (services) => new DefaultCompletionProvider(services),

--- a/packages/langium/src/index.ts
+++ b/packages/langium/src/index.ts
@@ -18,6 +18,7 @@ export * from './parser/langium-parser-builder';
 export * from './parser/parser-config';
 export * from './parser/token-builder';
 export * from './parser/value-converter';
+export * from './parser/lexer';
 export * from './references/linker';
 export * from './references/name-provider';
 export * from './references/scope-computation';

--- a/packages/langium/src/parser/completion-parser-builder.ts
+++ b/packages/langium/src/parser/completion-parser-builder.ts
@@ -10,9 +10,9 @@ import { createParser } from './parser-builder-base';
 
 export function createCompletionParser(services: LangiumServices): LangiumCompletionParser {
     const grammar = services.Grammar;
-    const buildTokens = services.parser.TokenBuilder.buildTokens(grammar, { caseInsensitive: services.LanguageMetaData.caseInsensitive });
-    const parser = new LangiumCompletionParser(services, buildTokens);
-    createParser(grammar, parser, buildTokens);
+    const lexer = services.parser.Lexer;
+    const parser = new LangiumCompletionParser(services);
+    createParser(grammar, parser, lexer.definition);
     parser.finalize();
     return parser;
 }

--- a/packages/langium/src/parser/cst-node-builder.ts
+++ b/packages/langium/src/parser/cst-node-builder.ts
@@ -68,13 +68,11 @@ export class CstNodeBuilder {
         }
     }
 
-    addHiddenTokens(hiddenTokens?: IToken[]): void {
-        if (hiddenTokens) {
-            for (const token of hiddenTokens) {
-                const hiddenNode = new LeafCstNodeImpl(token.startOffset, token.image.length, tokenToRange(token), token.tokenType, true);
-                hiddenNode.root = this.rootNode;
-                this.addHiddenToken(this.rootNode, hiddenNode);
-            }
+    addHiddenTokens(hiddenTokens: IToken[]): void {
+        for (const token of hiddenTokens) {
+            const hiddenNode = new LeafCstNodeImpl(token.startOffset, token.image.length, tokenToRange(token), token.tokenType, true);
+            hiddenNode.root = this.rootNode;
+            this.addHiddenToken(this.rootNode, hiddenNode);
         }
     }
 

--- a/packages/langium/src/parser/langium-parser-builder.ts
+++ b/packages/langium/src/parser/langium-parser-builder.ts
@@ -24,7 +24,7 @@ export function createLangiumParser(services: LangiumServices): LangiumParser {
  */
 export function prepareLangiumParser(services: LangiumServices): LangiumParser {
     const grammar = services.Grammar;
-    const buildTokens = services.parser.TokenBuilder.buildTokens(grammar, { caseInsensitive: services.LanguageMetaData.caseInsensitive });
-    const parser = new LangiumParser(services, buildTokens);
-    return createParser(grammar, parser, buildTokens);
+    const lexer = services.parser.Lexer;
+    const parser = new LangiumParser(services);
+    return createParser(grammar, parser, lexer.definition);
 }

--- a/packages/langium/src/parser/lexer.ts
+++ b/packages/langium/src/parser/lexer.ts
@@ -1,0 +1,85 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { ILexingError, IMultiModeLexerDefinition, IToken, Lexer as ChevrotainLexer, TokenType, TokenTypeDictionary, TokenVocabulary } from 'chevrotain';
+import { LangiumServices } from '../services';
+
+export interface LexerResult {
+    /**
+     * A list of all tokens that were lexed from the input.
+     *
+     * Note that Langium requires the optional properties
+     * `startLine`, `startColumn`, `endOffset`, `endLine` and `endColumn` to be set on each token.
+     */
+    tokens: IToken[];
+    /**
+     * Contains hidden tokens, usually comments.
+     */
+    hidden: IToken[];
+    errors: ILexingError[];
+}
+
+export interface Lexer {
+    readonly definition: TokenTypeDictionary;
+    tokenize(text: string): LexerResult;
+}
+
+export class DefaultLexer implements Lexer {
+
+    protected chevrotainLexer: ChevrotainLexer;
+    protected tokenTypes: TokenTypeDictionary;
+
+    constructor(services: LangiumServices) {
+        const tokens = services.parser.TokenBuilder.buildTokens(services.Grammar, {
+            caseInsensitive: services.LanguageMetaData.caseInsensitive
+        });
+        this.tokenTypes = this.toTokenTypeDictionary(tokens);
+        const lexerTokens = isTokenTypeDictionary(tokens) ? Object.values(tokens) : tokens;
+        this.chevrotainLexer = new ChevrotainLexer(lexerTokens);
+    }
+
+    get definition(): TokenTypeDictionary {
+        return this.tokenTypes;
+    }
+
+    tokenize(text: string): LexerResult {
+        const chevrotainResult = this.chevrotainLexer.tokenize(text);
+        return {
+            tokens: chevrotainResult.tokens,
+            errors: chevrotainResult.errors,
+            hidden: chevrotainResult.groups.hidden ?? []
+        };
+    }
+
+    protected toTokenTypeDictionary(buildTokens: TokenVocabulary): TokenTypeDictionary {
+        if (isTokenTypeDictionary(buildTokens)) return buildTokens;
+        const tokens = isIMultiModeLexerDefinition(buildTokens) ? Object.values(buildTokens.modes).flat() : buildTokens;
+        const res: TokenTypeDictionary = {};
+        tokens.forEach(token => res[token.name] = token);
+        return res;
+    }
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is TokenType array
+ */
+export function isTokenTypeArray(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenType[] {
+    return Array.isArray(tokenVocabulary) && (tokenVocabulary.length === 0 || 'name' in tokenVocabulary[0]);
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is IMultiModeLexerDefinition
+ */
+export function isIMultiModeLexerDefinition(tokenVocabulary: TokenVocabulary): tokenVocabulary is IMultiModeLexerDefinition {
+    return tokenVocabulary && 'modes' in tokenVocabulary && 'defaultMode' in tokenVocabulary;
+}
+
+/**
+ * Returns a check whether the given TokenVocabulary is TokenTypeDictionary
+ */
+export function isTokenTypeDictionary(tokenVocabulary: TokenVocabulary): tokenVocabulary is TokenTypeDictionary {
+    return !isTokenTypeArray(tokenVocabulary) && !isIMultiModeLexerDefinition(tokenVocabulary);
+}

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -25,6 +25,7 @@ import type { SemanticTokenProvider } from './lsp/semantic-token-provider';
 import type { LangiumCompletionParser, LangiumParser } from './parser/langium-parser';
 import type { IParserConfig } from './parser/parser-config';
 import type { TokenBuilder } from './parser/token-builder';
+import type { Lexer } from './parser/lexer';
 import type { ValueConverter } from './parser/value-converter';
 import type { Linker } from './references/linker';
 import type { NameProvider } from './references/name-provider';
@@ -96,6 +97,7 @@ export type LangiumDefaultServices = {
         LangiumParser: LangiumParser
         CompletionParser: LangiumCompletionParser
         TokenBuilder: TokenBuilder
+        Lexer: Lexer
     }
     references: {
         Linker: Linker

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { TokenType, TokenVocabulary } from 'chevrotain';
-import { AstNode, createServicesForGrammar, DefaultTokenBuilder, Grammar, LangiumParser, TerminalRule } from '../../src';
+import { AstNode, createServicesForGrammar, DefaultTokenBuilder, Grammar, GrammarAST, LangiumParser, TokenBuilderOptions } from '../../src';
 
 describe('Predicated grammar rules with alternatives', () => {
 
@@ -439,7 +439,7 @@ describe('MultiMode Lexing', () => {
     // Multi-mode token builder, filters tokens by state, and sets up push/pop behavior
     // Without this, we have no multi-mode lexing from the grammar alone
     class MultiModeTokenBuilder extends DefaultTokenBuilder {
-        buildTokens(grammar: Grammar, options?: { caseInsensitive?: boolean }): TokenVocabulary {
+        override buildTokens(grammar: Grammar, options?: TokenBuilderOptions): TokenVocabulary {
             const tokenTypes: TokenType[] = super.buildTokens(grammar, options) as TokenType[];
             return {
                 modes: {
@@ -450,7 +450,7 @@ describe('MultiMode Lexing', () => {
             };
         }
 
-        protected buildTerminalToken(terminal: TerminalRule): TokenType {
+        protected override buildTerminalToken(terminal: GrammarAST.TerminalRule): TokenType {
             const tokenType = super.buildTerminalToken(terminal);
             if(tokenType.name === 'Up') {
                 tokenType.PUSH_MODE = 'up';

--- a/packages/langium/test/parser/lexer.test.ts
+++ b/packages/langium/test/parser/lexer.test.ts
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createServicesForGrammar, Lexer } from '../../src';
+
+describe('DefaultLexer', () => {
+
+    test('should expose lexer definition', () => {
+        const lexer = getLexer(`
+        grammar X
+        entry Y: y='Y';
+        hidden terminal WS: /\\s+/;
+        `);
+        expect(Object.values(lexer.definition)).toHaveLength(2);
+        expect(lexer.definition.Y.name).toBe('Y');
+        expect(lexer.definition.WS.name).toBe('WS');
+    });
+
+    test('should lex input', () => {
+        const lexer = getLexer(`
+        grammar X
+        entry Y: name='Y';
+        hidden terminal WS: /\\s+/;
+        `);
+        const result = lexer.tokenize('Y');
+        expect(result.tokens).toHaveLength(1);
+        expect(result.tokens[0].image).toBe('Y');
+        expect(result.errors).toHaveLength(0);
+        expect(result.hidden).toHaveLength(0);
+    });
+
+    test('should return lexer errors', () => {
+        const lexer = getLexer(`
+        grammar X
+        entry Y: name=ID;
+        terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
+        hidden terminal WS: /\\s+/;
+        `);
+        const result = lexer.tokenize('4');
+        expect(result.tokens).toHaveLength(0);
+        expect(result.errors).toHaveLength(1);
+        expect(result.hidden).toHaveLength(0);
+    });
+
+    test('should lex hidden terminals', () => {
+        const lexer = getLexer(`
+        grammar X
+        entry Y: name=ID;
+        terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
+        hidden terminal WS: /\\s+/;
+        hidden terminal ML_COMMENT: /\\/\\*[\\s\\S]*?\\*\\//;
+        `);
+        const result = lexer.tokenize('Y /* Test */');
+        expect(result.tokens).toHaveLength(1);
+        expect(result.tokens[0].image).toBe('Y');
+        expect(result.errors).toHaveLength(0);
+        expect(result.hidden).toHaveLength(1);
+        expect(result.hidden[0].image).toBe('/* Test */');
+    });
+
+});
+
+function getLexer(grammar: string): Lexer {
+    const services = createServicesForGrammar({
+        grammar
+    });
+    return services.parser.Lexer;
+}


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/707

This allows users to build their own lexers for more complicated languages such as Python and JavaScript by building a custom lexer. 

Also fixes an issue where we had to append `:KW` to keyword tokens. This is no longer necessary.