### PR TITLE
Check if dir exists before calling rmdirSync

### DIFF
--- a/examples/domainmodel/test/domainmodel-cli.test.ts
+++ b/examples/domainmodel/test/domainmodel-cli.test.ts
@@ -50,7 +50,9 @@ describe('Test the domainmodel CLI', () => {
     });
 
     afterEach(() => {
-        fs.rmdirSync(destination, { recursive: true });
+        if (fs.existsSync(destination)) {
+            fs.rmdirSync(destination, { recursive: true });
+        }
     });
 
 });

--- a/examples/statemachine/test/statemachine-cli.test.ts
+++ b/examples/statemachine/test/statemachine-cli.test.ts
@@ -24,7 +24,9 @@ describe('Test the statemachine CLI', () => {
     });
 
     afterAll(() => {
-        fs.rmdirSync(destination, { recursive: true });
+        if (fs.existsSync(destination)) {
+            fs.rmdirSync(destination, { recursive: true });
+        }
     });
 
 });


### PR DESCRIPTION
Gracefully ignore errors if `destination` does not exist by first checking if directory exists before trying to delete it.