### PR TITLE
Use document paths for json serializer references

### DIFF
--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -29,7 +29,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@10"
               },
               "arguments": []
             }
@@ -41,7 +41,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Statement"
+                "$ref": "/rules@1"
               },
               "arguments": []
             },
@@ -64,14 +64,14 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Definition"
+              "$ref": "/rules@2"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Evaluation"
+              "$ref": "/rules@4"
             },
             "arguments": []
           }
@@ -101,7 +101,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@10"
               },
               "arguments": []
             }
@@ -120,7 +120,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "DeclaredParameter"
+                    "$ref": "/rules@3"
                   },
                   "arguments": []
                 }
@@ -139,7 +139,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "DeclaredParameter"
+                        "$ref": "/rules@3"
                       },
                       "arguments": []
                     }
@@ -165,7 +165,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Expression"
+                "$ref": "/rules@5"
               },
               "arguments": []
             }
@@ -193,7 +193,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$ref": "/rules@10"
           },
           "arguments": []
         }
@@ -218,7 +218,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Expression"
+                "$ref": "/rules@5"
               },
               "arguments": []
             }
@@ -242,7 +242,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$refText": "Addition"
+          "$ref": "/rules@6"
         },
         "arguments": []
       },
@@ -266,7 +266,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Multiplication"
+              "$ref": "/rules@7"
             },
             "arguments": []
           },
@@ -307,7 +307,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Multiplication"
+                    "$ref": "/rules@7"
                   },
                   "arguments": []
                 }
@@ -337,7 +337,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PrimaryExpression"
+              "$ref": "/rules@8"
             },
             "arguments": []
           },
@@ -378,7 +378,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "PrimaryExpression"
+                    "$ref": "/rules@8"
                   },
                   "arguments": []
                 }
@@ -415,7 +415,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "Expression"
+                  "$ref": "/rules@5"
                 },
                 "arguments": []
               },
@@ -442,7 +442,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NUMBER"
+                    "$ref": "/rules@11"
                   },
                   "arguments": []
                 }
@@ -466,7 +466,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractDefinition"
+                    "$ref": "/types@0"
                   },
                   "deprecatedSyntax": false
                 }
@@ -485,7 +485,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Expression"
+                        "$ref": "/rules@5"
                       },
                       "arguments": []
                     }
@@ -504,7 +504,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "Expression"
+                            "$ref": "/rules@5"
                           },
                           "arguments": []
                         }
@@ -592,7 +592,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Definition"
+            "$ref": "/rules@2"
           },
           "isArray": false,
           "isRef": false
@@ -600,7 +600,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "DeclaredParameter"
+            "$ref": "/rules@3"
           },
           "isArray": false,
           "isRef": false

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -29,7 +29,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@10"
+                "$ref": "#/rules@10"
               },
               "arguments": []
             }
@@ -41,7 +41,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@1"
+                "$ref": "#/rules@1"
               },
               "arguments": []
             },
@@ -64,14 +64,14 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@2"
+              "$ref": "#/rules@2"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@4"
+              "$ref": "#/rules@4"
             },
             "arguments": []
           }
@@ -101,7 +101,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@10"
+                "$ref": "#/rules@10"
               },
               "arguments": []
             }
@@ -120,7 +120,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@3"
+                    "$ref": "#/rules@3"
                   },
                   "arguments": []
                 }
@@ -139,7 +139,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@3"
+                        "$ref": "#/rules@3"
                       },
                       "arguments": []
                     }
@@ -165,7 +165,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@5"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -193,7 +193,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "/rules@10"
+            "$ref": "#/rules@10"
           },
           "arguments": []
         }
@@ -218,7 +218,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@5"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -242,7 +242,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$ref": "/rules@6"
+          "$ref": "#/rules@6"
         },
         "arguments": []
       },
@@ -266,7 +266,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@7"
+              "$ref": "#/rules@7"
             },
             "arguments": []
           },
@@ -307,7 +307,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@7"
+                    "$ref": "#/rules@7"
                   },
                   "arguments": []
                 }
@@ -337,7 +337,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@8"
+              "$ref": "#/rules@8"
             },
             "arguments": []
           },
@@ -378,7 +378,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@8"
+                    "$ref": "#/rules@8"
                   },
                   "arguments": []
                 }
@@ -415,7 +415,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@5"
+                  "$ref": "#/rules@5"
                 },
                 "arguments": []
               },
@@ -442,7 +442,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@11"
+                    "$ref": "#/rules@11"
                   },
                   "arguments": []
                 }
@@ -466,7 +466,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/types@0"
+                    "$ref": "#/types@0"
                   },
                   "deprecatedSyntax": false
                 }
@@ -485,7 +485,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@5"
+                        "$ref": "#/rules@5"
                       },
                       "arguments": []
                     }
@@ -504,7 +504,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "/rules@5"
+                            "$ref": "#/rules@5"
                           },
                           "arguments": []
                         }
@@ -592,7 +592,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         {
           "$type": "AtomType",
           "refType": {
-            "$ref": "/rules@2"
+            "$ref": "#/rules@2"
           },
           "isArray": false,
           "isRef": false
@@ -600,7 +600,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
         {
           "$type": "AtomType",
           "refType": {
-            "$ref": "/rules@3"
+            "$ref": "#/rules@3"
           },
           "isArray": false,
           "isRef": false

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -22,7 +22,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "/rules@1"
+            "$ref": "#/rules@1"
           },
           "arguments": []
         },
@@ -43,14 +43,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@2"
+              "$ref": "#/rules@2"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@3"
+              "$ref": "#/rules@3"
             },
             "arguments": []
           }
@@ -80,7 +80,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@7"
+                "$ref": "#/rules@7"
               },
               "arguments": []
             }
@@ -96,7 +96,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@1"
+                "$ref": "#/rules@1"
               },
               "arguments": []
             },
@@ -124,14 +124,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@4"
+              "$ref": "#/rules@4"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@5"
+              "$ref": "#/rules@5"
             },
             "arguments": []
           }
@@ -161,7 +161,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@9"
+                "$ref": "#/rules@9"
               },
               "arguments": []
             }
@@ -192,7 +192,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@9"
+                "$ref": "#/rules@9"
               },
               "arguments": []
             }
@@ -211,12 +211,12 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/rules@5"
+                    "$ref": "#/rules@5"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "/rules@7"
+                      "$ref": "#/rules@7"
                     },
                     "arguments": []
                   },
@@ -237,7 +237,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@6"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             },
@@ -279,7 +279,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@9"
+                "$ref": "#/rules@9"
               },
               "arguments": []
             }
@@ -295,12 +295,12 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@3"
+                "$ref": "#/rules@3"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@7"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -326,7 +326,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@9"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
@@ -340,7 +340,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@9"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               }

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -22,7 +22,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "AbstractElement"
+            "$ref": "/rules@1"
           },
           "arguments": []
         },
@@ -43,14 +43,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PackageDeclaration"
+              "$ref": "/rules@2"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Type"
+              "$ref": "/rules@3"
             },
             "arguments": []
           }
@@ -80,7 +80,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "QualifiedName"
+                "$ref": "/rules@7"
               },
               "arguments": []
             }
@@ -96,7 +96,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AbstractElement"
+                "$ref": "/rules@1"
               },
               "arguments": []
             },
@@ -124,14 +124,14 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "DataType"
+              "$ref": "/rules@4"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Entity"
+              "$ref": "/rules@5"
             },
             "arguments": []
           }
@@ -161,7 +161,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@9"
               },
               "arguments": []
             }
@@ -192,7 +192,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@9"
               },
               "arguments": []
             }
@@ -211,12 +211,12 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Entity"
+                    "$ref": "/rules@5"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "QualifiedName"
+                      "$ref": "/rules@7"
                     },
                     "arguments": []
                   },
@@ -237,7 +237,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Feature"
+                "$ref": "/rules@6"
               },
               "arguments": []
             },
@@ -279,7 +279,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@9"
               },
               "arguments": []
             }
@@ -295,12 +295,12 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "Type"
+                "$ref": "/rules@3"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "QualifiedName"
+                  "$ref": "/rules@7"
                 },
                 "arguments": []
               },
@@ -326,7 +326,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$ref": "/rules@9"
             },
             "arguments": []
           },
@@ -340,7 +340,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$ref": "/rules@9"
                 },
                 "arguments": []
               }

--- a/examples/domainmodel/test/nodelocator.test.ts
+++ b/examples/domainmodel/test/nodelocator.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstNode, getDocument, LangiumDocument, EmptyFileSystem } from 'langium';
+import { AstNode, EmptyFileSystem } from 'langium';
 import { parseDocument } from 'langium/test';
 import { createDomainModelServices } from '../src/language-server/domain-model-module';
 import { Domainmodel, PackageDeclaration } from '../src/language-server/generated/ast';
@@ -29,8 +29,8 @@ describe('AstNode location', () => {
     });
     test('Locate node for path', async () => {
         const model = await getModel();
-        expect(findNode(getDocument(model), '/elements@0')).toEqual(model.elements[0]);
-        expect(findNode(getDocument(model), '/elements@2/elements@0')).toEqual((model.elements[2] as PackageDeclaration).elements[0]);
+        expect(findNode(model, '/elements@0')).toEqual(model.elements[0]);
+        expect(findNode(model, '/elements@2/elements@0')).toEqual((model.elements[2] as PackageDeclaration).elements[0]);
     });
 });
 
@@ -44,6 +44,6 @@ function createPath(node: AstNode): string {
     return services.workspace.AstNodeLocator.getAstNodePath(node);
 }
 
-function findNode(document: LangiumDocument, path: string): AstNode | undefined {
-    return services.workspace.AstNodeLocator.getAstNode(document, path);
+function findNode(node: AstNode, path: string): AstNode | undefined {
+    return services.workspace.AstNodeLocator.getAstNode(node, path);
 }

--- a/examples/requirements/src/language-server/generated/grammar.ts
+++ b/examples/requirements/src/language-server/generated/grammar.ts
@@ -26,7 +26,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@3"
+                "$ref": "#/rules@3"
               },
               "arguments": []
             },
