### PR TITLE
Don't create empty AstNodes

### DIFF
--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -40,8 +40,12 @@ function isDataTypeRuleInternal(rule: ast.ParserRule, visited: Set<ast.ParserRul
     }
     visited.add(rule);
     for (const node of streamAllContents(rule)) {
-        if (ast.isRuleCall(node) && ast.isParserRule(node.rule.ref)) {
-            if (!isDataTypeRuleInternal(node.rule.ref, visited)) {
+        if (ast.isRuleCall(node)) {
+            if (!node.rule.ref) {
+                // RuleCall to unresolved rule. Don't assume `rule` is a DataType rule.
+                return false;
+            }
+            if (ast.isParserRule(node.rule.ref) && !isDataTypeRuleInternal(node.rule.ref, visited)) {
                 return false;
             }
         } else if (ast.isAssignment(node)) {
@@ -50,7 +54,7 @@ function isDataTypeRuleInternal(rule: ast.ParserRule, visited: Set<ast.ParserRul
             return false;
         }
     }
-    return true;
+    return Boolean(rule.definition);
 }
 
 export function getActionAtElement(element: ast.AbstractElement): ast.Action | undefined {

--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -210,7 +210,9 @@ export function collectInferredTypes(parserRules: ParserRule[], datatypeRules: P
 function getRuleTypes(context: TypeCollectionContext, rule: ParserRule): TypeAlternative[] {
     const type = newTypePart(rule);
     const graph = new TypeGraph(context, type);
-    collectElement(graph, graph.root, rule.definition);
+    if (rule.definition) {
+        collectElement(graph, graph.root, rule.definition);
+    }
     return graph.getTypes();
 }
 

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -208,14 +208,14 @@ export class LangiumParser extends AbstractLangiumParser {
             cstNode = this.nodeBuilder.buildCompositeNode(feature);
         }
         const subruleResult = this.wrapper.wrapSubrule(idx, rule, args) as any;
-        if (!this.isRecording()) {
+        if (!this.isRecording() && cstNode && cstNode.length > 0) {
             this.performSubruleAssignment(subruleResult, feature, cstNode);
         }
     }
 
-    private performSubruleAssignment(result: any, feature: AbstractElement, cstNode: CompositeCstNode | undefined): void {
+    private performSubruleAssignment(result: any, feature: AbstractElement, cstNode: CompositeCstNode): void {
         const { assignment, isCrossRef } = this.getAssignment(feature);
-        if (assignment && cstNode) {
+        if (assignment) {
             this.assign(assignment.operator, assignment.feature, result, cstNode, isCrossRef);
         } else if (!assignment) {
             // If we call a subrule without an assignment


### PR DESCRIPTION
Prevents creating AstNodes with an empty Cst content.

Also improves on `isDataType` check. The implementation will not identify a ParserRule with no `definition` or with a unresolved RuleCall inside `definition` as a DataType rule.  