### PR TITLE
langium-cli to generate types definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,9 +1349,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/commander": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
-      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "engines": {
         "node": ">= 12"
       }
@@ -4579,7 +4579,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
-        "commander": "^7.2.0",
+        "commander": "^8.0.0",
         "fs-extra": "^9.1.0",
         "jsonschema": "^1.4.0",
         "langium": "~0.5.0",
@@ -4593,14 +4593,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "packages/langium-cli/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "packages/langium-sprotty": {
@@ -5626,9 +5618,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "commander": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
-      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -6598,18 +6590,11 @@
       "requires": {
         "@types/fs-extra": "^9.0.13",
         "chalk": "^4.1.2",
-        "commander": "^7.2.0",
+        "commander": "^8.0.0",
         "fs-extra": "^9.1.0",
         "jsonschema": "^1.4.0",
         "langium": "~0.5.0",
         "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        }
       }
     },
     "langium-domainmodel-dsl": {

--- a/packages/langium-cli/package.json
+++ b/packages/langium-cli/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
-    "commander": "^7.2.0",
+    "commander": "^8.0.0",
     "fs-extra": "^9.1.0",
     "jsonschema": "^1.4.0",
     "langium": "~0.5.0",

--- a/packages/langium-cli/src/generator/types-generator.ts
+++ b/packages/langium-cli/src/generator/types-generator.ts
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { CompositeGeneratorNode, Grammar, LangiumServices, NL, processGeneratorNode } from 'langium';
+import { collectAst, distinctAndSorted, PropertyType } from 'langium/lib/grammar/type-system';
+import { LangiumGrammarGrammar } from 'langium/lib/grammar/generated/grammar';
+import { collectKeywords } from './util';
+
+export function generateTypesFile(services: LangiumServices, grammars: Grammar[]): string {
+    const astTypes = collectAst(services.shared.workspace.LangiumDocuments, grammars);
+    const fileNode = new CompositeGeneratorNode();
+    const reservedWords = new Set(collectKeywords(LangiumGrammarGrammar()));
+    astTypes.unions.filter((union) => !astTypes.interfaces.find((iface) =>
+        iface.name === union.name
+    )).forEach((union) => {
+        fileNode.append(`type ${escapeReservedWords(union.name, reservedWords)} = ${propertyTypesToString(union.union)};`);
+        fileNode.append(NL).append(NL);
+    });
+    astTypes.interfaces.forEach((iFace) => {
+        fileNode.append(`interface ${escapeReservedWords(iFace.name, reservedWords)}${iFace.interfaceSuperTypes.length > 0 ? (' extends ' + Array.from(iFace.interfaceSuperTypes).join(', ')) : ''} {`);
+        fileNode.append(NL);
+        fileNode.indent((body) => {
+            iFace.properties.forEach(property =>
+                body.append(`${escapeReservedWords(property.name, reservedWords)}${property.optional ? '?' : ''}: ${propertyTypesToString(property.typeAlternatives)}`).append(NL)
+            );
+        });
+        fileNode.append('}').append(NL).append(NL);
+    }
+    );
+    return processGeneratorNode(fileNode);
+}
+
+function propertyTypesToString(alternatives: PropertyType[]): string {
+    return distinctAndSorted(alternatives.map(typePropertyToString)).join(' | ');
+}
+
+function typePropertyToString(propertyType: PropertyType): string {
+    let res = distinctAndSorted(propertyType.types).join(' | ');
+    res = propertyType.reference ? `@${res}` : res;
+    res = propertyType.array ? `${res}[]` : res;
+    return res;
+}
+
+function escapeReservedWords(name: string, reserved: Set<string>): string {
+    return reserved.has(name) ? `^${name}` : name;
+}

--- a/packages/langium-cli/src/generator/util.ts
+++ b/packages/langium-cli/src/generator/util.ts
@@ -8,11 +8,10 @@ import { CompositeGeneratorNode, GeneratorNode, getAllReachableRules, Grammar, G
 import fs from 'fs-extra';
 import path from 'path';
 import * as readline from 'readline';
-import type { GenerateOptions } from '../generate';
 import chalk from 'chalk';
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function log(level: 'log' | 'warn' | 'error', options: GenerateOptions, message: string, ...args: any[]): void {
+export function log(level: 'log' | 'warn' | 'error', options: { watch: boolean }, message: string, ...args: any[]): void {
     if (options.watch) {
         console[level](getTime() + message, ...args);
     } else {

--- a/packages/langium-cli/src/langium.ts
+++ b/packages/langium-cli/src/langium.ts
@@ -8,7 +8,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import { Command } from 'commander';
 import { validate } from 'jsonschema';
-import { generate, GenerateOptions, GeneratorResult } from './generate';
+import { ExtractTypesOptions, generate, GenerateOptions, generateTypes, GeneratorResult } from './generate';
 import { cliVersion, elapsedTime, getTime, log, schema } from './generator/util';
 import { LangiumConfig, loadConfigs, RelativePath } from './package';
 import path from 'path';
@@ -27,6 +27,18 @@ program
             process.exit(1);
         });
     });
+program.command('extract-types')
+    .argument('<file>', 'the langium grammar file to generate types for')
+    .option('-o, --output <file>', 'output file name. Default is types.langium next to the grammar file.')
+    .option('-f, --force', 'Force overwrite existing file.')
+    .action((file, options: ExtractTypesOptions) => {
+        options.grammar = file;
+        generateTypes(options).catch(err => {
+            console.error(err);
+            process.exit(1);
+        });
+    })
+    .action;
 
 program.parse(process.argv);
 

--- a/packages/langium-cli/test/generator/types-generator.test.ts
+++ b/packages/langium-cli/test/generator/types-generator.test.ts
@@ -1,0 +1,109 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createLangiumGrammarServices, EmptyFileSystem, Grammar } from 'langium';
+import { parseHelper } from 'langium/test';
+import { generateTypesFile } from '../../src/generator/types-generator';
+
+const { grammar } = createLangiumGrammarServices(EmptyFileSystem);
+
+describe('Types generator', () => {
+
+    test('should generate types file', async () => {
+        const result = (await parseHelper<Grammar>(grammar)(TEST_GRAMMAR)).parseResult;
+        const typesFileContent = generateTypesFile(grammar, [result.value]);
+        expect(typesFileContent).toMatch(EXPECTED_TYPES);
+    });
+
+});
+
+const EXPECTED_TYPES =
+    `type AbstractDefinition = DeclaredParameter | Definition;
+
+type Expression = BinaryExpression | FunctionCall | NumberLiteral;
+
+type Statement = Definition | Evaluation;
+
+interface BinaryExpression {
+    left: Expression
+    operator: '*' | '+' | '-' | '/'
+    right: Expression
+}
+
+interface DeclaredParameter {
+    name: string
+}
+
+interface Definition {
+    name: string
+    args?: DeclaredParameter[]
+    expr: Expression
+}
+
+interface Evaluation {
+    expression: Expression
+}
+
+interface FunctionCall {
+    func: @AbstractDefinition
+    args?: Expression[]
+}
+
+interface Module {
+    name: string
+    statements?: Statement[]
+}
+
+interface NumberLiteral {
+    value: number
+}
+
+`;
+
+const TEST_GRAMMAR =
+    `
+grammar Arithmetics
+
+entry Module:
+    'module' name=ID
+    (statements+=Statement)*;
+
+Statement:
+    Definition | Evaluation;
+
+Definition:
+    'def' name=ID ('(' args+=DeclaredParameter (',' args+=DeclaredParameter)* ')')?
+    ':' expr=Expression ';';
+
+DeclaredParameter:
+    name=ID;
+
+type AbstractDefinition = Definition | DeclaredParameter;
+
+Evaluation:
+    expression=Expression ';';
+
+Expression:
+    Addition;
+
+Addition infers Expression:
+    Multiplication ({infer BinaryExpression.left=current} operator=('+' | '-') right=Multiplication)*;
+
+Multiplication infers Expression:
+    PrimaryExpression ({infer BinaryExpression.left=current} operator=('*' | '/') right=PrimaryExpression)*;
+
+PrimaryExpression infers Expression:
+    '(' Expression ')' |
+    {infer NumberLiteral} value=NUMBER |
+    {infer FunctionCall} func=[AbstractDefinition] ('(' args+=Expression (',' args+=Expression)* ')')?;
+
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;
+terminal NUMBER returns number: /[0-9]+(\\.[0-9]*)?/;
+
+hidden terminal ML_COMMENT: /\\/\\*[\\s\\S]*?\\*\\//;
+hidden terminal SL_COMMENT: /\\/\\/[^\\n\\r]*/;
+`;

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -19,12 +19,18 @@
     "vscode": "^1.53.0"
   },
   "contributes": {
-    "languages": [{
-      "id": "langium",
-      "extensions": [ ".langium" ],
-      "aliases": [ "Langium" ],
-      "configuration": "./data/langium.configuration.json"
-    }],
+    "languages": [
+      {
+        "id": "langium",
+        "extensions": [
+          ".langium"
+        ],
+        "aliases": [
+          "Langium"
+        ],
+        "configuration": "./data/langium.configuration.json"
+      }
+    ],
     "grammars": [
       {
         "language": "langium",
@@ -65,7 +71,7 @@
   "dependencies": {
     "langium": "0.5.0",
     "vscode-languageserver": "^8.0.2",
-    "ignore":"~5.2.0"
+    "ignore": "~5.2.0"
   },
   "devDependencies": {
     "@types/vscode": "^1.53.0",
@@ -78,7 +84,7 @@
   },
   "bugs": "https://github.com/langium/langium/issues",
   "author": {
-      "name": "TypeFox",
-      "url": "https://www.typefox.io"
+    "name": "TypeFox",
+    "url": "https://www.typefox.io"
   }
 }


### PR DESCRIPTION
This PR adds:
- a new option `-t, --types  <file>` to langium-cli that only triggers the type definition generation
- a command to the Langium extension that triggers langium-cli to generate type definitions
- a context menu entry to the Langium editor the triggers the command 

![generate-langium-types](https://user-images.githubusercontent.com/454322/199950845-6a792cff-1260-4024-b2b9-be4b3eb41f47.gif)