@@ -39,7 +39,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@1"
+                "$ref": "#/rules@1"
               },
               "arguments": []
             },
@@ -52,7 +52,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@2"
+                "$ref": "#/rules@2"
               },
               "arguments": []
             },
@@ -83,7 +83,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@5"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -99,7 +99,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@7"
+                "$ref": "#/rules@7"
               },
               "arguments": []
             }
@@ -130,7 +130,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@5"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -142,7 +142,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@7"
+                "$ref": "#/rules@7"
               },
               "arguments": []
             }
@@ -165,7 +165,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/rules@1"
+                    "$ref": "#/rules@1"
                   },
                   "deprecatedSyntax": false
                 }
@@ -184,7 +184,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "/rules@1"
+                        "$ref": "#/rules@1"
                       },
                       "deprecatedSyntax": false
                     }
@@ -225,7 +225,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@7"
+                "$ref": "#/rules@7"
               },
               "arguments": []
             }
@@ -332,7 +332,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@2"
+                "$ref": "#/rules@2"
               },
               "arguments": []
             },
@@ -345,7 +345,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@1"
+                "$ref": "#/rules@1"
               },
               "arguments": []
             },
@@ -376,7 +376,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@4"
+                "$ref": "#/rules@4"
               },
               "arguments": []
             }
@@ -399,7 +399,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@6"
+                    "$ref": "#/rules@6"
                   },
                   "arguments": []
                 }
@@ -418,12 +418,12 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@11"
+                "$ref": "#/rules@11"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@4"
+                  "$ref": "#/rules@4"
                 },
                 "arguments": []
               },
@@ -444,12 +444,12 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/rules@11"
+                    "$ref": "#/rules@11"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "/rules@4"
+                      "$ref": "#/rules@4"
                     },
                     "arguments": []
                   },
@@ -477,7 +477,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/rules@10"
+                    "$ref": "#/rules@10"
                   },
                   "deprecatedSyntax": false
                 }
@@ -496,7 +496,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "/rules@10"
+                        "$ref": "#/rules@10"
                       },
                       "deprecatedSyntax": false
                     }
@@ -537,7 +537,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@6"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -629,7 +629,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@2"
+                "$ref": "#/rules@2"
               },
               "arguments": []
             },
@@ -642,7 +642,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@10"
+                "$ref": "#/rules@10"
               },
               "arguments": []
             },
@@ -655,7 +655,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@11"
+                "$ref": "#/rules@11"
               },
               "arguments": []
             },
@@ -686,7 +686,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@4"
+                "$ref": "#/rules@4"
               },
               "arguments": []
             }
@@ -702,7 +702,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@6"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -733,7 +733,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@4"
+                "$ref": "#/rules@4"
               },
               "arguments": []
             }
@@ -745,7 +745,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@6"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -768,7 +768,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/rules@10"
+                    "$ref": "#/rules@10"
                   },
                   "deprecatedSyntax": false
                 }
@@ -787,7 +787,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "/rules@10"
+                        "$ref": "#/rules@10"
                       },
                       "deprecatedSyntax": false
                     }

--- a/examples/requirements/src/language-server/generated/grammar.ts
+++ b/examples/requirements/src/language-server/generated/grammar.ts
@@ -26,7 +26,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Contact"
+                "$ref": "/rules@3"
               },
               "arguments": []
             },
@@ -39,7 +39,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Environment"
+                "$ref": "/rules@1"
               },
               "arguments": []
             },
@@ -52,7 +52,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Requirement"
+                "$ref": "/rules@2"
               },
               "arguments": []
             },
@@ -83,7 +83,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@5"
               },
               "arguments": []
             }
@@ -99,7 +99,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@7"
               },
               "arguments": []
             }
@@ -130,7 +130,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@5"
               },
               "arguments": []
             }
@@ -142,7 +142,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@7"
               },
               "arguments": []
             }
@@ -165,7 +165,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Environment"
+                    "$ref": "/rules@1"
                   },
                   "deprecatedSyntax": false
                 }
@@ -184,7 +184,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "Environment"
+                        "$ref": "/rules@1"
                       },
                       "deprecatedSyntax": false
                     }
@@ -225,7 +225,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@7"
               },
               "arguments": []
             }
@@ -332,7 +332,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Contact"
+                "$ref": "/rules@2"
               },
               "arguments": []
             },
@@ -345,7 +345,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Test"
+                "$ref": "/rules@1"
               },
               "arguments": []
             },
@@ -376,7 +376,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@4"
               },
               "arguments": []
             }
@@ -399,7 +399,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "STRING"
+                    "$ref": "/rules@6"
                   },
                   "arguments": []
                 }
@@ -418,12 +418,12 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "Requirement"
+                "$ref": "/rules@11"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$ref": "/rules@4"
                 },
                 "arguments": []
               },
@@ -444,12 +444,12 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Requirement"
+                    "$ref": "/rules@11"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "ID"
+                      "$ref": "/rules@4"
                     },
                     "arguments": []
                   },
@@ -477,7 +477,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Environment"
+                    "$ref": "/rules@10"
                   },
                   "deprecatedSyntax": false
                 }
@@ -496,7 +496,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "Environment"
+                        "$ref": "/rules@10"
                       },
                       "deprecatedSyntax": false
                     }
@@ -537,7 +537,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@6"
               },
               "arguments": []
             }
@@ -629,7 +629,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Contact"
+                "$ref": "/rules@2"
               },
               "arguments": []
             },
@@ -642,7 +642,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Environment"
+                "$ref": "/rules@10"
               },
               "arguments": []
             },
@@ -655,7 +655,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Requirement"
+                "$ref": "/rules@11"
               },
               "arguments": []
             },
@@ -686,7 +686,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@4"
               },
               "arguments": []
             }
@@ -702,7 +702,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@6"
               },
               "arguments": []
             }
@@ -733,7 +733,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@4"
               },
               "arguments": []
             }
@@ -745,7 +745,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@6"
               },
               "arguments": []
             }
@@ -768,7 +768,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Environment"
+                    "$ref": "/rules@10"
                   },
                   "deprecatedSyntax": false
                 }
@@ -787,7 +787,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "Environment"
+                        "$ref": "/rules@10"
                       },
                       "deprecatedSyntax": false
                     }

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -29,7 +29,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@6"
               },
               "arguments": []
             }
@@ -48,7 +48,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Event"
+                    "$ref": "/rules@1"
                   },
                   "arguments": []
                 },
@@ -71,7 +71,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Command"
+                    "$ref": "/rules@2"
                   },
                   "arguments": []
                 },
@@ -91,7 +91,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "State"
+                "$ref": "/rules@3"
               },
               "deprecatedSyntax": false
             }
@@ -103,7 +103,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "State"
+                "$ref": "/rules@3"
               },
               "arguments": []
             },
@@ -127,7 +127,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$ref": "/rules@6"
           },
           "arguments": []
         }
@@ -149,7 +149,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$ref": "/rules@6"
           },
           "arguments": []
         }
@@ -178,7 +178,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@6"
               },
               "arguments": []
             }
@@ -201,7 +201,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Command"
+                    "$ref": "/rules@2"
                   },
                   "deprecatedSyntax": false
                 },
@@ -221,7 +221,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Transition"
+                "$ref": "/rules@4"
               },
               "arguments": []
             },
@@ -253,7 +253,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "Event"
+                "$ref": "/rules@1"
               },
               "deprecatedSyntax": false
             }
@@ -269,7 +269,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "State"
+                "$ref": "/rules@3"
               },
               "deprecatedSyntax": false
             }

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -29,7 +29,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@6"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -48,7 +48,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@1"
+                    "$ref": "#/rules@1"
                   },
                   "arguments": []
                 },
@@ -71,7 +71,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@2"
+                    "$ref": "#/rules@2"
                   },
                   "arguments": []
                 },
@@ -91,7 +91,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@3"
+                "$ref": "#/rules@3"
               },
               "deprecatedSyntax": false
             }
@@ -103,7 +103,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@3"
+                "$ref": "#/rules@3"
               },
               "arguments": []
             },
@@ -127,7 +127,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "/rules@6"
+            "$ref": "#/rules@6"
           },
           "arguments": []
         }
@@ -149,7 +149,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "/rules@6"
+            "$ref": "#/rules@6"
           },
           "arguments": []
         }
@@ -178,7 +178,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@6"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -201,7 +201,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/rules@2"
+                    "$ref": "#/rules@2"
                   },
                   "deprecatedSyntax": false
                 },
@@ -221,7 +221,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@4"
+                "$ref": "#/rules@4"
               },
               "arguments": []
             },
@@ -253,7 +253,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@1"
+                "$ref": "#/rules@1"
               },
               "deprecatedSyntax": false
             }
