### PR TITLE
Add type validation with respect to the hierarchy

### DIFF
--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -6,7 +6,7 @@
 
 import { Grammar } from '../generated/ast';
 import { LangiumDocuments } from '../../workspace/documents';
-import { sortInterfacesTopologically } from './types-util';
+import { addSubTypes, sortInterfacesTopologically } from './types-util';
 import { AstTypes, InterfaceType, isInterfaceType, isUnionType, TypeOption, UnionType } from './type-collector/types';
 import { collectTypeResources } from './type-collector/all-types';
 import { isPrimitiveType } from '../internal-grammar-util';
@@ -97,16 +97,6 @@ function filterInterfaceLikeTypes({ interfaces, unions }: AstTypes): Map<string,
         }
     }
     return nameToType;
-}
-
-function addSubTypes(nameToType: Map<string, TypeOption>) {
-    for (const interfaceType of nameToType.values()) {
-        for (const superTypeName of interfaceType.realSuperTypes) {
-            nameToType.get(superTypeName)
-                ?.subTypes.add(interfaceType.name);
-        }
-    }
-
 }
 
 /**

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -133,3 +133,12 @@ export function sortInterfacesTopologically(interfaces: InterfaceType[]): Interf
     }
     return l.map(e => e.value);
 }
+
+export function addSubTypes(nameToType: Map<string, TypeOption>) {
+    for (const interfaceType of nameToType.values()) {
+        for (const superTypeName of interfaceType.realSuperTypes) {
+            nameToType.get(superTypeName)
+                ?.subTypes.add(interfaceType.name);
+        }
+    }
+}

--- a/packages/langium/src/grammar/validation/types-validator.ts
+++ b/packages/langium/src/grammar/validation/types-validator.ts
@@ -76,7 +76,7 @@ function validateInferredInterface(inferredInterface: InterfaceType, accept: Val
                 accept(
                     'error',
                     `Mixing a cross-reference with other types is not supported. Consider splitting property "${prop.name}" into two or more different properties.`,
-                    { node:  targetNode}
+                    { node: targetNode }
                 );
             }
         }
@@ -183,14 +183,12 @@ function arePropTypesIdentical(a: Property, b: Property): boolean {
     return true;
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
 function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & DeclaredInfo, accept: ValidationAcceptor) {
     const { inferred, declared, declaredNode, inferredNodes } = typeInfo;
     const typeName = declared.name;
 
     const applyErrorToRulesAndActions = (msgPostfix?: string) => (errorMsg: string) =>
-        inferredNodes.forEach(node => accept('error', `${errorMsg}${msgPostfix ? ` ${msgPostfix}` : ''}.`,
+        inferredNodes.forEach(node => accept('error', `${errorMsg.slice(0, -1)}${msgPostfix ? ` ${msgPostfix}` : ''}.`,
             (node?.inferredType) ?
                 <DiagnosticInfo<ast.InferredType, string>>{ node: node?.inferredType, property: 'name' } :
                 <DiagnosticInfo<ast.ParserRule | ast.Action | ast.InferredType, string>>{ node, property: ast.isAction(node) ? 'type' : 'name' }
@@ -228,7 +226,7 @@ function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & Declare
             applyMissingPropErrorToRules
         );
     } else {
-        const errorMessage = `Inferred and declared versions of type ${typeName} both have to be interfaces or unions.`;
+        const errorMessage = `Inferred and declared versions of type '${typeName}' both have to be interfaces or unions.`;
         applyErrorToRulesAndActions()(errorMessage);
         accept('error', errorMessage, { node: declaredNode, property: 'name' });
     }
@@ -315,7 +313,7 @@ function validatePropertiesConsistency(inferred: MultiMap<string, Property>, dec
     for (const [name, expectedProperties] of declared.entriesGroupedByKey()) {
         const foundProperty = inferred.get(name);
         if (foundProperty.length === 0 && !expectedProperties.some(e => e.optional)) {
-            applyErrorToType(`A property '${name}' is expected`);
+            applyErrorToType(`A property '${name}' is expected.`);
         }
     }
 }

--- a/packages/langium/src/grammar/validation/types-validator.ts
+++ b/packages/langium/src/grammar/validation/types-validator.ts
@@ -187,7 +187,8 @@ function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & Declare
     const typeName = declared.name;
 
     const applyErrorToRulesAndActions = (msgPostfix?: string) => (errorMsg: string) =>
-        inferredNodes.forEach(node => accept('error', `${errorMsg.slice(0, -1)}${msgPostfix ? ` ${msgPostfix}` : ''}.`,
+        inferredNodes.forEach(node => accept('error',
+            `${errorMsg[-1] === '.' ? errorMsg.slice(0, -1) : errorMsg}${msgPostfix ? ` ${msgPostfix}` : ''}.`,
             (node?.inferredType) ?
                 <DiagnosticInfo<ast.InferredType, string>>{ node: node?.inferredType, property: 'name' } :
                 <DiagnosticInfo<ast.ParserRule | ast.Action | ast.InferredType, string>>{ node, property: ast.isAction(node) ? 'type' : 'name' }

--- a/packages/langium/src/grammar/validation/validation-resources-collector.ts
+++ b/packages/langium/src/grammar/validation/validation-resources-collector.ts
@@ -8,11 +8,11 @@ import { MultiMap } from '../../utils/collections';
 import { stream } from '../../utils/stream';
 import { LangiumDocuments } from '../../workspace/documents';
 import { AbstractElement, Action, Grammar, Interface, isAction, isAlternatives, isGroup, isUnorderedGroup, ParserRule, Type } from '../generated/ast';
-import { getActionType, getRuleType } from '../internal-grammar-util';
+import { getActionType, getRuleType, isPrimitiveType } from '../internal-grammar-util';
 import { AstResources, collectTypeResources, TypeResources } from '../type-system/type-collector/all-types';
-import { mergeInterfaces, mergeTypesAndInterfaces } from '../type-system/types-util';
-import { Property } from '../type-system/type-collector/types';
-import { TypeToValidationInfo, ValidationResources } from '../workspace/documents';
+import { addSubTypes, mergeInterfaces, mergeTypesAndInterfaces } from '../type-system/types-util';
+import { isUnionType, Property, TypeOption } from '../type-system/type-collector/types';
+import { isDeclared, TypeToValidationInfo, ValidationResources } from '../workspace/documents';
 import { LangiumGrammarServices } from '../langium-grammar-module';
 
 export class LangiumGrammarValidationResourcesCollector {
@@ -24,10 +24,10 @@ export class LangiumGrammarValidationResourcesCollector {
 
     collectValidationResources(grammar: Grammar): ValidationResources {
         const typeResources = collectTypeResources(grammar, this.documents);
-        return {
-            typeToValidationInfo: this.collectValidationInfo(typeResources),
-            typeToSuperProperties: this.collectSuperProperties(typeResources),
-        };
+        const typeToValidationInfo = this.collectValidationInfo(typeResources);
+        const typeToSuperProperties = this.collectSuperProperties(typeResources);
+        const typeToAliases = this.collectSubTypesAndAliases(typeToValidationInfo);
+        return { typeToValidationInfo, typeToSuperProperties, typeToAliases };
     }
 
     private collectValidationInfo({ astResources, inferred, declared }: TypeResources) {
@@ -60,12 +60,42 @@ export class LangiumGrammarValidationResourcesCollector {
         return res;
     }
 
-    private collectSuperProperties({ inferred, declared }: TypeResources) {
+    private collectSuperProperties({ inferred, declared }: TypeResources): Map<string, Property[]> {
         const typeToSuperProperties: Map<string, Property[]> = new Map();
         for (const type of mergeInterfaces(inferred, declared)) {
             typeToSuperProperties.set(type.name, Array.from(type.superProperties.values()));
         }
         return typeToSuperProperties;
+    }
+
+    private collectSubTypesAndAliases(typeToValidationInfo: TypeToValidationInfo): MultiMap<string, string> {
+        const nameToType = stream(typeToValidationInfo.entries())
+            .reduce((acc, [name, info]) => { acc.set(name, isDeclared(info) ? info.declared : info.inferred);  return acc; },
+                new Map<string, TypeOption>()
+            );
+        addSubTypes(nameToType);
+
+        const typeToAliases = new MultiMap<string, string>();
+        const queue = Array.from(nameToType.values()).filter(e => e.realSuperTypes.size === 0);
+        const visited = new Set<TypeOption>();
+        for (const type of queue) {
+            visited.add(type);
+            const subTypes = Array.from(type.subTypes)
+                .map(subType => nameToType.get(subType))
+                .filter(e => e !== undefined) as TypeOption[];
+            const superTypes = typeToAliases.get(type.name);
+            subTypes.forEach(subType => typeToAliases.addAll(subType.name, superTypes.length === 0 ? [type.name] : superTypes));
+            queue.push(...subTypes.filter(e => !visited.has(e)));
+
+            if (isUnionType(type) && subTypes.length === 0) {
+                const primitiveTypes = type.alternatives
+                    .filter(alt => !alt.array && !alt.reference)
+                    .flatMap(alt => alt.types)
+                    .filter(e => isPrimitiveType(e));
+                primitiveTypes.forEach(primType => typeToAliases.add(type.name, primType));
+            }
+        }
+        return typeToAliases;
     }
 }
 

--- a/packages/langium/src/grammar/workspace/documents.ts
+++ b/packages/langium/src/grammar/workspace/documents.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { MultiMap } from '../../utils/collections';
 import { LangiumDocument } from '../../workspace/documents';
 import { Action, Grammar, Interface, ParserRule, Type } from '../generated/ast';
 import { Property, TypeOption } from '../type-system/type-collector/types';
@@ -19,6 +20,7 @@ export interface LangiumGrammarDocument extends LangiumDocument<Grammar> {
 export type ValidationResources = {
     typeToValidationInfo: TypeToValidationInfo,
     typeToSuperProperties: Map<string, Property[]>,
+    typeToAliases: MultiMap<string, string>,
 }
 
 export type TypeToValidationInfo = Map<string, InferredInfo | DeclaredInfo | InferredInfo & DeclaredInfo>;

--- a/packages/langium/src/grammar/workspace/documents.ts
+++ b/packages/langium/src/grammar/workspace/documents.ts
@@ -4,7 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { MultiMap } from '../../utils/collections';
 import { LangiumDocument } from '../../workspace/documents';
 import { Action, Grammar, Interface, ParserRule, Type } from '../generated/ast';
 import { Property, TypeOption } from '../type-system/type-collector/types';
@@ -20,7 +19,7 @@ export interface LangiumGrammarDocument extends LangiumDocument<Grammar> {
 export type ValidationResources = {
     typeToValidationInfo: TypeToValidationInfo,
     typeToSuperProperties: Map<string, Property[]>,
-    typeToAliases: MultiMap<string, string>,
+    typeToAliases: Map<string, Set<string>>,
 }
 
 export type TypeToValidationInfo = Map<string, InferredInfo | DeclaredInfo | InferredInfo & DeclaredInfo>;

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -450,4 +450,34 @@ describe('Property types validation takes in account types hierarchy', () => {
         expect(validation.diagnostics).toStrictEqual([]);
     });
 
+    test('Handling type aliases shouldn\'t disable other validations.', async () => {
+        const validation = await validate(`
+            interface Y {
+                y: Z1
+            }
+            
+            interface Z {
+                name: string
+            }
+            
+            interface Z1 extends Z {
+                z: number
+            }
+            
+            interface Z2 extends Z {
+                a: string
+            }
+            
+            Y returns Y: y=Z2;
+            
+            Z1 returns Z1: z=NUMBER name=ID;
+            Z2 returns Z2: a=ID name=ID;
+
+            terminal ID: /[_a-zA-Z][\\w_]*/;
+            terminal NUMBER returns number: /[0-9]+(\\.[0-9]*)?/;
+        `);
+
+        expect(validation.diagnostics.filter(d => d.severity === DiagnosticSeverity.Error)).toHaveLength(1);
+    });
+
 });

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -394,4 +394,20 @@ describe('Property types validation takes in account types hierarchy', () => {
         expect(validation.diagnostics).toStrictEqual([]);
     });
 
+    // todo: a type can have 2 and more parents
+    // here `X` can be `string` or `XY` and `Y` cab be `number` or `XY
+    // test('Usage of child type with some parents is validated correctly.', async () => {
+    //     const validation = await validate(`
+    //         X returns string: 'X';
+    //         Y returns number: NUMBER;
+    //         QualifiedRef: name=NUMBER;
+    //         XY returns XY: X | Y | QualifiedRef;
+    //         terminal NUMBER returns number: /[0-9]+(\\.[0-9]+)?/;
+
+    //         type XY = string | number | QualifiedRef;
+    //     `);
+
+    //     expect(validation.diagnostics).toStrictEqual([]);
+    // });
+
 });


### PR DESCRIPTION
Closes #823.
Adds `typeToAlias` that maps a type name to its hierarchy root -- a type that doesn't inherit anything. Validation uses this structure to map all types to their roots and compare roots instead of initial types.