### PR TITLE
Enable keywords as properties in declared types

### DIFF
--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -409,7 +409,7 @@ export function isType(item: unknown): item is Type {
 export interface TypeAttribute extends AstNode {
     readonly $container: Interface;
     isOptional: boolean
-    name: string
+    name: FeatureName
     typeAlternatives: Array<AtomType>
 }
 

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -380,7 +380,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$refText": "ID"
+                "$refText": "FeatureName"
               },
               "arguments": []
             }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -22,7 +22,7 @@ fragment SchemaType:
     '{' attributes+=TypeAttribute* '}' ';'?;
 
 TypeAttribute:
-    name=ID (isOptional?='?')? ':' TypeAlternatives ';'?;
+    name=FeatureName (isOptional?='?')? ':' TypeAlternatives ';'?;
 
 fragment TypeAlternatives:
     typeAlternatives+=AtomType ('|' typeAlternatives+=AtomType)*;

--- a/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
+++ b/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
@@ -7,7 +7,7 @@
 import { SemanticTokenTypes } from 'vscode-languageserver';
 import { AstNode } from '../../syntax-tree';
 import { AbstractSemanticTokenProvider, SemanticTokenAcceptor } from '../../lsp/semantic-token-provider';
-import { isAction, isAssignment, isAtomType, isParameter, isParameterReference, isReturnType, isRuleCall } from '../generated/ast';
+import { isAction, isAssignment, isAtomType, isParameter, isParameterReference, isReturnType, isRuleCall, isTypeAttribute } from '../generated/ast';
 
 export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenProvider {
 
@@ -60,6 +60,12 @@ export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenPr
                     type: SemanticTokenTypes.type
                 });
             }
+        } else if (isTypeAttribute(node)) {
+            acceptor({
+                node,
+                property: 'name',
+                type: SemanticTokenTypes.property
+            });
         }
     }
 

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -95,6 +95,7 @@ describe('validate inferred types', () => {
 
     });
 });
+
 describe('Work with imported declared types', () => {
 
     test('Returning imported type should not produce an error #507', async () => {
@@ -110,6 +111,50 @@ describe('Work with imported declared types', () => {
 
         terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
         `.trim();
+        const document = await parseDocument(grammarServices, prog);
+        const diagnostics: Diagnostic[] = await grammarServices.validation.DocumentValidator.validateDocument(document);
+        expect(diagnostics.filter(d => d.severity === DiagnosticSeverity.Error)).toHaveLength(0);
+
+    });
+});
+
+describe('validate declared types', () => {
+
+    test('use langium keywords as properties in declared types', async () => {
+
+        const validKeywordsAsId = [
+            'current',
+            'entry',
+            'extends',
+            'false',
+            'fragment',
+            'grammar',
+            'hidden',
+            'import',
+            'infer',
+            'infers',
+            'interface',
+            'returns',
+            'terminal',
+            'true',
+            'type',
+            'with',
+            // primitive type, excluding Date
+            'string',
+            'number',
+            'boolean',
+            'bigint'
+        ];
+
+        const prog = `
+        interface Keywords {
+            ${validKeywordsAsId.map(keyword => keyword + ': string').join('\n    ')}
+        }
+        Keywords returns Keywords: ${validKeywordsAsId.map(keyword => keyword + '=ID').join(' ')};
+        hidden terminal WS: /\\s+/;
+        terminal ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
+        `.trim();
+
         const document = await parseDocument(grammarServices, prog);
         const diagnostics: Diagnostic[] = await grammarServices.validation.DocumentValidator.validateDocument(document);
         expect(diagnostics.filter(d => d.severity === DiagnosticSeverity.Error)).toHaveLength(0);


### PR DESCRIPTION
* Enable langium keywords as properties in declared types
* Add a test for using keywords as properties in declared types
* Add semantic token highlighting support for properties in declared types