@@ -269,7 +269,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@3"
+                "$ref": "#/rules@3"
               },
               "deprecatedSyntax": false
             }

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -104,10 +104,12 @@ function mapGrammarElements(grammars: Grammar[], visited: Set<string> = new Set(
 
 function embedReferencedGrammar(grammar: Grammar, map: Map<Grammar, GrammarElement[]>): void {
     const allGrammars = resolveTransitiveImports(documents, grammar);
+    const linker = grammarServices.references.Linker;
+    const buildReference = linker.buildReference.bind(linker);
     for (const importedGrammar of allGrammars) {
         const grammarElements = map.get(importedGrammar) ?? [];
         for (const element of grammarElements) {
-            const copy = copyAstNode(element, grammarServices.references.Linker);
+            const copy = copyAstNode(element, buildReference);
             // Deactivate copied entry rule
             if (GrammarAST.isParserRule(copy)) {
                 copy.entry = false;

--- a/packages/langium-cli/src/generator/grammar-serializer.ts
+++ b/packages/langium-cli/src/generator/grammar-serializer.ts
@@ -27,7 +27,7 @@ export function serializeGrammar(services: LangiumServices, grammars: Grammar[],
         if (grammar.name) {
             // The json serializer returns strings with \n line delimiter by default
             // We need to translate these line endings to the OS specific line ending
-            const json = services.serializer.JsonSerializer.serialize(grammar, 2).replace(/\\/g, '\\\\').replace(/`/g, '\\`').split('\n').join(EOL);
+            const json = services.serializer.JsonSerializer.serialize(grammar, { space: 2 }).replace(/\\/g, '\\\\').replace(/`/g, '\\`').split('\n').join(EOL);
             node.append(
                 'let loaded', grammar.name, 'Grammar: Grammar | undefined;', NL,
                 'export const ', grammar.name, 'Grammar = (): Grammar => loaded', grammar.name, 'Grammar ?? (loaded', grammar.name, 'Grammar = loadGrammarFromJson(`', json, '`));', NL

--- a/packages/langium-cli/src/parser-validation.ts
+++ b/packages/langium-cli/src/parser-validation.ts
@@ -10,14 +10,14 @@ import {
 } from 'langium';
 import { getFilePath, LangiumConfig, LangiumLanguageConfig } from './package';
 
-export function validateParser(grammar: Grammar, config: LangiumConfig, grammarConfigMap: Map<Grammar, LangiumLanguageConfig>,
-    grammarServices: LangiumGrammarServices): Error | undefined {
+export async function validateParser(grammar: Grammar, config: LangiumConfig, grammarConfigMap: Map<Grammar, LangiumLanguageConfig>,
+    grammarServices: LangiumGrammarServices): Promise<Error | undefined> {
     const parserConfig: IParserConfig = {
         ...config.chevrotainParserConfig,
         ...grammarConfigMap.get(grammar)?.chevrotainParserConfig,
         skipValidations: false
     };
-    const services = createServicesForGrammar({
+    const services = await createServicesForGrammar({
         grammarServices,
         grammar,
         languageMetaData: languageConfigToMetaData(grammarConfigMap.get(grammar)!),

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@57"
+                    "$ref": "#/rules@57"
                   },
                   "arguments": []
                 }
@@ -57,12 +57,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "/rules@0"
+                        "$ref": "#/rules@0"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "/rules@57"
+                          "$ref": "#/rules@57"
                         },
                         "arguments": []
                       },
@@ -83,12 +83,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "/rules@0"
+                            "$ref": "#/rules@0"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "/rules@57"
+                              "$ref": "#/rules@57"
                             },
                             "arguments": []
                           },
@@ -127,12 +127,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "/rules@8"
+                            "$ref": "#/rules@8"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "/rules@57"
+                              "$ref": "#/rules@57"
                             },
                             "arguments": []
                           },
@@ -153,12 +153,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                             "terminal": {
                               "$type": "CrossReference",
                               "type": {
-                                "$ref": "/rules@8"
+                                "$ref": "#/rules@8"
                               },
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$ref": "/rules@57"
+                                  "$ref": "#/rules@57"
                                 },
                                 "arguments": []
                               },
@@ -188,7 +188,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@9"
+                "$ref": "#/rules@9"
               },
               "arguments": []
             },
@@ -204,7 +204,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@8"
+                    "$ref": "#/rules@8"
                   },
                   "arguments": []
                 }
@@ -216,7 +216,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@1"
+                    "$ref": "#/rules@1"
                   },
                   "arguments": []
                 }
@@ -228,7 +228,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@7"
+                    "$ref": "#/rules@7"
                   },
                   "arguments": []
                 }
@@ -261,7 +261,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@57"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -280,7 +280,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/types@0"
+                    "$ref": "#/types@0"
                   },
                   "deprecatedSyntax": false
                 }
@@ -299,7 +299,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "/types@0"
+                        "$ref": "#/types@0"
                       },
                       "deprecatedSyntax": false
                     }
@@ -313,7 +313,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@2"
+              "$ref": "#/rules@2"
             },
             "arguments": []
           }
@@ -344,7 +344,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@3"
+                "$ref": "#/rules@3"
               },
               "arguments": []
             },
@@ -380,7 +380,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@57"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -402,7 +402,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@4"
+              "$ref": "#/rules@4"
             },
             "arguments": []
           },
@@ -434,7 +434,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@5"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -453,7 +453,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@5"
+                    "$ref": "#/rules@5"
                   },
                   "arguments": []
                 }
@@ -488,7 +488,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@6"
+                        "$ref": "#/rules@6"
                       },
                       "arguments": []
                     }
@@ -513,7 +513,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "/types@0"
+                            "$ref": "#/types@0"
                           },
                           "deprecatedSyntax": false
                         }
@@ -541,7 +541,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@22"
+                "$ref": "#/rules@22"
               },
               "arguments": []
             }
@@ -608,7 +608,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@57"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -620,7 +620,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@4"
+              "$ref": "#/rules@4"
             },
             "arguments": []
           },
@@ -647,14 +647,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@10"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@43"
+              "$ref": "#/rules@43"
             },
             "arguments": []
           }
@@ -684,7 +684,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@58"
+                "$ref": "#/rules@58"
               },
               "arguments": []
             }
@@ -736,7 +736,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@12"
+              "$ref": "#/rules@12"
             },
             "arguments": []
           },
@@ -769,12 +769,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "/types@0"
+                            "$ref": "#/types@0"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "/rules@57"
+                              "$ref": "#/rules@57"
                             },
                             "arguments": []
                           },
@@ -788,7 +788,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "/rules@6"
+                            "$ref": "#/rules@6"
                           },
                           "arguments": []
                         }
@@ -804,7 +804,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@11"
+                    "$ref": "#/rules@11"
                   },
                   "arguments": [
                     {
@@ -847,12 +847,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "/rules@8"
+                        "$ref": "#/rules@8"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "/rules@57"
+                          "$ref": "#/rules@57"
                         },
                         "arguments": []
                       },
@@ -873,12 +873,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "/rules@8"
+                            "$ref": "#/rules@8"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "/rules@57"
+                              "$ref": "#/rules@57"
                             },
                             "arguments": []
                           },
@@ -909,7 +909,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@14"
+                "$ref": "#/rules@14"
               },
               "arguments": []
             }
@@ -947,7 +947,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "guardCondition": {
                   "$type": "ParameterReference",
                   "parameter": {
-                    "$ref": "/rules@11/parameters@0"
+                    "$ref": "#/rules@11/parameters@0"
                   }
                 },
                 "elements": [
@@ -964,7 +964,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "value": {
                     "$type": "ParameterReference",
                     "parameter": {
-                      "$ref": "/rules@11/parameters@0"
+                      "$ref": "#/rules@11/parameters@0"
                     }
                   }
                 },
@@ -984,7 +984,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@57"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -1011,7 +1011,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@57"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -1033,7 +1033,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@13"
+                        "$ref": "#/rules@13"
                       },
                       "arguments": []
                     }
@@ -1052,7 +1052,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "/rules@13"
+                            "$ref": "#/rules@13"
                           },
                           "arguments": []
                         }
@@ -1088,7 +1088,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "/rules@57"
+            "$ref": "#/rules@57"
           },
           "arguments": []
         }
@@ -1113,7 +1113,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@15"
+              "$ref": "#/rules@15"
             },
             "arguments": []
           },
@@ -1143,7 +1143,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@15"
+                        "$ref": "#/rules@15"
                       },
                       "arguments": []
                     }
@@ -1176,7 +1176,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@16"
+              "$ref": "#/rules@16"
             },
             "arguments": []
           },
@@ -1201,7 +1201,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@26"
+                    "$ref": "#/rules@26"
                   },
                   "arguments": []
                 }
@@ -1217,7 +1217,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@18"
+                    "$ref": "#/rules@18"
                   },
                   "arguments": []
                 },
@@ -1247,7 +1247,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@17"
+              "$ref": "#/rules@17"
             },
             "arguments": []
           },
@@ -1277,7 +1277,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@17"
+                        "$ref": "#/rules@17"
                       },
                       "arguments": []
                     }
@@ -1310,7 +1310,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@18"
+              "$ref": "#/rules@18"
             },
             "arguments": []
           },
@@ -1333,7 +1333,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@18"
+                    "$ref": "#/rules@18"
                   },
                   "arguments": []
                 },
@@ -1364,14 +1364,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@19"
+              "$ref": "#/rules@19"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@20"
+              "$ref": "#/rules@20"
             },
             "arguments": []
           }
@@ -1400,14 +1400,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@34"
+                  "$ref": "#/rules@34"
                 },
                 "arguments": []
               },
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@21"
+                  "$ref": "#/rules@21"
                 },
                 "arguments": []
               }
@@ -1476,12 +1476,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/types@0"
+                    "$ref": "#/types@0"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "/rules@57"
+                      "$ref": "#/rules@57"
                     },
                     "arguments": []
                   },
@@ -1495,7 +1495,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@11"
+                    "$ref": "#/rules@11"
                   },
                   "arguments": [
                     {
@@ -1525,7 +1525,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@56"
+                    "$ref": "#/rules@56"
                   },
                   "arguments": []
                 }
@@ -1581,42 +1581,42 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@22"
+              "$ref": "#/rules@22"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@23"
+              "$ref": "#/rules@23"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@40"
+              "$ref": "#/rules@40"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@32"
+              "$ref": "#/rules@32"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@33"
+              "$ref": "#/rules@33"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@41"
+              "$ref": "#/rules@41"
             },
             "arguments": []
           }
@@ -1639,7 +1639,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "/rules@58"
+            "$ref": "#/rules@58"
           },
           "arguments": []
         }
@@ -1664,12 +1664,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@8"
+                "$ref": "#/rules@8"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@57"
+                  "$ref": "#/rules@57"
                 },
                 "arguments": []
               },
@@ -1690,7 +1690,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@24"
+                    "$ref": "#/rules@24"
                   },
                   "arguments": []
                 }
@@ -1709,7 +1709,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@24"
+                        "$ref": "#/rules@24"
                       },
                       "arguments": []
                     }
@@ -1749,12 +1749,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "/rules@13"
+                    "$ref": "#/rules@13"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "/rules@57"
+                      "$ref": "#/rules@57"
                     },
                     "arguments": []
                   },
@@ -1780,7 +1780,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@26"
+                "$ref": "#/rules@26"
               },
               "arguments": []
             }
@@ -1835,7 +1835,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@27"
+              "$ref": "#/rules@27"
             },
             "arguments": []
           },
