### PR TITLE
Only use name-nodes as definitions

### DIFF
--- a/packages/langium/src/references/references.ts
+++ b/packages/langium/src/references/references.ts
@@ -8,7 +8,7 @@ import { findAssignment } from '../utils/grammar-util';
 import { LangiumServices } from '../services';
 import { AstNode, CstNode, GenericAstNode, Reference } from '../syntax-tree';
 import { getDocument, isReference, streamAst, streamReferences } from '../utils/ast-util';
-import { toDocumentSegment } from '../utils/cst-util';
+import { isCstChildNode, toDocumentSegment } from '../utils/cst-util';
 import { stream, Stream } from '../utils/stream';
 import { equalURI } from '../utils/uri-util';
 import { ReferenceDescription } from '../workspace/ast-descriptions';
@@ -70,8 +70,7 @@ export class DefaultReferences implements References {
 
                 if (isReference(reference)) {
                     return reference.ref;
-                }
-                else if (Array.isArray(reference)) {
+                } else if (Array.isArray(reference)) {
                     for (const ref of reference) {
                         if (isReference(ref)
                             && ref.$refNode.offset <= sourceCstNode.offset
@@ -80,7 +79,11 @@ export class DefaultReferences implements References {
                         }
                     }
                 }
-                else {
+            }
+            if (nodeElem) {
+                const nameNode = this.nameProvider.getNameNode(nodeElem);
+                // Only return the targeted node in case the targeted cst node is the name node or part of it
+                if (nameNode && (nameNode === sourceCstNode || isCstChildNode(sourceCstNode, nameNode))) {
                     return nodeElem;
                 }
             }

--- a/packages/langium/src/utils/cst-util.ts
+++ b/packages/langium/src/utils/cst-util.ts
@@ -31,6 +31,19 @@ export function flattenCst(node: CstNode): Stream<LeafCstNode> {
     return streamCst(node).filter(isLeafCstNode);
 }
 
+/**
+ * Determines whether the specified cst node is a child of the specified parent node.
+ */
+export function isCstChildNode(child: CstNode, parent: CstNode): boolean {
+    while (child.parent) {
+        child = child.parent;
+        if (child === parent) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export function tokenToRange(token: IToken): Range {
     // Chevrotain uses 1-based indices everywhere
     // So we subtract 1 from every value to align with the LSP

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -211,14 +211,16 @@ export function findNodesForKeywordInternal(node: CstNode, keyword: string, elem
  * @param cstNode A CST node for which to find a property assignment.
  */
 export function findAssignment(cstNode: CstNode): ast.Assignment | undefined {
-    let n: CstNode | undefined = cstNode;
-    do {
-        const assignment = getContainerOfType(n.feature, ast.isAssignment);
+    const astNode = cstNode.element;
+    // Only search until the ast node of the parent cst node is no longer the original ast node
+    // This would make us jump to a preceding rule call, which contains only unrelated assignments
+    while (astNode === cstNode.parent?.element) {
+        const assignment = getContainerOfType(cstNode.feature, ast.isAssignment);
         if (assignment) {
             return assignment;
         }
-        n = n.parent;
-    } while (n);
+        cstNode = cstNode.parent;
+    }
     return undefined;
 }
 

--- a/packages/langium/test/lsp/goto-definition.test.ts
+++ b/packages/langium/test/lsp/goto-definition.test.ts
@@ -16,7 +16,7 @@ import { expectGoToDefinition } from '../../src/test';
 const text = `
 grammar test hidden(WS, <|>COMMENT)
 
-terminal ID: /\\w+/;
+term<|>inal ID: /\\w+/;
 terminal WS: /\\s+/;
 terminal <|COMMENT|>: /\\/\\/.*/;
 
@@ -28,14 +28,14 @@ interface A {
     <|name|>:string
 }
 
-X returns A:
+X retu<|>rns A:
     <|>na<|>me<|>=ID;
 `.trim();
 
 const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
 const gotoDefinition = expectGoToDefinition(grammarServices);
 
-describe('GoToResolver', () => {
+describe('Definition Provider', () => {
 
     test('Must find SL_COMMENT inside of array of cross references', async () => {
         await gotoDefinition({
@@ -48,7 +48,7 @@ describe('GoToResolver', () => {
     test('Entity must find itself when referenced from start of other location', async () => {
         await gotoDefinition({
             text,
-            index: 1,
+            index: 2,
             rangeIndex: 1
         });
     });
@@ -56,7 +56,7 @@ describe('GoToResolver', () => {
     test('Entity must find itself when referenced from within other location', async () => {
         await gotoDefinition({
             text,
-            index: 2,
+            index: 3,
             rangeIndex: 1
         });
     });
@@ -64,7 +64,7 @@ describe('GoToResolver', () => {
     test('Entity must find itself when referenced from source location', async () => {
         await gotoDefinition({
             text,
-            index: 3,
+            index: 4,
             rangeIndex: 1
         });
     });
@@ -72,7 +72,7 @@ describe('GoToResolver', () => {
     test('Assignment name in parser rule X must find property name in interface A from start of location', async () => {
         await gotoDefinition({
             text,
-            index: 4,
+            index: 6,
             rangeIndex: 2
         });
     });
@@ -80,7 +80,7 @@ describe('GoToResolver', () => {
     test('Assignment name in parser rule X must find property name in interface A from within location', async () => {
         await gotoDefinition({
             text,
-            index: 5,
+            index: 7,
             rangeIndex: 2
         });
     });
@@ -88,8 +88,27 @@ describe('GoToResolver', () => {
     test('Assignment name in parser rule X must find property name in interface A from end of location', async () => {
         await gotoDefinition({
             text,
-            index: 6,
+            index: 8,
             rangeIndex: 2
+        });
+    });
+
+    describe('Should not find anything on keywords', () => {
+
+        test('Should find nothing on `terminal` keyword', async () => {
+            await gotoDefinition({
+                text,
+                index: 1,
+                rangeIndex: []
+            });
+        });
+
+        test('Should find nothing on `returns` keyword', async () => {
+            await gotoDefinition({
+                text,
+                index: 5,
+                rangeIndex: []
+            });
         });
     });
 });


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/726

Improves the existing code on two parts:
1. Only provide the original element in case the targeted node is part of the name node
2. Only return in `findAssignment` if the assignment belongs to the current AST node

Also adds some new test cases for this. 