### PR TITLE
Fix type-generator.test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "prepare": "npm run clean && npm run build && npm run build --workspace=langium-vscode",
-    "clean": "shx rm -rf packages/**/lib packages/**/tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf packages/**/lib packages/**/out packages/**/tsconfig.tsbuildinfo",
     "build": "tsc -b tsconfig.build.json",
     "watch": "tsc -b tsconfig.build.json -w",
     "lint": "npm run lint --workspaces",
@@ -30,6 +30,10 @@
     "shx": "^0.3.4",
     "typescript": "^4.7.4",
     "vitest": "^0.23.2"
+  },
+  "volta": {
+    "node": "16.18.1",
+    "npm": "8.19.3"
   },
   "workspaces": [
     "packages/*",

--- a/packages/langium-cli/test/generator/types-generator.test.ts
+++ b/packages/langium-cli/test/generator/types-generator.test.ts
@@ -14,12 +14,10 @@ describe('Types generator', () => {
 
     test('should generate types file', async () => {
         const result = (await parseHelper<Grammar>(grammar)(TEST_GRAMMAR)).parseResult;
-        const typesFileContent = generateTypesFile(grammar, [result.value]);
-        let expectedTypes = EXPECTED_TYPES;
-        if (process.platform === 'win32') {
-            expectedTypes = EXPECTED_TYPES.replaceAll('\n', '\r\n');
-        }
-        expect(typesFileContent).toMatch(expectedTypes);
+        // on Windows system the line ending of result is "\r\n"
+        // Therefore typesFileContent is normalized to prevent false negatives
+        const typesFileContent = generateTypesFile(grammar, [result.value]).replace(/\r/g, '');
+        expect(typesFileContent).toMatch(EXPECTED_TYPES);
     });
 
 });

--- a/packages/langium-cli/test/generator/types-generator.test.ts
+++ b/packages/langium-cli/test/generator/types-generator.test.ts
@@ -15,7 +15,11 @@ describe('Types generator', () => {
     test('should generate types file', async () => {
         const result = (await parseHelper<Grammar>(grammar)(TEST_GRAMMAR)).parseResult;
         const typesFileContent = generateTypesFile(grammar, [result.value]);
-        expect(typesFileContent).toMatch(EXPECTED_TYPES);
+        let expectedTypes = EXPECTED_TYPES;
+        if (process.platform === 'win32') {
+            expectedTypes = EXPECTED_TYPES.replaceAll('\n', '\r\n');
+        }
+        expect(typesFileContent).toMatch(expectedTypes);
     });
 
 });


### PR DESCRIPTION
Test  type-generator.test.ts is broken on Windows because of different line endings.
In addition `clean` now removes out folders to clean old garbage,
I also would like to add volta to easily enforce a specific node/npm version, but I don't know if you want this?