@@ -1862,7 +1862,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@27"
+                    "$ref": "#/rules@27"
                   },
                   "arguments": []
                 }
@@ -1892,7 +1892,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@28"
+              "$ref": "#/rules@28"
             },
             "arguments": []
           },
@@ -1919,7 +1919,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@28"
+                    "$ref": "#/rules@28"
                   },
                   "arguments": []
                 }
@@ -1949,7 +1949,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@29"
+              "$ref": "#/rules@29"
             },
             "arguments": []
           },
@@ -1974,7 +1974,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@28"
+                    "$ref": "#/rules@28"
                   },
                   "arguments": []
                 }
@@ -2003,21 +2003,21 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@31"
+              "$ref": "#/rules@31"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@30"
+              "$ref": "#/rules@30"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@25"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           }
@@ -2047,7 +2047,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@26"
+              "$ref": "#/rules@26"
             },
             "arguments": []
           },
@@ -2074,12 +2074,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "/rules@13"
+            "$ref": "#/rules@13"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@57"
+              "$ref": "#/rules@57"
             },
             "arguments": []
           },
@@ -2123,7 +2123,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@58"
+                "$ref": "#/rules@58"
               },
               "arguments": []
             }
@@ -2167,12 +2167,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@8"
+                "$ref": "#/rules@8"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@57"
+                  "$ref": "#/rules@57"
                 },
                 "arguments": []
               },
@@ -2193,7 +2193,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@24"
+                    "$ref": "#/rules@24"
                   },
                   "arguments": []
                 }
@@ -2212,7 +2212,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@24"
+                        "$ref": "#/rules@24"
                       },
                       "arguments": []
                     }
@@ -2274,7 +2274,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@56"
+                "$ref": "#/rules@56"
               },
               "arguments": []
             }
@@ -2308,7 +2308,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@35"
+                "$ref": "#/rules@35"
               },
               "arguments": []
             }
@@ -2335,28 +2335,28 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@22"
+              "$ref": "#/rules@22"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@23"
+              "$ref": "#/rules@23"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@36"
+              "$ref": "#/rules@36"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@38"
+              "$ref": "#/rules@38"
             },
             "arguments": []
           }
@@ -2386,7 +2386,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@37"
+              "$ref": "#/rules@37"
             },
             "arguments": []
           },
@@ -2416,7 +2416,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@35"
+              "$ref": "#/rules@35"
             },
             "arguments": []
           },
@@ -2446,7 +2446,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@35"
+                        "$ref": "#/rules@35"
                       },
                       "arguments": []
                     }
@@ -2494,7 +2494,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/types@0"
+                "$ref": "#/types@0"
               },
               "deprecatedSyntax": false
             }
@@ -2527,7 +2527,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@39"
+                    "$ref": "#/rules@39"
                   },
                   "arguments": []
                 }
@@ -2561,14 +2561,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@22"
+              "$ref": "#/rules@22"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@23"
+              "$ref": "#/rules@23"
             },
             "arguments": []
           }
@@ -2598,7 +2598,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@14"
+              "$ref": "#/rules@14"
             },
             "arguments": []
           },
@@ -2649,7 +2649,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@14"
+                "$ref": "#/rules@14"
               },
               "arguments": []
             }
@@ -2680,14 +2680,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@6"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             },
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@57"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -2743,7 +2743,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@57"
+                        "$ref": "#/rules@57"
                       },
                       "arguments": []
                     }
@@ -2760,7 +2760,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "/rules@57"
+                        "$ref": "#/rules@57"
                       },
                       "arguments": []
                     }
@@ -2779,7 +2779,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "/rules@42"
+                            "$ref": "#/rules@42"
                           },
                           "arguments": []
                         }
@@ -2802,7 +2802,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@45"
+                "$ref": "#/rules@45"
               },
               "arguments": []
             }
@@ -2847,7 +2847,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@46"
+              "$ref": "#/rules@46"
             },
             "arguments": []
           },
@@ -2874,7 +2874,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@46"
+                    "$ref": "#/rules@46"
                   },
                   "arguments": []
                 }
@@ -2904,7 +2904,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@47"
+              "$ref": "#/rules@47"
             },
             "arguments": []
           },
@@ -2927,7 +2927,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@47"
+                    "$ref": "#/rules@47"
                   },
                   "arguments": []
                 },
@@ -2958,7 +2958,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@48"
+              "$ref": "#/rules@48"
             },
             "arguments": []
           },
@@ -3007,49 +3007,49 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@55"
+              "$ref": "#/rules@55"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@50"
+              "$ref": "#/rules@50"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@49"
+              "$ref": "#/rules@49"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@51"
+              "$ref": "#/rules@51"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@52"
+              "$ref": "#/rules@52"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@53"
+              "$ref": "#/rules@53"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@54"
+              "$ref": "#/rules@54"
             },
             "arguments": []
           }
@@ -3079,7 +3079,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@45"
+              "$ref": "#/rules@45"
             },
             "arguments": []
           },
@@ -3120,12 +3120,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "/rules@43"
+                "$ref": "#/rules@43"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "/rules@57"
+                  "$ref": "#/rules@57"
                 },
                 "arguments": []
               },
@@ -3169,7 +3169,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@48"
+                "$ref": "#/rules@48"
               },
               "arguments": []
             }
@@ -3211,7 +3211,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@48"
+                "$ref": "#/rules@48"
               },
               "arguments": []
             }
@@ -3249,7 +3249,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@44"
+                "$ref": "#/rules@44"
               },
               "arguments": []
             }
@@ -3317,7 +3317,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "/rules@22"
+                "$ref": "#/rules@22"
               },
               "arguments": []
             }
@@ -3336,7 +3336,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "/rules@22"
+                    "$ref": "#/rules@22"
                   },
                   "arguments": []
                 }
@@ -3427,14 +3427,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@6"
+              "$ref": "#/rules@6"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "/rules@57"
+              "$ref": "#/rules@57"
             },
             "arguments": []
           }
@@ -3505,7 +3505,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$ref": "/rules@1"
+            "$ref": "#/rules@1"
           },
           "isArray": false,
           "isRef": false
@@ -3513,7 +3513,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$ref": "/rules@7"
+            "$ref": "#/rules@7"
           },
           "isArray": false,
           "isRef": false
@@ -3521,7 +3521,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$ref": "/rules@20/definition/elements@0"
+            "$ref": "#/rules@20/definition/elements@0"
           },
           "isArray": false,
           "isRef": false
@@ -3529,7 +3529,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$ref": "/rules@10"
+            "$ref": "#/rules@10"
           },
           "isArray": false,
           "isRef": false

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -380,7 +380,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@56"
               },
               "arguments": []
             }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "ID"
+                    "$ref": "/rules@57"
                   },
                   "arguments": []
                 }
@@ -57,12 +57,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "Grammar"
+                        "$ref": "/rules@0"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$refText": "ID"
+                          "$ref": "/rules@57"
                         },
                         "arguments": []
                       },
@@ -83,12 +83,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "Grammar"
+                            "$ref": "/rules@0"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$ref": "/rules@57"
                             },
                             "arguments": []
                           },
@@ -127,12 +127,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractRule"
+                            "$ref": "/rules@8"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$ref": "/rules@57"
                             },
                             "arguments": []
                           },
@@ -153,12 +153,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                             "terminal": {
                               "$type": "CrossReference",
                               "type": {
-                                "$refText": "AbstractRule"
+                                "$ref": "/rules@8"
                               },
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$refText": "ID"
+                                  "$ref": "/rules@57"
                                 },
                                 "arguments": []
                               },
@@ -188,7 +188,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "GrammarImport"
+                "$ref": "/rules@9"
               },
               "arguments": []
             },
@@ -204,7 +204,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractRule"
+                    "$ref": "/rules@8"
                   },
                   "arguments": []
                 }
@@ -216,7 +216,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Interface"
+                    "$ref": "/rules@1"
                   },
                   "arguments": []
                 }
@@ -228,7 +228,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Type"
+                    "$ref": "/rules@7"
                   },
                   "arguments": []
                 }
@@ -261,7 +261,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@57"
               },
               "arguments": []
             }
@@ -280,7 +280,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractType"
+                    "$ref": "/types@0"
                   },
                   "deprecatedSyntax": false
                 }
@@ -299,7 +299,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "AbstractType"
+                        "$ref": "/types@0"
                       },
                       "deprecatedSyntax": false
                     }
@@ -313,7 +313,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "SchemaType"
+              "$ref": "/rules@2"
             },
             "arguments": []
           }
@@ -344,7 +344,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TypeAttribute"
+                "$ref": "/rules@3"
               },
               "arguments": []
             },
@@ -380,7 +380,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "FeatureName"
+                "$ref": "/rules@57"
               },
               "arguments": []
             }
@@ -402,7 +402,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TypeAlternatives"
+              "$ref": "/rules@4"
             },
             "arguments": []
           },
@@ -434,7 +434,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AtomType"
+                "$ref": "/rules@5"
               },
               "arguments": []
             }
@@ -453,7 +453,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AtomType"
+                    "$ref": "/rules@5"
                   },
                   "arguments": []
                 }
@@ -488,7 +488,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "PrimitiveType"
+                        "$ref": "/rules@6"
                       },
                       "arguments": []
                     }
@@ -513,7 +513,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractType"
+                            "$ref": "/types@0"
                           },
                           "deprecatedSyntax": false
                         }
@@ -541,7 +541,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Keyword"
+                "$ref": "/rules@22"
               },
               "arguments": []
             }
@@ -608,7 +608,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@57"
               },
               "arguments": []
             }
@@ -620,7 +620,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TypeAlternatives"
+              "$ref": "/rules@4"
             },
             "arguments": []
           },
@@ -647,14 +647,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParserRule"
+              "$ref": "/rules@10"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalRule"
+              "$ref": "/rules@43"
             },
             "arguments": []
           }
@@ -684,7 +684,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@58"
               },
               "arguments": []
             }
@@ -736,7 +736,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleNameAndParams"
+              "$ref": "/rules@12"
             },
             "arguments": []
           },
