### PR TITLE
Update GHA checkout and setup to remove deprecation warnings

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,9 +15,9 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Use Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Build


### PR DESCRIPTION
In addition, new node action also support volta and engines instructions:
https://github.com/actions/setup-node/releases/tag/v3.5.0