### PR TITLE
Refactored grammar language scoping

### DIFF
--- a/packages/langium/src/grammar/langium-grammar-module.ts
+++ b/packages/langium/src/grammar/langium-grammar-module.ts
@@ -34,7 +34,7 @@ export const LangiumGrammarModule: Module<LangiumGrammarServices, PartialLangium
     },
     lsp: {
         FoldingRangeProvider: (services) => new LangiumGrammarFoldingRangeProvider(services),
-        CodeActionProvider: () => new LangiumGrammarCodeActionProvider(),
+        CodeActionProvider: (services) => new LangiumGrammarCodeActionProvider(services),
         SemanticTokenProvider: (services) => new LangiumGrammarSemanticTokenProvider(services),
         Formatter: () => new LangiumGrammarFormatter(),
         DefinitionProvider: (services) => new LangiumGrammarDefinitionProvider(services),

--- a/packages/langium/src/references/scope-provider.ts
+++ b/packages/langium/src/references/scope-provider.ts
@@ -131,7 +131,7 @@ export class DefaultScopeProvider implements ScopeProvider {
             } while (currentNode);
         }
 
-        let result: Scope = this.getGlobalScope(referenceType);
+        let result: Scope = this.getGlobalScope(referenceType, context);
         for (let i = scopes.length - 1; i >= 0; i--) {
             result = this.createScope(scopes[i], result);
         }
@@ -163,7 +163,7 @@ export class DefaultScopeProvider implements ScopeProvider {
     /**
      * Create a global scope filtered for the given reference type.
      */
-    protected getGlobalScope(referenceType: string): Scope {
+    protected getGlobalScope(referenceType: string, _context: ReferenceInfo): Scope {
         return new StreamScope(this.indexManager.allElements(referenceType));
     }
 

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -113,12 +113,12 @@ describe('checkReferenceToRuleButNotType', () => {
         entry Model:
             'model' name=ID
             (elements+=Element)*;
-        
+
         type AbstractElement = Reference | string;
-        
+
         Element:
             Definition | Reference;
-        
+
         Definition infers DefType:
             name=ID;
         Reference infers RefType:
@@ -134,7 +134,7 @@ describe('checkReferenceToRuleButNotType', () => {
 
     test('CrossReference validation', () => {
         const crossRef = streamAllContents(validationResult.document.parseResult.value).find(GrammarAST.isCrossReference)!;
-        expectError(validationResult, "Use the rule type 'DefType' instead of the typed rule name 'Definition' for cross references.", {
+        expectError(validationResult, "Could not resolve reference to AbstractType named 'Definition'.", {
             node: crossRef,
             property: { name: 'type' }
         });
@@ -142,7 +142,7 @@ describe('checkReferenceToRuleButNotType', () => {
 
     test('AtomType validation', () => {
         const type = validationResult.document.parseResult.value.types[0];
-        expectError(validationResult, "Use the rule type 'RefType' instead of the typed rule name 'Reference' for cross references.", {
+        expectError(validationResult, "Could not resolve reference to AbstractType named 'Reference'.", {
             node: type,
             property: { name: 'typeAlternatives' }
         });
@@ -231,9 +231,9 @@ describe('Unordered group validations', () => {
     test('Unsupported optional element in unordered group error', async () => {
         const text = `
         grammar TestUnorderedGroup
-        
-        entry Book: 
-            'book' name=STRING 
+
+        entry Book:
+            'book' name=STRING
             (
                   ("description" descr=STRING)
                 & ("edition" version=STRING)?
@@ -257,7 +257,7 @@ describe('Unused rules validation', () => {
     test('Should not create validate for indirectly used terminal', async () => {
         const text = `
         grammar TestUsedTerminals
-        
+
         entry Used: name=ID;
         hidden terminal WS: /\\s+/;
         terminal ID: 'a' STRING;
@@ -270,7 +270,7 @@ describe('Unused rules validation', () => {
     test('Unused terminals are correctly identified', async () => {
         const text = `
         grammar TestUnusedTerminals
-        
+
         entry Used: name=ID;
         hidden terminal WS: /\\s+/;
         terminal ID: /[_a-zA-Z][\\w_]*/;
@@ -291,7 +291,7 @@ describe('Unused rules validation', () => {
     test('Unused parser rules are correctly identified', async () => {
         const text = `
         grammar TestUnusedParserRule
-        
+
         entry Used: name=ID;
         Unused: name=ID;
         hidden terminal WS: /\\s+/;


### PR DESCRIPTION
Fixes #746.

 * Restricted global scope to include only elements from explicitly imported grammar files.
 * Added code action to auto-import symbols from other files if they are found in the index.
 * Simplified the grammar scope provider so it includes only types and interfaces - parser rules and actions with inferred types are processed earlier and synthetically produce Interface node descriptions.