@@ -769,12 +769,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractType"
+                            "$ref": "/types@0"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$ref": "/rules@57"
                             },
                             "arguments": []
                           },
@@ -788,7 +788,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "PrimitiveType"
+                            "$ref": "/rules@6"
                           },
                           "arguments": []
                         }
@@ -804,7 +804,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "InferredType"
+                    "$ref": "/rules@11"
                   },
                   "arguments": [
                     {
@@ -847,12 +847,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$refText": "AbstractRule"
+                        "$ref": "/rules@8"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$refText": "ID"
+                          "$ref": "/rules@57"
                         },
                         "arguments": []
                       },
@@ -873,12 +873,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$refText": "AbstractRule"
+                            "$ref": "/rules@8"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$refText": "ID"
+                              "$ref": "/rules@57"
                             },
                             "arguments": []
                           },
@@ -909,7 +909,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Alternatives"
+                "$ref": "/rules@14"
               },
               "arguments": []
             }
@@ -947,7 +947,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "guardCondition": {
                   "$type": "ParameterReference",
                   "parameter": {
-                    "$refText": "imperative"
+                    "$ref": "/rules@11/parameters@0"
                   }
                 },
                 "elements": [
@@ -964,7 +964,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "value": {
                     "$type": "ParameterReference",
                     "parameter": {
-                      "$refText": "imperative"
+                      "$ref": "/rules@11/parameters@0"
                     }
                   }
                 },
@@ -984,7 +984,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@57"
               },
               "arguments": []
             }
@@ -1011,7 +1011,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@57"
               },
               "arguments": []
             }
@@ -1033,7 +1033,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Parameter"
+                        "$ref": "/rules@13"
                       },
                       "arguments": []
                     }
@@ -1052,7 +1052,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "Parameter"
+                            "$ref": "/rules@13"
                           },
                           "arguments": []
                         }
@@ -1088,7 +1088,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "ID"
+            "$ref": "/rules@57"
           },
           "arguments": []
         }
@@ -1113,7 +1113,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ConditionalBranch"
+              "$ref": "/rules@15"
             },
             "arguments": []
           },
@@ -1143,7 +1143,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ConditionalBranch"
+                        "$ref": "/rules@15"
                       },
                       "arguments": []
                     }
@@ -1176,7 +1176,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "UnorderedGroup"
+              "$ref": "/rules@16"
             },
             "arguments": []
           },
@@ -1201,7 +1201,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Disjunction"
+                    "$ref": "/rules@26"
                   },
                   "arguments": []
                 }
@@ -1217,7 +1217,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractToken"
+                    "$ref": "/rules@18"
                   },
                   "arguments": []
                 },
@@ -1247,7 +1247,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Group"
+              "$ref": "/rules@17"
             },
             "arguments": []
           },
@@ -1277,7 +1277,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "Group"
+                        "$ref": "/rules@17"
                       },
                       "arguments": []
                     }
@@ -1310,7 +1310,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AbstractToken"
+              "$ref": "/rules@18"
             },
             "arguments": []
           },
@@ -1333,7 +1333,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "AbstractToken"
+                    "$ref": "/rules@18"
                   },
                   "arguments": []
                 },
@@ -1364,14 +1364,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AbstractTokenWithCardinality"
+              "$ref": "/rules@19"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Action"
+              "$ref": "/rules@20"
             },
             "arguments": []
           }
@@ -1400,14 +1400,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "Assignment"
+                  "$ref": "/rules@34"
                 },
                 "arguments": []
               },
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "AbstractTerminal"
+                  "$ref": "/rules@21"
                 },
                 "arguments": []
               }
@@ -1476,12 +1476,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "AbstractType"
+                    "$ref": "/types@0"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "ID"
+                      "$ref": "/rules@57"
                     },
                     "arguments": []
                   },
@@ -1495,7 +1495,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "InferredType"
+                    "$ref": "/rules@11"
                   },
                   "arguments": [
                     {
@@ -1525,7 +1525,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "FeatureName"
+                    "$ref": "/rules@56"
                   },
                   "arguments": []
                 }
@@ -1581,42 +1581,42 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$ref": "/rules@22"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$ref": "/rules@23"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedElement"
+              "$ref": "/rules@40"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedKeyword"
+              "$ref": "/rules@32"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedRuleCall"
+              "$ref": "/rules@33"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PredicatedGroup"
+              "$ref": "/rules@41"
             },
             "arguments": []
           }
@@ -1639,7 +1639,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$refText": "STRING"
+            "$ref": "/rules@58"
           },
           "arguments": []
         }
@@ -1664,12 +1664,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractRule"
+                "$ref": "/rules@8"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$ref": "/rules@57"
                 },
                 "arguments": []
               },
@@ -1690,7 +1690,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NamedArgument"
+                    "$ref": "/rules@24"
                   },
                   "arguments": []
                 }
@@ -1709,7 +1709,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "NamedArgument"
+                        "$ref": "/rules@24"
                       },
                       "arguments": []
                     }
@@ -1749,12 +1749,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$refText": "Parameter"
+                    "$ref": "/rules@13"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$refText": "ID"
+                      "$ref": "/rules@57"
                     },
                     "arguments": []
                   },
@@ -1780,7 +1780,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Disjunction"
+                "$ref": "/rules@26"
               },
               "arguments": []
             }
@@ -1835,7 +1835,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Conjunction"
+              "$ref": "/rules@27"
             },
             "arguments": []
           },
@@ -1862,7 +1862,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Conjunction"
+                    "$ref": "/rules@27"
                   },
                   "arguments": []
                 }
@@ -1892,7 +1892,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Negation"
+              "$ref": "/rules@28"
             },
             "arguments": []
           },
@@ -1919,7 +1919,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Negation"
+                    "$ref": "/rules@28"
                   },
                   "arguments": []
                 }
@@ -1949,7 +1949,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Atom"
+              "$ref": "/rules@29"
             },
             "arguments": []
           },
@@ -1974,7 +1974,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Negation"
+                    "$ref": "/rules@28"
                   },
                   "arguments": []
                 }
@@ -2003,21 +2003,21 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParameterReference"
+              "$ref": "/rules@31"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedCondition"
+              "$ref": "/rules@30"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "LiteralCondition"
+              "$ref": "/rules@25"
             },
             "arguments": []
           }
@@ -2047,7 +2047,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Disjunction"
+              "$ref": "/rules@26"
             },
             "arguments": []
           },
@@ -2074,12 +2074,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$refText": "Parameter"
+            "$ref": "/rules@13"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$ref": "/rules@57"
             },
             "arguments": []
           },
@@ -2123,7 +2123,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "STRING"
+                "$ref": "/rules@58"
               },
               "arguments": []
             }
@@ -2167,12 +2167,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractRule"
+                "$ref": "/rules@8"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$ref": "/rules@57"
                 },
                 "arguments": []
               },
@@ -2193,7 +2193,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "NamedArgument"
+                    "$ref": "/rules@24"
                   },
                   "arguments": []
                 }
@@ -2212,7 +2212,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "NamedArgument"
+                        "$ref": "/rules@24"
                       },
                       "arguments": []
                     }
@@ -2274,7 +2274,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "FeatureName"
+                "$ref": "/rules@56"
               },
               "arguments": []
             }
@@ -2308,7 +2308,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "AssignableTerminal"
+                "$ref": "/rules@35"
               },
               "arguments": []
             }
@@ -2335,28 +2335,28 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$ref": "/rules@22"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$ref": "/rules@23"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedAssignableElement"
+              "$ref": "/rules@36"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "CrossReference"
+              "$ref": "/rules@38"
             },
             "arguments": []
           }
@@ -2386,7 +2386,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AssignableAlternatives"
+              "$ref": "/rules@37"
             },
             "arguments": []
           },
@@ -2416,7 +2416,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "AssignableTerminal"
+              "$ref": "/rules@35"
             },
             "arguments": []
           },
@@ -2446,7 +2446,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "AssignableTerminal"
+                        "$ref": "/rules@35"
                       },
                       "arguments": []
                     }
@@ -2494,7 +2494,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "AbstractType"
+                "$ref": "/types@0"
               },
               "deprecatedSyntax": false
             }
@@ -2527,7 +2527,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "CrossReferenceableTerminal"
+                    "$ref": "/rules@39"
                   },
                   "arguments": []
                 }
@@ -2561,14 +2561,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Keyword"
+              "$ref": "/rules@22"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RuleCall"
+              "$ref": "/rules@23"
             },
             "arguments": []
           }
@@ -2598,7 +2598,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Alternatives"
+              "$ref": "/rules@14"
             },
             "arguments": []
           },
@@ -2649,7 +2649,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Alternatives"
+                "$ref": "/rules@14"
               },
               "arguments": []
             }
@@ -2680,14 +2680,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "PrimitiveType"
+                "$ref": "/rules@6"
               },
               "arguments": []
             },
             {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$ref": "/rules@57"
               },
               "arguments": []
             }
@@ -2743,7 +2743,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ID"
+                        "$ref": "/rules@57"
                       },
                       "arguments": []
                     }
@@ -2760,7 +2760,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$refText": "ID"
+                        "$ref": "/rules@57"
                       },
                       "arguments": []
                     }
@@ -2779,7 +2779,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$refText": "ReturnType"
+                            "$ref": "/rules@42"
                           },
                           "arguments": []
                         }
@@ -2802,7 +2802,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalAlternatives"
+                "$ref": "/rules@45"
               },
               "arguments": []
             }
@@ -2847,7 +2847,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalGroup"
+              "$ref": "/rules@46"
             },
             "arguments": []
           },
@@ -2874,7 +2874,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "TerminalGroup"
+                    "$ref": "/rules@46"
                   },
                   "arguments": []
                 }
@@ -2904,7 +2904,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalToken"
+              "$ref": "/rules@47"
             },
             "arguments": []
           },
@@ -2927,7 +2927,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "TerminalToken"
+                    "$ref": "/rules@47"
                   },
                   "arguments": []
                 },
@@ -2958,7 +2958,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalTokenElement"
+              "$ref": "/rules@48"
             },
             "arguments": []
           },
