### PR TITLE
Removed deprecated API

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -36,7 +36,7 @@ import { DefaultAstNodeDescriptionProvider, DefaultReferenceDescriptionProvider 
 import { DefaultAstNodeLocator } from './workspace/ast-node-locator';
 import { DefaultConfigurationProvider } from './workspace/configuration';
 import { DefaultDocumentBuilder } from './workspace/document-builder';
-import { DefaultLangiumDocumentFactory, DefaultLangiumDocuments, DefaultTextDocumentFactory } from './workspace/documents';
+import { DefaultLangiumDocumentFactory, DefaultLangiumDocuments } from './workspace/documents';
 import { FileSystemProvider } from './workspace/file-system-provider';
 import { DefaultIndexManager } from './workspace/index-manager';
 import { DefaultWorkspaceManager } from './workspace/workspace-manager';
@@ -130,7 +130,6 @@ export function createDefaultSharedModule(context: DefaultSharedModuleContext): 
             LangiumDocumentFactory: (services) => new DefaultLangiumDocumentFactory(services),
             DocumentBuilder: (services) => new DefaultDocumentBuilder(services),
             TextDocuments: () => new TextDocuments(TextDocument),
-            TextDocumentFactory: (services) => new DefaultTextDocumentFactory(services),
             IndexManager: (services) => new DefaultIndexManager(services),
             WorkspaceManager: (services) => new DefaultWorkspaceManager(services),
             FileSystemProvider: (services) => context.fileSystemProvider(services),

--- a/packages/langium/src/references/scope-computation.ts
+++ b/packages/langium/src/references/scope-computation.ts
@@ -50,11 +50,6 @@ export interface ScopeComputation {
      */
     computeLocalScopes(document: LangiumDocument, cancelToken?: CancellationToken): Promise<PrecomputedScopes>;
 
-    /**
-     * @deprecated This method has been renamed to `computeLocalScopes`.
-     */
-    computeScope(document: LangiumDocument, cancelToken?: CancellationToken): never
-
 }
 
 /**
@@ -140,13 +135,6 @@ export class DefaultScopeComputation implements ScopeComputation {
                 scopes.add(container, this.descriptions.createDescription(node, name, document));
             }
         }
-    }
-
-    /**
-     * @deprecated This method has been renamed to `computeLocalScopes`.
-     */
-    computeScope(): never {
-        throw new Error('Deprecated: This method has been renamed to `computeLocalScopes`.');
     }
 
 }

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -42,7 +42,7 @@ import type { AstNodeDescriptionProvider, ReferenceDescriptionProvider } from '.
 import type { AstNodeLocator } from './workspace/ast-node-locator';
 import type { ConfigurationProvider } from './workspace/configuration';
 import type { DocumentBuilder } from './workspace/document-builder';
-import type { LangiumDocumentFactory, LangiumDocuments, TextDocumentFactory } from './workspace/documents';
+import type { LangiumDocumentFactory, LangiumDocuments } from './workspace/documents';
 import type { FileSystemProvider } from './workspace/file-system-provider';
 import type { IndexManager } from './workspace/index-manager';
 import type { WorkspaceManager } from './workspace/workspace-manager';
@@ -156,7 +156,6 @@ export type LangiumDefaultSharedServices = {
         LangiumDocuments: LangiumDocuments
         LangiumDocumentFactory: LangiumDocumentFactory
         TextDocuments: TextDocuments<TextDocument>
-        TextDocumentFactory: TextDocumentFactory
         WorkspaceManager: WorkspaceManager
         FileSystemProvider: FileSystemProvider
         MutexLock: MutexLock

--- a/packages/langium/src/workspace/ast-descriptions.ts
+++ b/packages/langium/src/workspace/ast-descriptions.ts
@@ -32,11 +32,6 @@ export interface AstNodeDescriptionProvider {
      */
     createDescription(node: AstNode, name: string, document?: LangiumDocument): AstNodeDescription;
 
-    /**
-     * @deprecated This method has been moved to the `ScopeComputation` service and renamed to `computeExports`.
-     */
-    createDescriptions(document: LangiumDocument, cancelToken?: CancellationToken): never;
-
 }
 
 export class DefaultAstNodeDescriptionProvider implements AstNodeDescriptionProvider {
@@ -55,13 +50,6 @@ export class DefaultAstNodeDescriptionProvider implements AstNodeDescriptionProv
             documentUri: document.uri,
             path: this.astNodeLocator.getAstNodePath(node)
         };
-    }
-
-    /**
-     * @deprecated This method has been moved to the `ScopeComputation` service and renamed to `computeExports`.
-     */
-    createDescriptions(): never {
-        throw new Error('Deprecated: This method has been moved to the `ScopeComputation` service and renamed to `computeExports`.');
     }
 
 }

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -98,42 +98,6 @@ export interface DocumentSegment {
 }
 
 /**
- * Shared service for creating `TextDocument` instances.
- * @deprecated This service is no longer necessary and will be removed.
- */
-export interface TextDocumentFactory {
-    /**
-     * Creates a `TextDocument` from a given `URI`.
-     */
-    fromUri(uri: URI): TextDocument;
-}
-
-/**
- * @deprecated This service implementation is no longer necessary and will be removed.
- */
-export class DefaultTextDocumentFactory implements TextDocumentFactory {
-
-    protected readonly serviceRegistry: ServiceRegistry;
-    protected readonly fileSystemProvider: FileSystemProvider;
-
-    constructor(services: LangiumSharedServices) {
-        this.serviceRegistry = services.ServiceRegistry;
-        this.fileSystemProvider = services.workspace.FileSystemProvider;
-    }
-
-    fromUri(uri: URI): TextDocument {
-        const content = this.getContent(uri);
-        const services = this.serviceRegistry.getServices(uri);
-        return TextDocument.create(uri.toString(), services.LanguageMetaData.languageId, 0, content);
-    }
-
-    protected getContent(uri: URI): string {
-        return this.fileSystemProvider.readFileSync(uri);
-    }
-
-}
-
-/**
  * Shared service for creating `LangiumDocument` instances.
  */
 export interface LangiumDocumentFactory {


### PR DESCRIPTION
In preparation of the upcoming 1.0 release, we should remove API that is marked `@deprecated`.