### PR TITLE
Fixed some small issues

### DIFF
--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -634,12 +634,18 @@ export class LangiumGrammarValidator {
     }
 
     checkAssignmentToFragmentRule(assignment: ast.Assignment, accept: ValidationAcceptor): void {
+        if(!assignment.terminal) {
+            return;
+        }
         if (isRuleCall(assignment.terminal) && isParserRule(assignment.terminal.rule.ref) && assignment.terminal.rule.ref.fragment) {
             accept('error', `Cannot use fragment rule '${assignment.terminal.rule.ref.name}' for assignment of property '${assignment.feature}'.`, { node: assignment, property: 'terminal' });
         }
     }
 
     checkAssignmentTypes(assignment: ast.Assignment, accept: ValidationAcceptor): void {
+        if(!assignment.terminal) {
+            return;
+        }
         let firstType: 'ref' | 'other';
         const foundMixed = streamAllContents(assignment.terminal).map(node => ast.isCrossReference(node) ? 'ref' : 'other').find(type => {
             if (!firstType) {

--- a/packages/langium/src/references/linker.ts
+++ b/packages/langium/src/references/linker.ts
@@ -149,6 +149,10 @@ export class DefaultLinker implements Linker {
                 } else if (this._ref === undefined) {
                     // The reference has not been linked yet, so do that now.
                     const refData = linker.getLinkedNode({ reference, container: node, property });
+                    if(refData.error && getDocument(node).state < DocumentState.ComputedScopes) {
+                        // Document scope is not ready, don't set `this._ref` so linker can retry later.
+                        return undefined;
+                    }
                     this._ref = refData.node ?? refData.error;
                     this._nodeDescription = refData.descr;
                 }

--- a/packages/langium/src/utils/ast-util.ts
+++ b/packages/langium/src/utils/ast-util.ts
@@ -96,6 +96,9 @@ export function findRootNode(node: AstNode): AstNode {
  * single-valued as well as multi-valued (array) properties.
  */
 export function streamContents(node: AstNode): Stream<AstNode> {
+    if(!node) {
+        throw new Error('Node must be an AstNode.');
+    }
     type State = { keys: string[], keyIndex: number, arrayIndex: number };
     return new StreamImpl<State, AstNode>(() => ({
         keys: Object.keys(node),
@@ -131,6 +134,9 @@ export function streamContents(node: AstNode): Stream<AstNode> {
  * This does not include the root node itself.
  */
 export function streamAllContents(root: AstNode): TreeStream<AstNode> {
+    if(!root) {
+        throw new Error('Root node must be an AstNode.');
+    }
     return new TreeStreamImpl(root, node => streamContents(node));
 }
 
@@ -139,6 +145,9 @@ export function streamAllContents(root: AstNode): TreeStream<AstNode> {
  * including the root node itself.
  */
 export function streamAst(root: AstNode): TreeStream<AstNode> {
+    if(!root) {
+        throw new Error('Root node must be an AstNode.');
+    }
     return new TreeStreamImpl(root, node => streamContents(node), { includeRoot: true });
 }
 


### PR DESCRIPTION
- Validation throws an error with a broken model: validator.ts
- Report undefined node when about to stream it contents: ast-utils.ts
- Allow recomputing `_ref` when a linkage error was created in a phase before ComputedScopes: linker.ts

The problem in linker.ts occurs when e.g. semanticHighlighting asks for a reference, but the document is still parsing or indexing and can not link to a local reference. Warning is logged: `Attempted reference resolution before document reached ComputedScopes state`
