### PR TITLE
Use plain function to register custom validations

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics-module.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-module.ts
@@ -6,7 +6,7 @@
 
 import { createDefaultModule, createDefaultSharedModule, DefaultSharedModuleContext, inject, LangiumServices, LangiumSharedServices, Module, PartialLangiumServices } from 'langium';
 import { ArithmeticsGeneratedModule, ArithmeticsGeneratedSharedModule } from './generated/module';
-import { ArithmeticsValidationRegistry, ArithmeticsValidator } from './arithmetics-validator';
+import { ArithmeticsValidator, registerValidationChecks } from './arithmetics-validator';
 import { ArithmeticsScopeProvider } from './arithmetics-scope-provider';
 
 /**
@@ -34,7 +34,6 @@ export const ArithmeticsModule: Module<ArithmeticsServices, PartialLangiumServic
         ScopeProvider: (services) => new ArithmeticsScopeProvider(services)
     },
     validation: {
-        ValidationRegistry: (services) => new ArithmeticsValidationRegistry(services),
         ArithmeticsValidator: () => new ArithmeticsValidator()
     }
 };
@@ -68,5 +67,6 @@ export function createArithmeticsServices(context: DefaultSharedModuleContext): 
         ArithmeticsModule
     );
     shared.ServiceRegistry.register(arithmetics);
+    registerValidationChecks(arithmetics);
     return { shared, arithmetics };
 }

--- a/examples/arithmetics/src/language-server/arithmetics-validator.ts
+++ b/examples/arithmetics/src/language-server/arithmetics-validator.ts
@@ -4,22 +4,21 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
+import { ValidationAcceptor, ValidationChecks } from 'langium';
 import { ArithmeticsAstType, isNumberLiteral, Definition, isFunctionCall, Expression, BinaryExpression, isBinaryExpression } from './generated/ast';
-import { ArithmeticsServices } from './arithmetics-module';
+import type { ArithmeticsServices } from './arithmetics-module';
 import { applyOp } from '../cli/cli-util';
 
-export class ArithmeticsValidationRegistry extends ValidationRegistry {
-    constructor(services: ArithmeticsServices) {
-        super(services);
-        const validator = services.validation.ArithmeticsValidator;
-        const checks: ValidationChecks<ArithmeticsAstType> = {
-            BinaryExpression: validator.checkDivByZero,
-            Definition: validator.checkNormalisable
-        };
-        this.register(checks, validator);
-    }
+export function registerValidationChecks(services: ArithmeticsServices): void {
+    const registry = services.validation.ValidationRegistry;
+    const validator = services.validation.ArithmeticsValidator;
+    const checks: ValidationChecks<ArithmeticsAstType> = {
+        BinaryExpression: validator.checkDivByZero,
+        Definition: validator.checkNormalisable
+    };
+    registry.register(checks, validator);
 }
+
 export class ArithmeticsValidator {
     checkDivByZero(binExpr: BinaryExpression, accept: ValidationAcceptor): void {
         if (binExpr.operator === '/' && isNumberLiteral(binExpr.right) && binExpr.right.value === 0) {

--- a/examples/domainmodel/src/language-server/domain-model-module.ts
+++ b/examples/domainmodel/src/language-server/domain-model-module.ts
@@ -6,7 +6,7 @@
 
 import { LangiumServices, Module, PartialLangiumServices, LangiumSharedServices, DefaultSharedModuleContext, inject, createDefaultSharedModule, createDefaultModule } from 'langium';
 import { DomainModelGeneratedModule, DomainModelGeneratedSharedModule } from './generated/module';
-import { DomainModelValidationRegistry, DomainModelValidator } from './domain-model-validator';
+import { DomainModelValidator, registerValidationChecks } from './domain-model-validator';
 import { DomainModelScopeComputation } from './domain-model-scope';
 import { DomainModelNameProvider } from './domain-model-naming';
 import { DomainModelFormatter } from './domain-model-formatter';
@@ -26,7 +26,6 @@ export const DomainModelModule: Module<DomainModelServices, PartialLangiumServic
         NameProvider: () => new DomainModelNameProvider()
     },
     validation: {
-        ValidationRegistry: (services) => new DomainModelValidationRegistry(services),
         DomainModelValidator: () => new DomainModelValidator()
     },
     lsp: {
@@ -49,5 +48,6 @@ export function createDomainModelServices(context: DefaultSharedModuleContext): 
         DomainModelModule
     );
     shared.ServiceRegistry.register(domainmodel);
+    registerValidationChecks(domainmodel);
     return { shared, domainmodel };
 }

--- a/examples/domainmodel/src/language-server/domain-model-validator.ts
+++ b/examples/domainmodel/src/language-server/domain-model-validator.ts
@@ -4,19 +4,17 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
+import { ValidationAcceptor, ValidationChecks } from 'langium';
 import { DomainModelAstType, Type } from './generated/ast';
-import { DomainModelServices } from './domain-model-module';
+import type { DomainModelServices } from './domain-model-module';
 
-export class DomainModelValidationRegistry extends ValidationRegistry {
-    constructor(services: DomainModelServices) {
-        super(services);
-        const validator = services.validation.DomainModelValidator;
-        const checks: ValidationChecks<DomainModelAstType> = {
-            Type: validator.checkTypeStartsWithCapital
-        };
-        this.register(checks, validator);
-    }
+export function registerValidationChecks(services: DomainModelServices) {
+    const registry = services.validation.ValidationRegistry;
+    const validator = services.validation.DomainModelValidator;
+    const checks: ValidationChecks<DomainModelAstType> = {
+        Type: validator.checkTypeStartsWithCapital
+    };
+    registry.register(checks, validator);
 }
 
 export class DomainModelValidator {

--- a/examples/requirements/src/cli/index.ts
+++ b/examples/requirements/src/cli/index.ts
@@ -13,7 +13,7 @@ import { generateSummary } from './generator';
 import { NodeFileSystem } from 'langium/node';
 
 export const generateAction = async (fileName: string, opts: GenerateOptions): Promise<void> => {
-    const services = createRequirementsAndTestsLangServices(NodeFileSystem).RequirementsLang;
+    const services = createRequirementsAndTestsLangServices(NodeFileSystem).requirements;
     const [requirementModel, testModels]  = await extractRequirementModelWithTestModels(fileName, services);
     const generatedFilePath = generateSummary(requirementModel, testModels, fileName, opts.destination);
     console.log(chalk.green(`Requirement coverage generated successfully: ${generatedFilePath}`));

--- a/examples/requirements/src/language-server/requirements-and-tests-lang-module.ts
+++ b/examples/requirements/src/language-server/requirements-and-tests-lang-module.ts
@@ -8,9 +8,13 @@ import {
     createDefaultModule, createDefaultSharedModule, DefaultSharedModuleContext, inject,
     LangiumSharedServices
 } from 'langium';
-import { RequirementsAndTestsGeneratedSharedModule, RequirementsGeneratedModule, TestsGeneratedModule } from './generated/module';
+import {
+    RequirementsAndTestsGeneratedSharedModule, RequirementsGeneratedModule, TestsGeneratedModule
+} from './generated/module';
 import { RequirementsLangModule, RequirementsLangServices } from './requirements-lang-module';
+import { registerRequirementsValidationChecks } from './requirements-lang-validator';
 import { TestsLangModule, TestsLangServices } from './tests-lang-module';
+import { registerTestsValidationChecks } from './tests-lang-validator';
 
 /**
  * Create the full set of services required by Langium.
@@ -29,24 +33,26 @@ import { TestsLangModule, TestsLangServices } from './tests-lang-module';
  */
 export function createRequirementsAndTestsLangServices(context: DefaultSharedModuleContext): {
     shared: LangiumSharedServices,
-    RequirementsLang: RequirementsLangServices,
-    TestsLang: TestsLangServices
+    requirements: RequirementsLangServices,
+    tests: TestsLangServices
 } {
     const shared = inject(
         createDefaultSharedModule(context),
         RequirementsAndTestsGeneratedSharedModule
     );
-    const RequirementsLang = inject(
+    const requirements = inject(
         createDefaultModule({ shared }),
         RequirementsGeneratedModule,
         RequirementsLangModule
     );
-    const TestsLang = inject(
+    const tests = inject(
         createDefaultModule({ shared }),
         TestsGeneratedModule,
         TestsLangModule
     );
-    shared.ServiceRegistry.register(RequirementsLang);
-    shared.ServiceRegistry.register(TestsLang);
-    return { shared, RequirementsLang: RequirementsLang, TestsLang: TestsLang };
+    shared.ServiceRegistry.register(requirements);
+    shared.ServiceRegistry.register(tests);
+    registerRequirementsValidationChecks(requirements);
+    registerTestsValidationChecks(tests);
+    return { shared, requirements, tests };
 }

--- a/examples/requirements/src/language-server/requirements-lang-module.ts
+++ b/examples/requirements/src/language-server/requirements-lang-module.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { LangiumServices, Module, PartialLangiumServices } from 'langium';
-import { RequirementsLangValidationRegistry, RequirementsLangValidator } from './requirements-lang-validator';
+import { RequirementsLangValidator } from './requirements-lang-validator';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -29,7 +29,6 @@ export type RequirementsLangServices = LangiumServices & RequirementsLangAddedSe
  */
 export const RequirementsLangModule: Module<RequirementsLangServices, PartialLangiumServices & RequirementsLangAddedServices> = {
     validation: {
-        ValidationRegistry: (services) => new RequirementsLangValidationRegistry(services),
         RequirementsLangValidator: (services) => new RequirementsLangValidator(services)
     }
 };

--- a/examples/requirements/src/language-server/requirements-lang-validator.ts
+++ b/examples/requirements/src/language-server/requirements-lang-validator.ts
@@ -4,30 +4,22 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
+import { ValidationAcceptor, ValidationChecks } from 'langium';
 import { RequirementsAndTestsAstType, Requirement, isTestModel } from './generated/ast';
-import { RequirementsLangServices } from './requirements-lang-module';
+import type { RequirementsLangServices } from './requirements-lang-module';
 
-/**
- * Registry for validation checks.
- */
-export class RequirementsLangValidationRegistry extends ValidationRegistry {
-    constructor(services: RequirementsLangServices) {
-        super(services);
-        const validator = services.validation.RequirementsLangValidator;
-        const checks: ValidationChecks<RequirementsAndTestsAstType> = {
-            Requirement: [
-                validator.checkRequirementNameContainsANumber,
-                validator.checkRequirementIsCoveredByATest
-            ]
-        };
-        this.register(checks, validator);
-    }
+export function registerRequirementsValidationChecks(services: RequirementsLangServices) {
+    const registry = services.validation.ValidationRegistry;
+    const validator = services.validation.RequirementsLangValidator;
+    const checks: ValidationChecks<RequirementsAndTestsAstType> = {
+        Requirement: [
+            validator.checkRequirementNameContainsANumber,
+            validator.checkRequirementIsCoveredByATest
+        ]
+    };
+    registry.register(checks, validator);
 }
 
-/**
- * Implementation of custom validations.
- */
 export class RequirementsLangValidator {
     private services: RequirementsLangServices;
 

--- a/examples/requirements/src/language-server/tests-lang-module.ts
+++ b/examples/requirements/src/language-server/tests-lang-module.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { LangiumServices, Module, PartialLangiumServices } from 'langium';
-import { TestsLangValidationRegistry, TestsLangValidator } from './tests-lang-validator';
+import { TestsLangValidator } from './tests-lang-validator';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -29,7 +29,6 @@ export type TestsLangServices = LangiumServices & TestsLangAddedServices
  */
 export const TestsLangModule: Module<TestsLangServices, PartialLangiumServices & TestsLangAddedServices> = {
     validation: {
-        ValidationRegistry: (services) => new TestsLangValidationRegistry(services),
         TestsLangValidator: () => new TestsLangValidator()
     }
 };

--- a/examples/requirements/src/language-server/tests-lang-validator.ts
+++ b/examples/requirements/src/language-server/tests-lang-validator.ts
@@ -4,30 +4,22 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
+import { ValidationAcceptor, ValidationChecks } from 'langium';
 import { RequirementsAndTestsAstType, Test } from './generated/ast';
-import { TestsLangServices } from './tests-lang-module';
+import type { TestsLangServices } from './tests-lang-module';
 
-/**
- * Registry for validation checks.
- */
-export class TestsLangValidationRegistry extends ValidationRegistry {
-    constructor(services: TestsLangServices) {
-        super(services);
-        const validator = services.validation.TestsLangValidator;
-        const checks: ValidationChecks<RequirementsAndTestsAstType> = {
-            Test: [
-                validator.checkTestNameContainsANumber,
-                validator.checkTestReferencesOnlyEnvironmentsAlsoReferencedInSomeRequirement
-            ]
-        };
-        this.register(checks, validator);
-    }
+export function registerTestsValidationChecks(services: TestsLangServices) {
+    const registry = services.validation.ValidationRegistry;
+    const validator = services.validation.TestsLangValidator;
+    const checks: ValidationChecks<RequirementsAndTestsAstType> = {
+        Test: [
+            validator.checkTestNameContainsANumber,
+            validator.checkTestReferencesOnlyEnvironmentsAlsoReferencedInSomeRequirement
+        ]
+    };
+    registry.register(checks, validator);
 }
 
-/**
- * Implementation of custom validations.
- */
 export class TestsLangValidator {
 
     checkTestNameContainsANumber(test: Test, accept: ValidationAcceptor): void {

--- a/examples/requirements/test/generator.test.ts
+++ b/examples/requirements/test/generator.test.ts
@@ -16,7 +16,7 @@ describe('The generator should allow to extract all test cases referencing a spe
         const services = createRequirementsAndTestsLangServices(NodeFileSystem);
         const [requirementModel, testModels]  = await extractRequirementModelWithTestModels(
             path.join(__dirname, 'files', 'good', 'requirements.req'),
-            services.RequirementsLang
+            services.requirements
         );
 
         // generate summary

--- a/examples/requirements/test/validator.test.ts
+++ b/examples/requirements/test/validator.test.ts
@@ -14,7 +14,7 @@ describe('A requirement identifier and a test identifier shall contain a number.
         const services = createRequirementsAndTestsLangServices(NodeFileSystem);
         const [mainDoc,allDocs] = await extractDocuments(
             path.join(__dirname, 'files', 'good', 'requirements.req'),
-            services.RequirementsLang
+            services.requirements
         );
         expect((mainDoc.diagnostics ?? [])).toEqual([]);
         expect(allDocs.length).toEqual(3);
@@ -29,7 +29,7 @@ describe('A requirement identifier shall contain a number.', () => {
         const services = createRequirementsAndTestsLangServices(NodeFileSystem);
         const [mainDoc,] = await extractDocuments(
             path.join(__dirname, 'files', 'bad1', 'requirements.req'),
-            services.RequirementsLang
+            services.requirements
         );
         expect(mainDoc.diagnostics ?? []).toEqual(expect.arrayContaining([
             expect.objectContaining({
@@ -46,7 +46,7 @@ describe('A test identifier shall contain a number.', () => {
         const services = createRequirementsAndTestsLangServices(NodeFileSystem);
         const [,allDocs] = await extractDocuments(
             path.join(__dirname, 'files', 'bad1', 'requirements.req'),
-            services.RequirementsLang
+            services.requirements
         );
         const doc = allDocs.find(doc=>/tests_part1.tst/.test(doc.uri.fsPath));
         expect(doc).toBeDefined();
@@ -65,7 +65,7 @@ describe('A requirement shall be covered by at least one test.', () => {
         const services = createRequirementsAndTestsLangServices(NodeFileSystem);
         const [mainDoc,] = await extractDocuments(
             path.join(__dirname, 'files', 'bad1', 'requirements.req'),
-            services.RequirementsLang
+            services.requirements
         );
         expect(mainDoc.diagnostics ?? []).toEqual(expect.arrayContaining([
             expect.objectContaining({
@@ -81,7 +81,7 @@ describe('A referenced environment in a test must be found in one of the referen
         const services = createRequirementsAndTestsLangServices(NodeFileSystem);
         const [,allDocs] = await extractDocuments(
             path.join(__dirname, 'files', 'bad2', 'requirements.req'),
-            services.RequirementsLang
+            services.requirements
         );
         const doc = allDocs.find(doc=>/tests_part1.tst/.test(doc.uri.fsPath));
         expect(doc).toBeDefined();

--- a/examples/statemachine/src/language-server/statemachine-module.ts
+++ b/examples/statemachine/src/language-server/statemachine-module.ts
@@ -9,7 +9,7 @@ import {
     LangiumServices, LangiumSharedServices, Module, PartialLangiumServices
 } from 'langium';
 import { StatemachineGeneratedModule, StatemachineGeneratedSharedModule } from './generated/module';
-import { StatemachineValidationRegistry, StatemachineValidator } from './statemachine-validator';
+import { registerValidationChecks, StatemachineValidator } from './statemachine-validator';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -33,7 +33,6 @@ export type StatemachineServices = LangiumServices & StatemachineAddedServices
  */
 export const StatemachineModule: Module<StatemachineServices, PartialLangiumServices & StatemachineAddedServices> = {
     validation: {
-        ValidationRegistry: (services) => new StatemachineValidationRegistry(services),
         StatemachineValidator: () => new StatemachineValidator()
     }
 };
@@ -67,5 +66,6 @@ export function createStatemachineServices(context: DefaultSharedModuleContext):
         StatemachineModule
     );
     shared.ServiceRegistry.register(statemachine);
+    registerValidationChecks(statemachine);
     return { shared, statemachine };
 }

--- a/examples/statemachine/src/language-server/statemachine-validator.ts
+++ b/examples/statemachine/src/language-server/statemachine-validator.ts
@@ -4,19 +4,17 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
+import { ValidationAcceptor, ValidationChecks } from 'langium';
 import { State, StatemachineAstType } from './generated/ast';
-import { StatemachineServices } from './statemachine-module';
+import type { StatemachineServices } from './statemachine-module';
 
-export class StatemachineValidationRegistry extends ValidationRegistry {
-    constructor(services: StatemachineServices) {
-        super(services);
-        const validator = services.validation.StatemachineValidator;
-        const checks: ValidationChecks<StatemachineAstType> = {
-            State: validator.checkStateNameStartsWithCapital
-        };
-        this.register(checks, validator);
-    }
+export function registerValidationChecks(services: StatemachineServices) {
+    const registry = services.validation.ValidationRegistry;
+    const validator = services.validation.StatemachineValidator;
+    const checks: ValidationChecks<StatemachineAstType> = {
+        State: validator.checkStateNameStartsWithCapital
+    };
+    registry.register(checks, validator);
 }
 
 export class StatemachineValidator {

--- a/packages/generator-langium/langium-template/src/language-server/language-id-module.ts
+++ b/packages/generator-langium/langium-template/src/language-server/language-id-module.ts
@@ -3,7 +3,7 @@ import {
     LangiumServices, LangiumSharedServices, Module, PartialLangiumServices
 } from 'langium';
 import { <%= LanguageName %>GeneratedModule, <%= LanguageName %>GeneratedSharedModule } from './generated/module';
-import { <%= LanguageName %>ValidationRegistry, <%= LanguageName %>Validator } from './<%= language-id %>-validator';
+import { <%= LanguageName %>Validator, registerValidationChecks } from './<%= language-id %>-validator';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -27,7 +27,6 @@ export type <%= LanguageName %>Services = LangiumServices & <%= LanguageName %>A
  */
 export const <%= LanguageName %>Module: Module<<%= LanguageName %>Services, PartialLangiumServices & <%= LanguageName %>AddedServices> = {
     validation: {
-        ValidationRegistry: (services) => new <%= LanguageName %>ValidationRegistry(services),
         <%= LanguageName %>Validator: () => new <%= LanguageName %>Validator()
     }
 };
@@ -61,5 +60,6 @@ export function create<%= LanguageName %>Services(context: DefaultSharedModuleCo
         <%= LanguageName %>Module
     );
     shared.ServiceRegistry.register(<%= LanguageName %>);
+    registerValidationChecks(<%= LanguageName %>);
     return { shared, <%= LanguageName %> };
 }

--- a/packages/generator-langium/langium-template/src/language-server/language-id-validator.ts
+++ b/packages/generator-langium/langium-template/src/language-server/language-id-validator.ts
@@ -1,19 +1,17 @@
-import { ValidationAcceptor, ValidationChecks, ValidationRegistry } from 'langium';
+import { ValidationAcceptor, ValidationChecks } from 'langium';
 import { <%= LanguageName %>AstType, Person } from './generated/ast';
 import type { <%= LanguageName %>Services } from './<%= language-id %>-module';
 
 /**
- * Registry for validation checks.
+ * Register custom validation checks.
  */
-export class <%= LanguageName %>ValidationRegistry extends ValidationRegistry {
-    constructor(services: <%= LanguageName %>Services) {
-        super(services);
-        const validator = services.validation.<%= LanguageName %>Validator;
-        const checks: ValidationChecks<<%= LanguageName %>AstType> = {
-            Person: validator.checkPersonStartsWithCapital
-        };
-        this.register(checks, validator);
-    }
+export function registerValidationChecks(services: <%= LanguageName %>Services) {
+    const registry = services.validation.ValidationRegistry;
+    const validator = services.validation.<%= LanguageName %>Validator;
+    const checks: ValidationChecks<<%= LanguageName %>AstType> = {
+        Person: validator.checkPersonStartsWithCapital
+    };
+    registry.register(checks, validator);
 }
 
 /**


### PR DESCRIPTION
Creating a subclass just to register some checks is overly complicated. Let's do it directly instead, which is possible without changing the API. With this we show a general scheme to register stuff (same approach for build listeners, for example).