### PR TITLE
Programmatic reference construction

### DIFF
--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -38,7 +38,7 @@ export function generateAst(services: LangiumServices, grammars: Grammar[], conf
 }
 
 function hasCrossReferences(grammar: Grammar): boolean {
-    return !!streamAllContents(grammar).find(GrammarAST.isCrossReference);
+    return Boolean(streamAllContents(grammar).find(GrammarAST.isCrossReference));
 }
 
 function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): GeneratorNode {

--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -11,7 +11,7 @@ import { generatedHeader } from './util';
 
 export function generateModule(grammars: langium.Grammar[], config: LangiumConfig, grammarConfigMap: Map<langium.Grammar, LangiumLanguageConfig>): string {
     const parserConfig = config.chevrotainParserConfig;
-    const hasIParserConfigImport: boolean = !!parserConfig || grammars.some(grammar => grammarConfigMap.get(grammar)?.chevrotainParserConfig !== undefined);
+    const hasIParserConfigImport = Boolean(parserConfig) || grammars.some(grammar => grammarConfigMap.get(grammar)?.chevrotainParserConfig !== undefined);
     const node = new CompositeGeneratorNode();
 
     node.append(generatedHeader);
@@ -45,7 +45,7 @@ export function generateModule(grammars: langium.Grammar[], config: LangiumConfi
             node.indent(metaData => {
                 metaData.append(`languageId: '${config.id}',`, NL);
                 metaData.append(`fileExtensions: [${config.fileExtensions && config.fileExtensions.map(e => appendQuotesAndDot(e)).join(', ')}],`, NL);
-                metaData.append(`caseInsensitive: ${!!config.caseInsensitive}`, NL);
+                metaData.append(`caseInsensitive: ${Boolean(config.caseInsensitive)}`, NL);
             });
             node.append('};', NL, NL);
         }

--- a/packages/langium-cli/src/parser-validation.ts
+++ b/packages/langium-cli/src/parser-validation.ts
@@ -59,7 +59,7 @@ function languageConfigToMetaData(config: LangiumLanguageConfig): LanguageMetaDa
     return {
         languageId: config.id,
         fileExtensions: config.fileExtensions ?? [],
-        caseInsensitive: !!config.caseInsensitive
+        caseInsensitive: Boolean(config.caseInsensitive)
     };
 }
 

--- a/packages/langium/src/grammar/langium-grammar-validator.ts
+++ b/packages/langium/src/grammar/langium-grammar-validator.ts
@@ -295,7 +295,7 @@ export class LangiumGrammarValidator {
         for (const action of streamAllContents(grammar).filter(ast.isAction)) {
             const actionType = this.getActionType(action);
             if (actionType) {
-                const isInfers = !!action.inferredType;
+                const isInfers = Boolean(action.inferredType);
                 const typeName = getTypeName(action);
                 if (action.type && types.has(typeName) === isInfers) {
                     const keywordNode = isInfers ? findNodeForKeyword(action.$cstNode, 'infer') : findNodeForKeyword(action.$cstNode, '{');

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -337,7 +337,7 @@ export abstract class AbstractFormatter implements Formatter {
         } else if (lines !== undefined) {
             edits.push(this.createLineTextEdit(betweenRange, lines, context, formatting.options));
         } else if (tabs !== undefined) {
-            edits.push(this.createTabTextEdit(betweenRange, !!a, context));
+            edits.push(this.createTabTextEdit(betweenRange, Boolean(a), context));
         }
         if (isLeafCstNode(b)) {
             context.indentation = existingIndentation;

--- a/packages/langium/src/lsp/language-server.ts
+++ b/packages/langium/src/lsp/language-server.ts
@@ -67,7 +67,7 @@ export class DefaultLanguageServer implements LanguageServer {
     protected buildInitializeResult(_params: InitializeParams): InitializeResult {
         const languages = this.services.ServiceRegistry.all;
         const hasFormattingService = this.hasService(e => e.lsp.Formatter);
-        const formattingOnTypeOptions = languages.map(e => e.lsp.Formatter?.formatOnTypeOptions).find(e => !!e);
+        const formattingOnTypeOptions = languages.map(e => e.lsp.Formatter?.formatOnTypeOptions).find(e => Boolean(e));
         const hasCodeActionProvider = this.hasService(e => e.lsp.CodeActionProvider);
         const hasSemanticTokensProvider = this.hasService(e => e.lsp.SemanticTokenProvider);
         const commandNames = this.services.lsp.ExecuteCommandHandler?.commands;
@@ -122,10 +122,10 @@ export class DefaultLanguageServer implements LanguageServer {
                     ? {}
                     : undefined,
                 documentLinkProvider: documentLinkProvider
-                    ? { resolveProvider: !!documentLinkProvider.resolveDocumentLink }
+                    ? { resolveProvider: Boolean(documentLinkProvider.resolveDocumentLink) }
                     : undefined,
                 codeLensProvider: codeLensProvider
-                    ? { resolveProvider: !!codeLensProvider.resolveCodeLens }
+                    ? { resolveProvider: Boolean(codeLensProvider.resolveCodeLens) }
                     : undefined,
                 declarationProvider: hasDeclarationProvider
             }

--- a/packages/langium/src/lsp/references-provider.ts
+++ b/packages/langium/src/lsp/references-provider.ts
@@ -60,7 +60,7 @@ export class DefaultReferencesProvider implements ReferencesProvider {
         if (targetAstNode) {
             const options = { includeDeclaration: params.context.includeDeclaration };
             this.references.findReferences(targetAstNode, options).forEach(reference => {
-                if (isReference(reference)) {
+                if (isReference(reference) && reference.$refNode) {
                     refs.push(Location.create(document.uri.toString(), reference.$refNode.range));
                 } else {
                     refs.push(Location.create(reference.sourceUri.toString(), reference.segment.range));

--- a/packages/langium/src/lsp/references-provider.ts
+++ b/packages/langium/src/lsp/references-provider.ts
@@ -7,7 +7,7 @@
 import { CancellationToken, Location,  ReferenceParams } from 'vscode-languageserver';
 import { NameProvider } from '../references/name-provider';
 import { References } from '../references/references';
-import { AstNode, isReference, LeafCstNode } from '../syntax-tree';
+import { LeafCstNode } from '../syntax-tree';
 import { LangiumServices } from '../services';
 import { findDeclarationNodeAtOffset } from '../utils/cst-util';
 import { MaybePromise } from '../utils/promise-util';
@@ -49,24 +49,18 @@ export class DefaultReferencesProvider implements ReferencesProvider {
             return [];
         }
 
-        const refs: Location[] = this.getReferences(selectedNode, params, document);
-
-        return refs;
+        return this.getReferences(selectedNode, params, document);
     }
 
-    protected getReferences(selectedNode: LeafCstNode, params: ReferenceParams, document: LangiumDocument<AstNode>): Location[] {
-        const refs: Location[] = [];
+    protected getReferences(selectedNode: LeafCstNode, params: ReferenceParams, _document: LangiumDocument): Location[] {
+        const locations: Location[] = [];
         const targetAstNode = this.references.findDeclaration(selectedNode);
         if (targetAstNode) {
             const options = { includeDeclaration: params.context.includeDeclaration };
             this.references.findReferences(targetAstNode, options).forEach(reference => {
-                if (isReference(reference) && reference.$refNode) {
-                    refs.push(Location.create(document.uri.toString(), reference.$refNode.range));
-                } else {
-                    refs.push(Location.create(reference.sourceUri.toString(), reference.segment.range));
-                }
+                locations.push(Location.create(reference.sourceUri.toString(), reference.segment.range));
             });
         }
-        return refs;
+        return locations;
     }
 }

--- a/packages/langium/src/parser/parser-builder-base.ts
+++ b/packages/langium/src/parser/parser-builder-base.ts
@@ -147,7 +147,7 @@ function buildPredicate(condition: Condition): Predicate {
         const name = condition.parameter.ref!.name;
         return (args) => args !== undefined && args[name] === true;
     } else if (isLiteralCondition(condition)) {
-        const value = !!condition.true;
+        const value = Boolean(condition.true);
         return () => value;
     }
     assertUnreachable(condition);

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -61,7 +61,7 @@ export class DefaultTokenBuilder implements TokenBuilder {
             .distinct(e => e.value).toArray()
             // Sort keywords by descending length
             .sort((a, b) => b.value.length - a.value.length)
-            .map(keyword => this.buildKeywordToken(keyword, terminalTokens, !!options?.caseInsensitive));
+            .map(keyword => this.buildKeywordToken(keyword, terminalTokens, Boolean(options?.caseInsensitive)));
     }
 
     protected buildKeywordToken(keyword: Keyword, terminalTokens: TokenType[], caseInsensitive: boolean): TokenType {

--- a/packages/langium/src/references/linker.ts
+++ b/packages/langium/src/references/linker.ts
@@ -59,7 +59,7 @@ export interface Linker {
      * @param refText The cross reference text denoting the target AstNode
      * @returns the desired Reference node, whose behavior wrt. resolving the cross reference is implementation specific.
      */
-    buildReference(node: AstNode, property: string, refNode: CstNode, refText: string): Reference;
+    buildReference(node: AstNode, property: string, refNode: CstNode | undefined, refText: string): Reference;
 }
 
 interface DefaultReference extends Reference {
@@ -129,7 +129,7 @@ export class DefaultLinker implements Linker {
         return description ?? this.createLinkingError(refInfo);
     }
 
-    buildReference(node: AstNode, property: string, refNode: CstNode, refText: string): Reference {
+    buildReference(node: AstNode, property: string, refNode: CstNode | undefined, refText: string): Reference {
         // See behavior description in doc of Linker, update that on changes in here.
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const linker = this;

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -58,7 +58,7 @@ export interface Reference<T extends AstNode = AstNode> {
     /** If any problem occurred while resolving the reference, it is described by this property. */
     readonly error?: LinkingError;
     /** The CST node from which the reference was parsed */
-    readonly $refNode: CstNode;
+    readonly $refNode?: CstNode;
     /** The actual text used to look up in the surrounding scope */
     readonly $refText: string;
     /** The node description for the AstNode returned by `ref`  */

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -211,7 +211,7 @@ export interface CompositeCstNode extends CstNode {
 }
 
 export function isCompositeCstNode(node: unknown): node is CompositeCstNode {
-    return typeof node === 'object' && !!node && 'children' in node;
+    return typeof node === 'object' && node !== null && 'children' in node;
 }
 
 /**
@@ -222,7 +222,7 @@ export interface LeafCstNode extends CstNode {
 }
 
 export function isLeafCstNode(node: unknown): node is LeafCstNode {
-    return typeof node === 'object' && !!node && 'tokenType' in node;
+    return typeof node === 'object' && node !== null && 'tokenType' in node;
 }
 
 export interface RootCstNode extends CompositeCstNode {

--- a/packages/langium/src/utils/regex-util.ts
+++ b/packages/langium/src/utils/regex-util.ts
@@ -56,7 +56,7 @@ class CommentRegexVisitor extends BaseRegExpVisitor {
         if (!this.multiline) {
             const set = this.regex.substring(node.loc.begin, node.loc.end);
             const regex = new RegExp(set);
-            this.multiline = !!'\n'.match(regex);
+            this.multiline = Boolean('\n'.match(regex));
         }
         if (node.quantifier) {
             this.isStarting = false;

--- a/packages/langium/src/utils/stream.ts
+++ b/packages/langium/src/utils/stream.ts
@@ -282,7 +282,7 @@ export class StreamImpl<S, T> implements Stream<T> {
 
     isEmpty(): boolean {
         const iterator = this.iterator();
-        return !!iterator.next().done;
+        return Boolean(iterator.next().done);
     }
 
     count(): number {

--- a/packages/langium/src/workspace/ast-descriptions.ts
+++ b/packages/langium/src/workspace/ast-descriptions.ts
@@ -115,20 +115,23 @@ export class DefaultReferenceDescriptionProvider implements ReferenceDescription
         for (const astNode of streamAst(rootNode)) {
             await interruptAndCheck(cancelToken);
             streamReferences(astNode).filter(refInfo => !isLinkingError(refInfo)).forEach(refInfo => {
-                const targetNodeDesc = refInfo.reference.$nodeDescription;
-                // Do not handle not yet linked references.
                 // TODO: Consider logging a warning or throw an exception when DocumentState is < than Linked
-                if (targetNodeDesc) {
-                    descr.push(this.createDescription(refInfo, targetNodeDesc));
+                const description = this.createDescription(refInfo);
+                if (description) {
+                    descr.push(description);
                 }
             });
         }
         return descr;
     }
 
-    protected createDescription(refInfo: ReferenceInfo, targetNodeDescr: AstNodeDescription): ReferenceDescription {
-        const docUri = getDocument(refInfo.container).uri;
+    protected createDescription(refInfo: ReferenceInfo): ReferenceDescription | undefined {
+        const targetNodeDescr = refInfo.reference.$nodeDescription;
         const refCstNode = refInfo.reference.$refNode;
+        if (!targetNodeDescr || !refCstNode) {
+            return undefined;
+        }
+        const docUri = getDocument(refInfo.container).uri;
         return {
             sourceUri: docUri,
             sourcePath: this.nodeLocator.getAstNodePath(refInfo.container),


### PR DESCRIPTION
See https://github.com/langium/langium/discussions/773. The `$refNode` property is made optional so programmatic construction of (partial) ASTs with references is easier.