### PR TITLE
Prevent keyword/terminal name clashing

### DIFF
--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -227,9 +227,11 @@ export function resolveImport(documents: LangiumDocuments, imp: ast.GrammarImpor
     return undefined;
 }
 
-export function resolveTransitiveImports(documents: LangiumDocuments, grammar: ast.Grammar | ast.GrammarImport): ast.Grammar[] {
-    if (ast.isGrammarImport(grammar)) {
-        const resolvedGrammar = resolveImport(documents, grammar);
+export function resolveTransitiveImports(documents: LangiumDocuments, grammar: ast.Grammar): ast.Grammar[]
+export function resolveTransitiveImports(documents: LangiumDocuments, importNode: ast.GrammarImport): ast.Grammar[]
+export function resolveTransitiveImports(documents: LangiumDocuments, grammarOrImport: ast.Grammar | ast.GrammarImport): ast.Grammar[] {
+    if (ast.isGrammarImport(grammarOrImport)) {
+        const resolvedGrammar = resolveImport(documents, grammarOrImport);
         if (resolvedGrammar) {
             const transitiveGrammars = resolveTransitiveImportsInternal(documents, resolvedGrammar);
             transitiveGrammars.push(resolvedGrammar);
@@ -237,7 +239,7 @@ export function resolveTransitiveImports(documents: LangiumDocuments, grammar: a
         }
         return [];
     } else {
-        return resolveTransitiveImportsInternal(documents, grammar);
+        return resolveTransitiveImportsInternal(documents, grammarOrImport);
     }
 }
 

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -5,11 +5,12 @@
  ******************************************************************************/
 
 import { AstNode, createLangiumGrammarServices, EmptyFileSystem, Properties, streamAllContents, GrammarAST } from '../../src';
-import { expectError, expectIssue, expectNoIssues, expectWarning, validationHelper, ValidationResult } from '../../src/test';
+import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper, ValidationResult } from '../../src/test';
 import { IssueCodes } from '../../src/grammar/langium-grammar-validator';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 
 const services = createLangiumGrammarServices(EmptyFileSystem);
+const parse = parseHelper(services.grammar);
 const locator = services.grammar.workspace.AstNodeLocator;
 const validate = validationHelper<GrammarAST.Grammar>(services.grammar);
 
@@ -426,6 +427,67 @@ describe('Whitespace keywords', () => {
             'rules@0/definition/elements@3'
         )!;
         expectWarning(validationResult, 'Keywords should not contain whitespace characters.', { node });
+    });
+
+});
+
+describe('Clashing token names', () => {
+
+    afterEach(() => {
+        clearDocuments(services.grammar);
+    });
+
+    test('Local terminal clashing with local keyword', async () => {
+        const text = `
+        Rule: a='a';
+        terminal a: /a/; 
+        `;
+        const validation = await validate(text);
+        const terminal = locator.getAstNode(validation.document.parseResult.value, '/rules@1')!;
+        expectError(validation, 'Terminal name clashes with existing keyword.', {
+            node: terminal,
+            property: {
+                name: 'name'
+            }
+        });
+    });
+
+    test('Local terminal clashing with imported keyword', async () => {
+        const importedGrammar = await parse(`
+        Rule: a='a';
+        `);
+        const path = importedGrammar.uri.path;
+        const grammar = `
+        import ".${path}";
+        terminal a: /a/;
+        `;
+        const validation = await validate(grammar);
+        const terminal = locator.getAstNode(validation.document.parseResult.value, '/rules@0')!;
+        expectError(validation, /Terminal name clashes with imported keyword from/, {
+            node: terminal,
+            property: {
+                name: 'name'
+            }
+        });
+    });
+
+    test('Imported terminal clashing with local keyword', async () => {
+        const importedGrammar = await parse(`
+        terminal a: /a/;
+        `);
+        const path = importedGrammar.uri.path;
+        const grammar = `
+        import ".${path}";
+        Rule: a='a';
+        `;
+        const validation = await validate(grammar);
+        const importNode = validation.document.parseResult.value.imports[0];
+        expectError(validation, 'Imported terminals (a) clash with locally defined keywords.', {
+            node: importNode,
+            property: {
+                name: 'path'
+            }
+        });
     });
 
 });


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/719
Closes https://github.com/langium/langium/issues/810

Prevents keywords and terminals from sharing the same token name using a validation. The validation looks at:

1. Local terminals clashing with local keywords
2. Local terminals clashing with imported keywords
3. Imported terminals clashing with local keywords
4. Imported terminals clashing with imported keywords

Note that another solution could've been possible, which included internally renaming tokens generated from terminals during the token builder phase. However, that is pretty invasive and non-obvious for adopters, which is why we simply prevent those cases using validations.