@@ -3007,49 +3007,49 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "CharacterRange"
+              "$ref": "/rules@55"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalRuleCall"
+              "$ref": "/rules@50"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ParenthesizedTerminalElement"
+              "$ref": "/rules@49"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "NegatedToken"
+              "$ref": "/rules@51"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "UntilToken"
+              "$ref": "/rules@52"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "RegexToken"
+              "$ref": "/rules@53"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "Wildcard"
+              "$ref": "/rules@54"
             },
             "arguments": []
           }
@@ -3079,7 +3079,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "TerminalAlternatives"
+              "$ref": "/rules@45"
             },
             "arguments": []
           },
@@ -3120,12 +3120,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$refText": "TerminalRule"
+                "$ref": "/rules@43"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$refText": "ID"
+                  "$ref": "/rules@57"
                 },
                 "arguments": []
               },
@@ -3169,7 +3169,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalTokenElement"
+                "$ref": "/rules@48"
               },
               "arguments": []
             }
@@ -3211,7 +3211,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "TerminalTokenElement"
+                "$ref": "/rules@48"
               },
               "arguments": []
             }
@@ -3249,7 +3249,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "RegexLiteral"
+                "$ref": "/rules@44"
               },
               "arguments": []
             }
@@ -3317,7 +3317,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "Keyword"
+                "$ref": "/rules@22"
               },
               "arguments": []
             }
@@ -3336,7 +3336,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$refText": "Keyword"
+                    "$ref": "/rules@22"
                   },
                   "arguments": []
                 }
@@ -3427,14 +3427,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "PrimitiveType"
+              "$ref": "/rules@6"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$refText": "ID"
+              "$ref": "/rules@57"
             },
             "arguments": []
           }
@@ -3505,7 +3505,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Interface"
+            "$ref": "/rules@1"
           },
           "isArray": false,
           "isRef": false
@@ -3513,7 +3513,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Type"
+            "$ref": "/rules@7"
           },
           "isArray": false,
           "isRef": false
@@ -3521,7 +3521,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "Action"
+            "$ref": "/rules@20/definition/elements@0"
           },
           "isArray": false,
           "isRef": false
