### PR TITLE
Improve validation check type safety

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -113,7 +113,18 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
     return reflection.isInstance(item, NumberLiteral);
 }
 
-export type ArithmeticsAstType = 'AbstractDefinition' | 'BinaryExpression' | 'DeclaredParameter' | 'Definition' | 'Evaluation' | 'Expression' | 'FunctionCall' | 'Module' | 'NumberLiteral' | 'Statement';
+export interface ArithmeticsAstType {
+    AbstractDefinition: AbstractDefinition
+    BinaryExpression: BinaryExpression
+    DeclaredParameter: DeclaredParameter
+    Definition: Definition
+    Evaluation: Evaluation
+    Expression: Expression
+    FunctionCall: FunctionCall
+    Module: Module
+    NumberLiteral: NumberLiteral
+    Statement: Statement
+}
 
 export class ArithmeticsAstReflection implements AstReflection {
 

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -84,7 +84,15 @@ export function isPackageDeclaration(item: unknown): item is PackageDeclaration 
     return reflection.isInstance(item, PackageDeclaration);
 }
 
-export type DomainModelAstType = 'AbstractElement' | 'DataType' | 'Domainmodel' | 'Entity' | 'Feature' | 'PackageDeclaration' | 'Type';
+export interface DomainModelAstType {
+    AbstractElement: AbstractElement
+    DataType: DataType
+    Domainmodel: Domainmodel
+    Entity: Entity
+    Feature: Feature
+    PackageDeclaration: PackageDeclaration
+    Type: Type
+}
 
 export class DomainModelAstReflection implements AstReflection {
 

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -80,7 +80,14 @@ export function isTestModel(item: unknown): item is TestModel {
     return reflection.isInstance(item, TestModel);
 }
 
-export type RequirementsAndTestsAstType = 'Contact' | 'Environment' | 'Requirement' | 'RequirementModel' | 'Test' | 'TestModel';
+export interface RequirementsAndTestsAstType {
+    Contact: Contact
+    Environment: Environment
+    Requirement: Requirement
+    RequirementModel: RequirementModel
+    Test: Test
+    TestModel: TestModel
+}
 
 export class RequirementsAndTestsAstReflection implements AstReflection {
 

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -68,7 +68,13 @@ export function isTransition(item: unknown): item is Transition {
     return reflection.isInstance(item, Transition);
 }
 
-export type StatemachineAstType = 'Command' | 'Event' | 'State' | 'Statemachine' | 'Transition';
+export interface StatemachineAstType {
+    Command: Command
+    Event: Event
+    State: State
+    Statemachine: Statemachine
+    Transition: Transition
+}
 
 export class StatemachineAstReflection implements AstReflection {
 

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -47,21 +47,28 @@ function hasCrossReferences(grammar: Grammar): boolean {
 }
 
 function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): GeneratorNode {
-    const typeNames: string[] = astTypes.interfaces.map(t => `'${t.name}'`)
-        .concat(astTypes.unions.map(t => `'${t.name}'`))
+    const typeNames: string[] = astTypes.interfaces.map(t => t.name)
+        .concat(astTypes.unions.map(t => t.name))
         .sort();
     const crossReferenceTypes = buildCrossReferenceTypes(astTypes);
     const reflectionNode = new CompositeGeneratorNode();
 
+    reflectionNode.append(`export interface ${config.projectName}AstType {`, NL);
+    reflectionNode.indent(astTypeBody => {
+        for (const type of typeNames) {
+            astTypeBody.append(type, ': ', type, NL);
+        }
+    });
+    reflectionNode.append('}', NL, NL);
+
     reflectionNode.append(
-        `export type ${config.projectName}AstType = ${typeNames.join(' | ')};`, NL, NL,
         `export class ${config.projectName}AstReflection implements AstReflection {`, NL, NL
     );
 
     reflectionNode.indent(classBody => {
         classBody.append('getAllTypes(): string[] {', NL);
         classBody.indent(allTypes => {
-            allTypes.append(`return [${typeNames.join(', ')}];`, NL);
+            allTypes.append(`return [${typeNames.map(e => `'${e}'`).join(', ')}];`, NL);
         });
         classBody.append('}', NL, NL, 'isInstance(node: unknown, type: string): boolean {', NL);
         classBody.indent(isInstance => {

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -453,7 +453,45 @@ export function isWildcard(item: unknown): item is Wildcard {
     return reflection.isInstance(item, Wildcard);
 }
 
-export type LangiumGrammarAstType = 'AbstractElement' | 'AbstractRule' | 'AbstractType' | 'Action' | 'Alternatives' | 'Assignment' | 'AtomType' | 'CharacterRange' | 'Condition' | 'Conjunction' | 'CrossReference' | 'Disjunction' | 'Grammar' | 'GrammarImport' | 'Group' | 'InferredType' | 'Interface' | 'Keyword' | 'LiteralCondition' | 'NamedArgument' | 'NegatedToken' | 'Negation' | 'Parameter' | 'ParameterReference' | 'ParserRule' | 'RegexToken' | 'ReturnType' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRule' | 'TerminalRuleCall' | 'Type' | 'TypeAttribute' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
+export interface LangiumGrammarAstType {
+    AbstractElement: AbstractElement
+    AbstractRule: AbstractRule
+    AbstractType: AbstractType
+    Action: Action
+    Alternatives: Alternatives
+    Assignment: Assignment
+    AtomType: AtomType
+    CharacterRange: CharacterRange
+    Condition: Condition
+    Conjunction: Conjunction
+    CrossReference: CrossReference
+    Disjunction: Disjunction
+    Grammar: Grammar
+    GrammarImport: GrammarImport
+    Group: Group
+    InferredType: InferredType
+    Interface: Interface
+    Keyword: Keyword
+    LiteralCondition: LiteralCondition
+    NamedArgument: NamedArgument
+    NegatedToken: NegatedToken
+    Negation: Negation
+    Parameter: Parameter
+    ParameterReference: ParameterReference
+    ParserRule: ParserRule
+    RegexToken: RegexToken
+    ReturnType: ReturnType
+    RuleCall: RuleCall
+    TerminalAlternatives: TerminalAlternatives
+    TerminalGroup: TerminalGroup
+    TerminalRule: TerminalRule
+    TerminalRuleCall: TerminalRuleCall
+    Type: Type
+    TypeAttribute: TypeAttribute
+    UnorderedGroup: UnorderedGroup
+    UntilToken: UntilToken
+    Wildcard: Wildcard
+}
 
 export class LangiumGrammarAstReflection implements AstReflection {
 

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -31,6 +31,8 @@ export interface GenericAstNode extends AstNode {
     [key: string]: unknown
 }
 
+export type AstTypeList<T> = Record<keyof T, AstNode>;
+
 type SpecificNodeProperties<N extends AstNode> = keyof Omit<N, keyof AstNode | number | symbol>;
 
 /**


### PR DESCRIPTION
As of now, validations can be written as `Type: (node: NotOfType, acceptor)` which might break validations during runtime. This change improves type safety in the validation registry and also introduces a better `AstTypes` generator.