### PR TITLE
Parsing errors may lead to invalid CST range data

### DIFF
--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -185,7 +185,7 @@ export class LangiumParser extends AbstractLangiumParser {
 
     consume(idx: number, tokenType: TokenType, feature: AbstractElement): void {
         const token = this.wrapper.wrapConsume(idx, tokenType);
-        if (!this.isRecording()) {
+        if (!this.isRecording() && !token.isInsertedInRecovery) {
             const leafNode = this.nodeBuilder.buildLeafNode(token, feature);
             const { assignment, isCrossRef } = this.getAssignment(feature);
             const current = this.current;


### PR DESCRIPTION
Should fix  #695 bei filtering out nodes inserted in recovery from the CST