@@ -3529,7 +3529,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         {
           "$type": "AtomType",
           "refType": {
-            "$refText": "ParserRule"
+            "$ref": "/rules@10"
           },
           "isArray": false,
           "isRef": false

--- a/packages/langium/src/grammar/references/grammar-references.ts
+++ b/packages/langium/src/grammar/references/grammar-references.ts
@@ -187,7 +187,7 @@ export class LangiumGrammarReferences extends DefaultReferences {
         const refs = this.index.findAllReferences(interf, this.nodeLocator.getAstNodePath(interf));
         refs.forEach(ref => {
             const doc = this.documents.getOrCreateDocument(ref.sourceUri);
-            const astNode = this.nodeLocator.getAstNode(doc, ref.sourcePath);
+            const astNode = this.nodeLocator.getAstNode(doc.parseResult.value, ref.sourcePath);
             if (isParserRule(astNode) || isAction(astNode)) {
                 rules.push(astNode);
             }

--- a/packages/langium/src/grammar/references/grammar-scope.ts
+++ b/packages/langium/src/grammar/references/grammar-scope.ts
@@ -116,8 +116,6 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
     /**
      * Add synthetic Interface in case of explicitly or implicitly inferred type:<br>
      * cases: `ParserRule: ...;` or `ParserRule infers Type: ...;`
-     * @param astNodeLocator AstNodeLocator
-     * @returns scope populator
      */
     protected processTypeNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
         const container = node.$container;

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -185,7 +185,7 @@ export function collectChildrenTypes(interfaceNode: Interface, references: Refer
     const refs = references.findReferences(interfaceNode, {});
     refs.forEach(ref => {
         const doc = langiumDocuments.getOrCreateDocument(ref.sourceUri);
-        const astNode = nodeLocator.getAstNode(doc, ref.sourcePath);
+        const astNode = nodeLocator.getAstNode(doc.parseResult.value, ref.sourcePath);
         if (isInterface(astNode)) {
             childrenTypes.add(astNode);
             const childrenOfInterface = collectChildrenTypes(astNode, references, langiumDocuments, nodeLocator);

--- a/packages/langium/src/references/linker.ts
+++ b/packages/langium/src/references/linker.ts
@@ -196,7 +196,7 @@ export class DefaultLinker implements Linker {
             return nodeDescription.node;
         }
         const doc = this.langiumDocuments().getOrCreateDocument(nodeDescription.documentUri);
-        return this.astNodeLocator.getAstNode(doc, nodeDescription.path);
+        return this.astNodeLocator.getAstNode(doc.parseResult.value, nodeDescription.path);
     }
 
     protected createLinkingError(refInfo: ReferenceInfo, targetDescription?: AstNodeDescription): LinkingError {

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -71,48 +71,6 @@ export class DefaultJsonSerializer implements JsonSerializer {
         return value;
     }
 
-    protected decycle(object: AstNode, ignore: Set<string>): unknown {
-        const objects = new Set<unknown>(); // Keep references to each unique object
-
-        const replace = (item: unknown) => {
-            // The replace function recurses through the object, producing the deep copy.
-            if (typeof item === 'object' && item !== null) {
-                if (objects.has(item)) {
-                    throw new Error('Cycle in ast detected.');
-                } else {
-                    objects.add(item);
-                }
-                // If it is a reference, transform it into a path
-                if (isReference(item)) {
-                    const refValue = item.ref;
-                    return {
-                        $ref: refValue && this.astNodeLocator.getAstNodePath(refValue)
-                    };
-                }
-                let newItem: Record<string, unknown> | unknown[];
-                // If it is an array, replicate the array.
-                if (Array.isArray(item)) {
-                    newItem = [];
-                    for (let i = 0; i < item.length; i++) {
-                        newItem[i] = replace(item[i]);
-                    }
-                } else {
-                    // If it is an object, replicate the object.
-                    newItem = {};
-                    for (const [name, itemValue] of Object.entries(item)) {
-                        if (!ignore.has(name)) {
-                            newItem[name] = replace(itemValue);
-                        }
-                    }
-                }
-                return newItem;
-            }
-            return item;
-        };
-        const result = replace(object);
-        return result;
-    }
-
     protected linkNode(node: GenericAstNode, root: AstNode, container?: AstNode, containerProperty?: string, containerIndex?: number) {
         for (const [propertyName, item] of Object.entries(node)) {
             if (Array.isArray(item)) {

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -5,8 +5,14 @@
  ******************************************************************************/
 
 import { LangiumServices } from '../services';
-import { AstNode, isAstNode, isReference } from '../syntax-tree';
+import { AstNode, GenericAstNode, isAstNode, isReference } from '../syntax-tree';
+import { Mutable } from '../utils/ast-util';
 import { AstNodeLocator } from '../workspace/ast-node-locator';
+
+export interface JsonSerializeOptions {
+    space?: string | number
+    refText?: boolean
+}
 
 /**
  * Utility service for transforming an `AstNode` into a JSON string and vice versa.
@@ -17,7 +23,7 @@ export interface JsonSerializer {
      * @param node The `AstNode` to be serialized.
      * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
      */
-    serialize(node: AstNode, space?: string | number): string;
+    serialize(node: AstNode, options?: JsonSerializeOptions): string;
     /**
      * Deserialize (parse) a JSON `string` into an `AstNode`.
      */
@@ -25,6 +31,7 @@ export interface JsonSerializer {
 }
 
 interface IntermediateReference {
+    $refText?: string
     $ref: string
 }
 
@@ -34,22 +41,37 @@ function isIntermediateReference(obj: unknown): obj is IntermediateReference {
 
 export class DefaultJsonSerializer implements JsonSerializer {
 
-    protected ignoreProperties = ['$container', '$containerProperty', '$containerIndex', '$document', '$cstNode'];
+    protected ignoreProperties = new Set(['$container', '$containerProperty', '$containerIndex', '$document', '$cstNode']);
     protected readonly astNodeLocator: AstNodeLocator;
 
     constructor(services: LangiumServices) {
         this.astNodeLocator = services.workspace.AstNodeLocator;
     }
 
-    serialize(node: AstNode, space?: string | number): string {
-        return JSON.stringify(this.decycle(node, this.ignoreProperties), undefined, space);
+    serialize(node: AstNode, options?: JsonSerializeOptions): string {
+        return JSON.stringify(node, (key, value) => this.replacer(key, value, options?.refText), options?.space);
     }
 
     deserialize(content: string): AstNode {
-        return this.revive(JSON.parse(content));
+        const root = JSON.parse(content);
+        this.linkNode(root, root);
+        return root;
     }
 
-    protected decycle(object: AstNode, ignore: string[]): unknown {
+    protected replacer(key: string, value: unknown, refText?: boolean): unknown {
+        if (this.ignoreProperties.has(key)) {
+            return undefined;
+        } else if (isReference(value)) {
+            const refValue = value.ref;
+            return {
+                $refText: refText ? value.$refText : undefined,
+                $ref: '#' + (refValue && this.astNodeLocator.getAstNodePath(refValue))
+            };
+        }
+        return value;
+    }
+
+    protected decycle(object: AstNode, ignore: Set<string>): unknown {
         const objects = new Set<unknown>(); // Keep references to each unique object
 
         const replace = (item: unknown) => {
@@ -78,7 +100,7 @@ export class DefaultJsonSerializer implements JsonSerializer {
                     // If it is an object, replicate the object.
                     newItem = {};
                     for (const [name, itemValue] of Object.entries(item)) {
-                        if (!ignore.includes(name)) {
+                        if (!ignore.has(name)) {
                             newItem[name] = replace(itemValue);
                         }
                     }
@@ -91,51 +113,36 @@ export class DefaultJsonSerializer implements JsonSerializer {
         return result;
     }
 
-    protected revive(root: AstNode): AstNode {
-        const pathActions: Array<() => void> = [];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const internalRevive = (value: Record<string, any>, container?: unknown, propName?: string) => {
-            if (Array.isArray(value)) {
-                for (let i = 0; i < value.length; i++) {
-                    const item = value[i];
-                    if (isIntermediateReference(item) && isAstNode(container)) {
-                        const index = i;
-                        pathActions.push(() => {
-                            const ref = this.evalRef(root, item.$ref);
-                            value[index] = { ref, $refText: '' };
-                        });
-                    } else if (typeof item === 'object' && item !== null) {
-                        internalRevive(item);
-                        item.$container = container;
-                        item.$containerProperty = propName;
-                        item.$containerIndex = i;
+    protected linkNode(node: GenericAstNode, root: AstNode, container?: AstNode, containerProperty?: string, containerIndex?: number) {
+        for (const [propertyName, item] of Object.entries(node)) {
+            if (Array.isArray(item)) {
+                for (let index = 0; index < item.length; index++) {
+                    const element = item[index];
+                    if (isIntermediateReference(element)) {
+                        item[index] = {
+                            $refText: element.$refText ?? '',
+                            ref: this.getRefNode(root, element.$ref),
+                        };
+                    } else if (isAstNode(element)) {
+                        this.linkNode(element as GenericAstNode, root, node, propertyName, index);
                     }
                 }
-            } else if (typeof value === 'object' && value !== null) {
-                for (const [name, item] of Object.entries(value)) {
-                    if (typeof item === 'object' && item !== null) {
-                        if (isIntermediateReference(item)) {
-                            pathActions.push(() => {
-                                const ref = this.evalRef(root, item.$ref);
-                                value[name] = { ref, $refText: '' };
-                            });
-                        } else if (Array.isArray(item)) {
-                            internalRevive(item, value, name);
-                        } else {
-                            internalRevive(item);
-                            item.$container = value;
-                            item.$containerProperty = name;
-                        }
-                    }
-                }
+            } else if (isIntermediateReference(item)) {
+                node[propertyName] = {
+                    $refText: item.$refText ?? '',
+                    ref: this.getRefNode(root, item.$ref),
+                };
+            } else if (isAstNode(item)) {
+                this.linkNode(item as GenericAstNode, root, node, propertyName);
             }
-        };
-        internalRevive(root);
-        pathActions.forEach(e => e());
-        return root;
+        }
+        const mutable = node as Mutable<GenericAstNode>;
+        mutable.$container = container;
+        mutable.$containerProperty = containerProperty;
+        mutable.$containerIndex = containerIndex;
     }
 
-    protected evalRef(root: AstNode, path: string): AstNode {
-        return this.astNodeLocator.getAstNode(root, path)!;
+    protected getRefNode(root: AstNode, path: string): AstNode {
+        return this.astNodeLocator.getAstNode(root, path.substring(1))!;
     }
 }

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -4,8 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { Linker } from '../references/linker';
-import { AstNode, GenericAstNode, isAstNode, isReference, Reference, ReferenceInfo } from '../syntax-tree';
+import { AstNode, CstNode, GenericAstNode, isAstNode, isReference, Reference, ReferenceInfo } from '../syntax-tree';
 import { DONE_RESULT, Stream, stream, StreamImpl, TreeStream, TreeStreamImpl } from '../utils/stream';
 import { LangiumDocument } from '../workspace/documents';
 
@@ -200,17 +199,17 @@ export function findLocalReferences(targetNode: AstNode, lookup = getDocument(ta
  * Creates a deep copy of the specified AST node.
  * The resulting copy will only contain semantically relevant information, such as the `$type` property and AST properties.
  *
- * References are copied without resolved cross reference. The specified linker is used to resolve them when necessary.
+ * References are copied without resolved cross reference. The specified function is used to rebuild them.
  */
-export function copyAstNode<T extends AstNode = AstNode>(node: T, linker: Linker): T {
+export function copyAstNode<T extends AstNode = AstNode>(node: T, buildReference: (node: AstNode, property: string, refNode: CstNode | undefined, refText: string) => Reference<AstNode>): T {
     const copy: GenericAstNode = { $type: node.$type };
 
     for (const [name, value] of Object.entries(node)) {
         if (!name.startsWith('$')) {
             if (isAstNode(value)) {
-                copy[name] = copyAstNode(value, linker);
+                copy[name] = copyAstNode(value, buildReference);
             } else if (isReference(value)) {
-                copy[name] = linker.buildReference(
+                copy[name] = buildReference(
                     copy,
                     name,
                     value.$refNode,
@@ -220,10 +219,10 @@ export function copyAstNode<T extends AstNode = AstNode>(node: T, linker: Linker
                 const copiedArray: unknown[] = [];
                 for (const element of value) {
                     if (isAstNode(element)) {
-                        copiedArray.push(copyAstNode(element, linker));
+                        copiedArray.push(copyAstNode(element, buildReference));
                     } else if (isReference(element)) {
                         copiedArray.push(
-                            linker.buildReference(
+                            buildReference(
                                 copy,
                                 name,
                                 element.$refNode,

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -272,8 +272,7 @@ function findNameAssignmentInternal(type: ast.AbstractType, cache: Map<ast.Abstr
 export function loadGrammarFromJson(json: string): ast.Grammar {
     const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
     const astNode = services.serializer.JsonSerializer.deserialize(json) as Mutable<ast.Grammar>;
-    const document = services.shared.workspace.LangiumDocumentFactory.fromModel(astNode, URI.parse('memory://grammar.langium'));
-    astNode.$document = document;
+    services.shared.workspace.LangiumDocumentFactory.fromModel(astNode, URI.parse(`memory://${astNode.name ?? 'grammar'}.langium`));
     return astNode;
 }
 

--- a/packages/langium/src/workspace/ast-node-locator.ts
+++ b/packages/langium/src/workspace/ast-node-locator.ts
@@ -5,7 +5,6 @@
  ******************************************************************************/
 
 import { AstNode } from '../syntax-tree';
-import { LangiumDocument } from './documents';
 
 /**
  * Language-specific service for locating an `AstNode` in a document.
@@ -23,14 +22,14 @@ export interface AstNodeLocator {
     getAstNodePath(node: AstNode): string;
 
     /**
-     * Locates an `AstNode` inside a document by following the given path.
+     * Locates an `AstNode` inside another node by following the given path.
      *
-     * @param document The document in which to look up.
-     * @param path Describes how to locate the `AstNode` inside the given `document`.
+     * @param node Parent element.
+     * @param path Describes how to locate the `AstNode` inside the given `node`.
      * @returns The `AstNode` located under the given path, or `undefined` if the path cannot be resolved.
      * @see AstNodeLocator.getAstNodePath
      */
-    getAstNode<T extends AstNode = AstNode>(document: LangiumDocument, path: string): T | undefined;
+    getAstNode<T extends AstNode = AstNode>(node: AstNode, path: string): T | undefined;
 
 }
 
@@ -58,7 +57,7 @@ export class DefaultAstNodeLocator implements AstNodeLocator {
         return $containerProperty;
     }
 
-    getAstNode<T extends AstNode = AstNode>(document: LangiumDocument, path: string): T | undefined {
+    getAstNode<T extends AstNode = AstNode>(node: AstNode, path: string): T | undefined {
         const segments = path.split(this.segmentSeparator);
         return segments.reduce((previousValue, currentValue) => {
             if (!previousValue || currentValue.length === 0) {
@@ -69,10 +68,10 @@ export class DefaultAstNodeLocator implements AstNodeLocator {
                 const property = currentValue.substring(0, propertyIndex);
                 const arrayIndex = parseInt(currentValue.substring(propertyIndex + 1));
                 const array = (previousValue as unknown as Record<string, AstNode[]>)[property];
-                return array[arrayIndex];
+                return array?.[arrayIndex];
             }
             return (previousValue as unknown as Record<string, AstNode>)[currentValue];
-        }, document.parseResult.value) as T;
+        }, node) as T;
     }
 
 }

--- a/packages/langium/src/workspace/index-manager.ts
+++ b/packages/langium/src/workspace/index-manager.ts
@@ -125,6 +125,7 @@ export class DefaultIndexManager implements IndexManager {
             const uriString = uri.toString();
             this.simpleIndex.delete(uriString);
             this.referenceIndex.delete(uriString);
+            this.globalScopeCache.clear();
         }
     }
 

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -398,7 +398,7 @@ describe('Whitespace keywords', () => {
 
     test('No validation errors for whitespace keywords in terminal rule', () => {
         const node = locator.getAstNode<GrammarAST.Keyword>(
-            validationResult.document,
+            validationResult.document.parseResult.value,
             'rules@1/definition/elements@1'
         )!;
         expectNoIssues(validationResult, { node });
@@ -406,7 +406,7 @@ describe('Whitespace keywords', () => {
 
     test('Should error for whitespace keyword in parser rule', () => {
         const node = locator.getAstNode<GrammarAST.Keyword>(
-            validationResult.document,
+            validationResult.document.parseResult.value,
             'rules@0/definition/elements@1'
         )!;
         expectError(validationResult, 'Keywords cannot only consist of whitespace characters.', { node });
@@ -414,7 +414,7 @@ describe('Whitespace keywords', () => {
 
     test('Should error for empty keyword in parser rule', () => {
         const node = locator.getAstNode<GrammarAST.Keyword>(
-            validationResult.document,
+            validationResult.document.parseResult.value,
             'rules@0/definition/elements@2'
         )!;
         expectError(validationResult, 'Keywords cannot be empty.', { node });
@@ -422,7 +422,7 @@ describe('Whitespace keywords', () => {
 
     test('Should warn for keywords with whitespaces in parser rule', () => {
         const node = locator.getAstNode<GrammarAST.Keyword>(
-            validationResult.document,
+            validationResult.document.parseResult.value,
             'rules@0/definition/elements@3'
         )!;
         expectWarning(validationResult, 'Keywords should not contain whitespace characters.', { node });

--- a/packages/langium/test/lsp/completion-provider.test.ts
+++ b/packages/langium/test/lsp/completion-provider.test.ts
@@ -85,7 +85,7 @@ describe('Completion within alternatives', () => {
         hidden terminal WS: /\\s+/;
         `;
 
-        const services = createServicesForGrammar({ grammar });
+        const services = await createServicesForGrammar({ grammar });
         const completion = expectCompletion(services);
         const text = '<|>a <|>b <|>c';
 
@@ -117,7 +117,7 @@ describe('Completion within alternatives', () => {
         hidden terminal WS: /\\s+/;
         `;
 
-        const services = createServicesForGrammar({ grammar });
+        const services = await createServicesForGrammar({ grammar });
         const completion = expectCompletion(services);
         const text = 'item A ref <|>A';
 

--- a/packages/langium/test/lsp/execute-command-handler.test.ts
+++ b/packages/langium/test/lsp/execute-command-handler.test.ts
@@ -23,7 +23,7 @@ describe('AbstractExecuteCommandHandler', () => {
             }
         }
 
-        const services = createServicesForGrammar({
+        const services = await createServicesForGrammar({
             grammar: grammarStub,
             sharedModule: {
                 lsp: {
@@ -50,7 +50,7 @@ describe('AbstractExecuteCommandHandler', () => {
             }
         }
 
-        const services = createServicesForGrammar({
+        const services = await createServicesForGrammar({
             grammar: grammarStub,
             sharedModule: {
                 lsp: {

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -29,7 +29,11 @@ describe('Predicated grammar rules with alternatives', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    const parser = parserFromGrammar(content);
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
 
     function hasProp(prop: string): void {
         const main = parser.parse(prop + '1').value;
@@ -79,7 +83,11 @@ describe('Predicated groups', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    const parser = parserFromGrammar(content);
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
 
     function expectCorrectParse(text: string, a: number, b = 0): void {
         const result = parser.parse(text);
@@ -164,7 +172,11 @@ describe('Handle unordered group', () => {
     terminal STRING: /"[^"]*"|'[^']*'/;
     `;
 
-    const parser = parserFromGrammar(content);
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
 
     test('Should parse documents without Errors', () => {
         type bookType = { version?: string, author?: string, descr?: string }
@@ -262,10 +274,8 @@ describe('One name for terminal and non-terminal rules', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    test('Should work without Parser Definition Errors', () => {
-        expect(() => {
-            parserFromGrammar(content);
-        }).not.toThrow();
+    test('Should work without Parser Definition Errors', async () => {
+        await parserFromGrammar(content).catch(e => fail(e));
     });
 
 });
@@ -277,7 +287,11 @@ describe('Boolean value converter', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    const parser = parserFromGrammar(content);
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
 
     function expectValue(input: string, value: unknown): void {
         const main = parser.parse(input).value as unknown as { value: unknown };
@@ -305,7 +319,11 @@ describe('BigInt Parser value converter', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    const parser = parserFromGrammar(content);
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
 
     function expectValue(input: string, value: unknown): void {
         const main = parser.parse(input).value as unknown as { value: unknown };
@@ -330,7 +348,11 @@ describe('Date Parser value converter', () => {
     hidden terminal WS: /\\s+/;
     `;
 
-    const parser = parserFromGrammar(content);
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
 
     test('Should have no definition errors', () => {
         expect(parser.definitionErrors).toHaveLength(0);
@@ -369,7 +391,11 @@ describe('Parser calls value converter', () => {
     hidden terminal ML_COMMENT: /\\/\\*[\\s\\S]*?\\*\\//;
     `;
 
-    const parser = parserFromGrammar(content);
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        parser = await parserFromGrammar(content);
+    });
 
     function expectValue(input: string, value: unknown): void {
         const main = parser.parse(input).value as unknown as { value: unknown };
@@ -491,15 +517,19 @@ describe('MultiMode Lexing', () => {
 
     hidden terminal WS: /\\s+/;`;
 
-    const services = createServicesForGrammar({
-        grammar,
-        module: {
-            parser: {
-                TokenBuilder: () => new MultiModeTokenBuilder()
+    let parser: LangiumParser;
+
+    beforeEach(async () => {
+        const services = await createServicesForGrammar({
+            grammar,
+            module: {
+                parser: {
+                    TokenBuilder: () => new MultiModeTokenBuilder()
+                }
             }
-        }
+        });
+        parser = services.parser.LangiumParser;
     });
-    const parser = services.parser.LangiumParser;
 
     test('multimode lexing works in default mode as expected', () => {
         const result = parser.parse('apple banana cherry');
@@ -580,16 +610,16 @@ describe('ALL(*) parser', () => {
 
     hidden terminal WS: /\\s+/;`;
 
-    const parser = parserFromGrammar(grammar);
-
-    test('can parse with unbounded lookahead #1', () => {
+    test('can parse with unbounded lookahead #1', async () => {
+        const parser = await parserFromGrammar(grammar);
         const result = parser.parse('aaaaaaaaaab');
         expect(result.lexerErrors).toHaveLength(0);
         expect(result.parserErrors).toHaveLength(0);
         expect(result.value.$type).toBe('A');
     });
 
-    test('can parse with unbounded lookahead #2', () => {
+    test('can parse with unbounded lookahead #2', async () => {
+        const parser = await parserFromGrammar(grammar);
         const result = parser.parse('aaaaaaaaaaaaaac');
         expect(result.lexerErrors).toHaveLength(0);
         expect(result.parserErrors).toHaveLength(0);
@@ -597,6 +627,6 @@ describe('ALL(*) parser', () => {
     });
 });
 
-function parserFromGrammar(grammar: string): LangiumParser {
-    return createServicesForGrammar({ grammar }).parser.LangiumParser;
+async function parserFromGrammar(grammar: string): Promise<LangiumParser> {
+    return (await createServicesForGrammar({ grammar })).parser.LangiumParser;
 }

--- a/packages/langium/test/parser/lexer.test.ts
+++ b/packages/langium/test/parser/lexer.test.ts
@@ -8,8 +8,8 @@ import { createServicesForGrammar, Lexer } from '../../src';
 
 describe('DefaultLexer', () => {
 
-    test('should expose lexer definition', () => {
-        const lexer = getLexer(`
+    test('should expose lexer definition', async () => {
+        const lexer = await getLexer(`
         grammar X
         entry Y: y='Y';
         hidden terminal WS: /\\s+/;
@@ -19,8 +19,8 @@ describe('DefaultLexer', () => {
         expect(lexer.definition.WS.name).toBe('WS');
     });
 
-    test('should lex input', () => {
-        const lexer = getLexer(`
+    test('should lex input', async () => {
+        const lexer = await getLexer(`
         grammar X
         entry Y: name='Y';
         hidden terminal WS: /\\s+/;
@@ -32,8 +32,8 @@ describe('DefaultLexer', () => {
         expect(result.hidden).toHaveLength(0);
     });
 
-    test('should return lexer errors', () => {
-        const lexer = getLexer(`
+    test('should return lexer errors', async () => {
+        const lexer = await getLexer(`
         grammar X
         entry Y: name=ID;
         terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
@@ -45,8 +45,8 @@ describe('DefaultLexer', () => {
         expect(result.hidden).toHaveLength(0);
     });
 
-    test('should lex hidden terminals', () => {
-        const lexer = getLexer(`
+    test('should lex hidden terminals', async () => {
+        const lexer = await getLexer(`
         grammar X
         entry Y: name=ID;
         terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
@@ -63,8 +63,8 @@ describe('DefaultLexer', () => {
 
 });
 
-function getLexer(grammar: string): Lexer {
-    const services = createServicesForGrammar({
+async function getLexer(grammar: string): Promise<Lexer> {
+    const services = await createServicesForGrammar({
         grammar
     });
     return services.parser.Lexer;

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -5,8 +5,8 @@
  ******************************************************************************/
 
 import { Position, Range } from 'vscode-languageserver';
-import { createServicesForGrammar } from '../../src';
-import { validationHelper } from '../../src/test';
+import { AstNode, createServicesForGrammar } from '../../src';
+import { validationHelper, ValidationResult } from '../../src/test';
 
 // Related to https://github.com/langium/langium/issues/571
 describe('Parser error is thrown on resynced token with NaN position', () => {
@@ -27,11 +27,15 @@ describe('Parser error is thrown on resynced token with NaN position', () => {
     terminal INT returns number: /[0-9]+/;
     terminal STRING: /"[^"]*"|'[^']*'/;
     `;
-    const services = createServicesForGrammar({
-        grammar
-    });
 
-    const validate = validationHelper(services);
+    let validate: (input: string) => Promise<ValidationResult<AstNode>>;
+
+    beforeEach(async () => {
+        const services = await createServicesForGrammar({
+            grammar
+        });
+        validate = validationHelper(services);
+    });
 
     test('Diagnostic is shown on at the end of the previous token', async () => {
         const text = `person Aasdf

--- a/packages/langium/test/workspace/ast-node-locator.test.ts
+++ b/packages/langium/test/workspace/ast-node-locator.test.ts
@@ -35,9 +35,9 @@ describe('DefaultAstNodeLocator', () => {
         `);
         const model = document.parseResult.value;
         const nodeLocator = grammarServices.workspace.AstNodeLocator;
-        expect(nodeLocator.getAstNode(document, '/rules@0')).toBe(model.rules[0]);
-        expect(nodeLocator.getAstNode(document, '/rules@0/definition')).toBe((model.rules[0] as ParserRule).definition);
-        expect(nodeLocator.getAstNode(document, '/rules@0/definition/elements@1')).toBe(((model.rules[0] as ParserRule).definition as Alternatives).elements[1]);
+        expect(nodeLocator.getAstNode(model, '/rules@0')).toBe(model.rules[0]);
+        expect(nodeLocator.getAstNode(model, '/rules@0/definition')).toBe((model.rules[0] as ParserRule).definition);
+        expect(nodeLocator.getAstNode(model, '/rules@0/definition/elements@1')).toBe(((model.rules[0] as ParserRule).definition as Alternatives).elements[1]);
     });
 
 });


### PR DESCRIPTION
To facilitate grammar loading without resorting to using the linker, we now use document paths for the json serializer. This makes some functions async which were previously sync, but these were used for testing purposes only anyway.

Also introduces a function to copy AST nodes, as we now need deep copies of AST nodes for the langium-cli to correctly embed referenced grammars.