### PR TITLE
Internal type split

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -149,7 +149,7 @@ export class ArithmeticsAstReflection extends AbstractAstReflection {
                 return this.isSubtype(AbstractDefinition, supertype);
             }
             case Definition: {
-                return this.isSubtype(Statement, supertype) || this.isSubtype(AbstractDefinition, supertype);
+                return this.isSubtype(AbstractDefinition, supertype) || this.isSubtype(Statement, supertype);
             }
             case Evaluation: {
                 return this.isSubtype(Statement, supertype);

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -588,25 +588,24 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
   "types": [
     {
       "$type": "Type",
-      "typeAlternatives": [
-        {
-          "$type": "AtomType",
-          "refType": {
-            "$ref": "#/rules@2"
+      "name": "AbstractDefinition",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@2"
+            }
           },
-          "isArray": false,
-          "isRef": false
-        },
-        {
-          "$type": "AtomType",
-          "refType": {
-            "$ref": "#/rules@3"
-          },
-          "isArray": false,
-          "isRef": false
-        }
-      ],
-      "name": "AbstractDefinition"
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@3"
+            }
+          }
+        ]
+      }
     }
   ],
   "definesHiddenTokens": false,

--- a/examples/arithmetics/syntaxes/arithmetics.monarch.ts
+++ b/examples/arithmetics/syntaxes/arithmetics.monarch.ts
@@ -4,9 +4,9 @@ export default {
         'def','module'
     ],
     operators: [
-        '-',',',';',':','*','/','+'
+        '*','+',',','-','/',':',';'
     ],
-    symbols:  /-|,|;|:|\(|\)|\*|/|\+/,
+    symbols:  /\(|\)|\*|\+|,|-|/|:|;/,
 
     tokenizer: {
         initial: [

--- a/examples/domainmodel/syntaxes/domainmodel.monarch.ts
+++ b/examples/domainmodel/syntaxes/domainmodel.monarch.ts
@@ -4,9 +4,9 @@ export default {
         'datatype','entity','extends','many','package'
     ],
     operators: [
-        ':','.'
+        '.',':'
     ],
-    symbols:  /:|\.|\{|\}/,
+    symbols:  /\.|:|\{|\}/,
 
     tokenizer: {
         initial: [

--- a/examples/statemachine/syntaxes/statemachine.monarch.ts
+++ b/examples/statemachine/syntaxes/statemachine.monarch.ts
@@ -6,7 +6,7 @@ export default {
     operators: [
         '=>'
     ],
-    symbols:  /\{|\}|=>/,
+    symbols:  /=>|\{|\}/,
 
     tokenizer: {
         initial: [

--- a/packages/langium-cli/src/generator/util.ts
+++ b/packages/langium-cli/src/generator/util.ts
@@ -63,7 +63,7 @@ export function collectKeywords(grammar: Grammar): string[] {
         keywords.add(keyword.value);
     }
 
-    return Array.from(keywords).sort((a, b) => a.localeCompare(b));
+    return Array.from(keywords).sort();
 }
 
 export function getUserInput(text: string): Promise<string> {

--- a/packages/langium/src/grammar/ast-reflection-interpreter.ts
+++ b/packages/langium/src/grammar/ast-reflection-interpreter.ts
@@ -4,13 +4,13 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AstReflection, isAstNode, ReferenceInfo, TypeMandatoryProperty, TypeMetaData } from '../syntax-tree';
+import { AbstractAstReflection, AstReflection, ReferenceInfo, TypeMandatoryProperty, TypeMetaData } from '../syntax-tree';
 import { MultiMap } from '../utils/collections';
 import { LangiumDocuments } from '../workspace/documents';
 import { Grammar, isGrammar } from './generated/ast';
 import { collectAst } from './type-system/ast-collector';
 import { AstTypes, Property } from './type-system/type-collector/types';
-import { collectAllProperties } from './type-system/types-util';
+import { collectTypeHierarchy, findReferenceTypes, hasArrayType, hasBooleanType, mergeTypesAndInterfaces } from './type-system/types-util';
 
 export function interpretAstReflection(astTypes: AstTypes): AstReflection;
 export function interpretAstReflection(grammar: Grammar, documents?: LangiumDocuments): AstReflection;
@@ -24,56 +24,78 @@ export function interpretAstReflection(grammarOrTypes: Grammar | AstTypes, docum
     const allTypes = collectedTypes.interfaces.map(e => e.name).concat(collectedTypes.unions.map(e => e.name));
     const references = buildReferenceTypes(collectedTypes);
     const metaData = buildTypeMetaData(collectedTypes);
-    const superTypeMap = buildSupertypeMap(collectedTypes);
+    const superTypes = collectTypeHierarchy(mergeTypesAndInterfaces(collectedTypes)).superTypes;
 
-    return {
-        getAllTypes() {
-            return allTypes;
-        },
-        getReferenceType(refInfo: ReferenceInfo): string {
-            const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
-            const referenceType = references.get(referenceId);
-            if (referenceType) {
-                return referenceType;
-            }
-            throw new Error('Could not find reference type for ' + referenceId);
-        },
-        getTypeMetaData(type: string): TypeMetaData {
-            return metaData.get(type) ?? {
-                name: type,
-                mandatory: []
-            };
-        },
-        isInstance(node: unknown, type: string): boolean {
-            return isAstNode(node) && this.isSubtype(node.$type, type);
-        },
-        isSubtype(subtype: string, originalSuperType: string): boolean {
-            if (subtype === originalSuperType) {
+    return new InterpretedAstReflection({
+        allTypes,
+        references,
+        metaData,
+        superTypes
+    });
+}
+
+class InterpretedAstReflection extends AbstractAstReflection {
+
+    private readonly allTypes: string[];
+    private readonly references: Map<string, string>;
+    private readonly metaData: Map<string, TypeMetaData>;
+    private readonly superTypes: MultiMap<string, string>;
+
+    constructor(options: {
+        allTypes: string[]
+        references: Map<string, string>
+        metaData: Map<string, TypeMetaData>
+        superTypes: MultiMap<string, string>
+    }) {
+        super();
+        this.allTypes = options.allTypes;
+        this.references = options.references;
+        this.metaData = options.metaData;
+        this.superTypes = options.superTypes;
+    }
+
+    getAllTypes(): string[] {
+        return this.allTypes;
+    }
+
+    getReferenceType(refInfo: ReferenceInfo): string {
+        const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
+        const referenceType = this.references.get(referenceId);
+        if (referenceType) {
+            return referenceType;
+        }
+        throw new Error('Could not find reference type for ' + referenceId);
+    }
+
+    getTypeMetaData(type: string): TypeMetaData {
+        return this.metaData.get(type) ?? {
+            name: type,
+            mandatory: []
+        };
+    }
+
+    protected computeIsSubtype(subtype: string, originalSuperType: string): boolean {
+        const superTypes = this.superTypes.get(subtype);
+        for (const superType of superTypes) {
+            if (this.isSubtype(superType, originalSuperType)) {
                 return true;
             }
-            const superTypes = superTypeMap.get(subtype);
-            for (const superType of superTypes) {
-                if (this.isSubtype(superType, originalSuperType)) {
-                    return true;
-                }
-            }
-            return false;
         }
-    };
+        return false;
+    }
+
 }
 
 function buildReferenceTypes(astTypes: AstTypes): Map<string, string> {
     const references = new MultiMap<string, [string, string]>();
     for (const interfaceType of astTypes.interfaces) {
         for (const property of interfaceType.properties) {
-            for (const propertyAlternative of property.typeAlternatives) {
-                if (propertyAlternative.reference) {
-                    references.add(interfaceType.name, [property.name, propertyAlternative.types[0]]);
-                }
+            for (const referenceType of findReferenceTypes(property.type)) {
+                references.add(interfaceType.name, [property.name, referenceType]);
             }
         }
-        for (const superType of interfaceType.printingSuperTypes) {
-            const superTypeReferences = references.get(superType);
+        for (const superType of interfaceType.interfaceSuperTypes) {
+            const superTypeReferences = references.get(superType.name);
             references.addAll(interfaceType.name, superTypeReferences);
         }
     }
@@ -86,11 +108,10 @@ function buildReferenceTypes(astTypes: AstTypes): Map<string, string> {
 
 function buildTypeMetaData(astTypes: AstTypes): Map<string, TypeMetaData> {
     const map = new Map<string, TypeMetaData>();
-    const allProperties = collectAllProperties(astTypes.interfaces);
     for (const interfaceType of astTypes.interfaces) {
-        const props = allProperties.get(interfaceType.name)!;
-        const arrayProps = props.filter(e => e.typeAlternatives.some(e => e.array));
-        const booleanProps = props.filter(e => e.typeAlternatives.every(e => !e.array && e.types.includes('boolean')));
+        const props = interfaceType.superProperties;
+        const arrayProps = props.filter(e => hasArrayType(e.type));
+        const booleanProps = props.filter(e => !hasArrayType(e.type) && hasBooleanType(e.type));
         if (arrayProps.length > 0 || booleanProps.length > 0) {
             map.set(interfaceType.name, {
                 name: interfaceType.name,
@@ -112,15 +133,4 @@ function buildMandatoryMetaData(arrayProps: Property[], booleanProps: Property[]
         });
     }
     return array;
-}
-
-function buildSupertypeMap(astTypes: AstTypes): MultiMap<string, string> {
-    const map = new MultiMap<string, string>();
-    for (const interfaceType of astTypes.interfaces) {
-        map.addAll(interfaceType.name, interfaceType.realSuperTypes);
-    }
-    for (const unionType of astTypes.unions) {
-        map.addAll(unionType.name, unionType.realSuperTypes);
-    }
-    return map;
 }

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -30,12 +30,20 @@ export function isCondition(item: unknown): item is Condition {
     return reflection.isInstance(item, Condition);
 }
 
-export type FeatureName = string;
+export type FeatureName = 'current' | 'entry' | 'extends' | 'false' | 'fragment' | 'grammar' | 'hidden' | 'import' | 'infer' | 'infers' | 'interface' | 'returns' | 'terminal' | 'true' | 'type' | 'with' | PrimitiveType | string;
 
 export type PrimitiveType = 'Date' | 'bigint' | 'boolean' | 'number' | 'string';
 
+export type TypeDefinition = ArrayType | ReferenceType | SimpleType | UnionType;
+
+export const TypeDefinition = 'TypeDefinition';
+
+export function isTypeDefinition(item: unknown): item is TypeDefinition {
+    return reflection.isInstance(item, TypeDefinition);
+}
+
 export interface AbstractElement extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?'
 }
@@ -46,20 +54,16 @@ export function isAbstractElement(item: unknown): item is AbstractElement {
     return reflection.isInstance(item, AbstractElement);
 }
 
-export interface AtomType extends AstNode {
-    readonly $container: Type | TypeAttribute;
-    readonly $type: 'AtomType';
-    isArray: boolean
-    isRef: boolean
-    keywordType?: Keyword
-    primitiveType?: PrimitiveType
-    refType?: Reference<AbstractType>
+export interface ArrayType extends AstNode {
+    readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
+    readonly $type: 'ArrayType';
+    elementType: TypeDefinition
 }
 
-export const AtomType = 'AtomType';
+export const ArrayType = 'ArrayType';
 
-export function isAtomType(item: unknown): item is AtomType {
-    return reflection.isInstance(item, AtomType);
+export function isArrayType(item: unknown): item is ArrayType {
+    return reflection.isInstance(item, ArrayType);
 }
 
 export interface Conjunction extends AstNode {
@@ -132,7 +136,7 @@ export function isInferredType(item: unknown): item is InferredType {
 }
 
 export interface Interface extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Interface';
     attributes: Array<TypeAttribute>
     name: string
@@ -208,7 +212,7 @@ export function isParameterReference(item: unknown): item is ParameterReference 
 }
 
 export interface ParserRule extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'ParserRule';
     dataType?: PrimitiveType
     definesHiddenTokens: boolean
@@ -229,6 +233,18 @@ export function isParserRule(item: unknown): item is ParserRule {
     return reflection.isInstance(item, ParserRule);
 }
 
+export interface ReferenceType extends AstNode {
+    readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
+    readonly $type: 'ReferenceType';
+    referenceType: TypeDefinition
+}
+
+export const ReferenceType = 'ReferenceType';
+
+export function isReferenceType(item: unknown): item is ReferenceType {
+    return reflection.isInstance(item, ReferenceType);
+}
+
 export interface ReturnType extends AstNode {
     readonly $container: TerminalRule;
     readonly $type: 'ReturnType';
@@ -241,8 +257,22 @@ export function isReturnType(item: unknown): item is ReturnType {
     return reflection.isInstance(item, ReturnType);
 }
 
+export interface SimpleType extends AstNode {
+    readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
+    readonly $type: 'SimpleType';
+    primitiveType?: PrimitiveType
+    stringType?: string
+    typeRef?: Reference<AbstractType>
+}
+
+export const SimpleType = 'SimpleType';
+
+export function isSimpleType(item: unknown): item is SimpleType {
+    return reflection.isInstance(item, SimpleType);
+}
+
 export interface TerminalRule extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalRule';
     definition: AbstractElement
     fragment: boolean
@@ -258,10 +288,10 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
 }
 
 export interface Type extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Type';
     name: string
-    typeAlternatives: Array<AtomType>
+    type: TypeDefinition
 }
 
 export const Type = 'Type';
@@ -275,7 +305,7 @@ export interface TypeAttribute extends AstNode {
     readonly $type: 'TypeAttribute';
     isOptional: boolean
     name: FeatureName
-    typeAlternatives: Array<AtomType>
+    type: TypeDefinition
 }
 
 export const TypeAttribute = 'TypeAttribute';
@@ -284,8 +314,20 @@ export function isTypeAttribute(item: unknown): item is TypeAttribute {
     return reflection.isInstance(item, TypeAttribute);
 }
 
+export interface UnionType extends AstNode {
+    readonly $container: ArrayType | ReferenceType | Type | TypeAttribute | UnionType;
+    readonly $type: 'UnionType';
+    types: Array<TypeDefinition>
+}
+
+export const UnionType = 'UnionType';
+
+export function isUnionType(item: unknown): item is UnionType {
+    return reflection.isInstance(item, UnionType);
+}
+
 export interface Action extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Action';
     feature?: FeatureName
     inferredType?: InferredType
@@ -300,7 +342,7 @@ export function isAction(item: unknown): item is Action {
 }
 
 export interface Alternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Alternatives';
     elements: Array<AbstractElement>
 }
@@ -312,7 +354,7 @@ export function isAlternatives(item: unknown): item is Alternatives {
 }
 
 export interface Assignment extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Assignment';
     feature: FeatureName
     operator: '+=' | '=' | '?='
@@ -326,7 +368,7 @@ export function isAssignment(item: unknown): item is Assignment {
 }
 
 export interface CharacterRange extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'CharacterRange';
     left: Keyword
     right?: Keyword
@@ -339,7 +381,7 @@ export function isCharacterRange(item: unknown): item is CharacterRange {
 }
 
 export interface CrossReference extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'CrossReference';
     deprecatedSyntax: boolean
     terminal?: AbstractElement
@@ -353,7 +395,7 @@ export function isCrossReference(item: unknown): item is CrossReference {
 }
 
 export interface Group extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Group';
     elements: Array<AbstractElement>
     guardCondition?: Condition
@@ -366,7 +408,7 @@ export function isGroup(item: unknown): item is Group {
 }
 
 export interface Keyword extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Keyword';
     value: string
 }
@@ -378,7 +420,7 @@ export function isKeyword(item: unknown): item is Keyword {
 }
 
 export interface NegatedToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'NegatedToken';
     terminal: AbstractElement
 }
@@ -390,7 +432,7 @@ export function isNegatedToken(item: unknown): item is NegatedToken {
 }
 
 export interface RegexToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'RegexToken';
     regex: string
 }
@@ -402,7 +444,7 @@ export function isRegexToken(item: unknown): item is RegexToken {
 }
 
 export interface RuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'RuleCall';
     arguments: Array<NamedArgument>
     rule: Reference<AbstractRule>
@@ -415,7 +457,7 @@ export function isRuleCall(item: unknown): item is RuleCall {
 }
 
 export interface TerminalAlternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalAlternatives';
     elements: Array<AbstractElement>
 }
@@ -427,7 +469,7 @@ export function isTerminalAlternatives(item: unknown): item is TerminalAlternati
 }
 
 export interface TerminalGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalGroup';
     elements: Array<AbstractElement>
 }
@@ -439,7 +481,7 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
 }
 
 export interface TerminalRuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalRuleCall';
     rule: Reference<TerminalRule>
 }
@@ -451,7 +493,7 @@ export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
 }
 
 export interface UnorderedGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'UnorderedGroup';
     elements: Array<AbstractElement>
 }
@@ -463,7 +505,7 @@ export function isUnorderedGroup(item: unknown): item is UnorderedGroup {
 }
 
 export interface UntilToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'UntilToken';
     terminal: AbstractElement
 }
@@ -475,7 +517,7 @@ export function isUntilToken(item: unknown): item is UntilToken {
 }
 
 export interface Wildcard extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Wildcard';
 }
 
@@ -491,8 +533,8 @@ export interface LangiumGrammarAstType {
     AbstractType: AbstractType
     Action: Action
     Alternatives: Alternatives
+    ArrayType: ArrayType
     Assignment: Assignment
-    AtomType: AtomType
     CharacterRange: CharacterRange
     Condition: Condition
     Conjunction: Conjunction
@@ -511,15 +553,19 @@ export interface LangiumGrammarAstType {
     Parameter: Parameter
     ParameterReference: ParameterReference
     ParserRule: ParserRule
+    ReferenceType: ReferenceType
     RegexToken: RegexToken
     ReturnType: ReturnType
     RuleCall: RuleCall
+    SimpleType: SimpleType
     TerminalAlternatives: TerminalAlternatives
     TerminalGroup: TerminalGroup
     TerminalRule: TerminalRule
     TerminalRuleCall: TerminalRuleCall
     Type: Type
     TypeAttribute: TypeAttribute
+    TypeDefinition: TypeDefinition
+    UnionType: UnionType
     UnorderedGroup: UnorderedGroup
     UntilToken: UntilToken
     Wildcard: Wildcard
@@ -528,28 +574,11 @@ export interface LangiumGrammarAstType {
 export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'Assignment', 'AtomType', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'Grammar', 'GrammarImport', 'Group', 'InferredType', 'Interface', 'Keyword', 'LiteralCondition', 'NamedArgument', 'NegatedToken', 'Negation', 'Parameter', 'ParameterReference', 'ParserRule', 'RegexToken', 'ReturnType', 'RuleCall', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'UnorderedGroup', 'UntilToken', 'Wildcard'];
+        return ['AbstractElement', 'AbstractRule', 'AbstractType', 'Action', 'Alternatives', 'ArrayType', 'Assignment', 'CharacterRange', 'Condition', 'Conjunction', 'CrossReference', 'Disjunction', 'Grammar', 'GrammarImport', 'Group', 'InferredType', 'Interface', 'Keyword', 'LiteralCondition', 'NamedArgument', 'NegatedToken', 'Negation', 'Parameter', 'ParameterReference', 'ParserRule', 'ReferenceType', 'RegexToken', 'ReturnType', 'RuleCall', 'SimpleType', 'TerminalAlternatives', 'TerminalGroup', 'TerminalRule', 'TerminalRuleCall', 'Type', 'TypeAttribute', 'TypeDefinition', 'UnionType', 'UnorderedGroup', 'UntilToken', 'Wildcard'];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
         switch (subtype) {
-            case Conjunction:
-            case Disjunction:
-            case LiteralCondition:
-            case Negation:
-            case ParameterReference: {
-                return this.isSubtype(Condition, supertype);
-            }
-            case Interface:
-            case Type: {
-                return this.isSubtype(AbstractType, supertype);
-            }
-            case ParserRule: {
-                return this.isSubtype(AbstractRule, supertype) || this.isSubtype(AbstractType, supertype);
-            }
-            case TerminalRule: {
-                return this.isSubtype(AbstractRule, supertype);
-            }
             case Action: {
                 return this.isSubtype(AbstractElement, supertype) || this.isSubtype(AbstractType, supertype);
             }
@@ -570,6 +599,29 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
             case Wildcard: {
                 return this.isSubtype(AbstractElement, supertype);
             }
+            case ArrayType:
+            case ReferenceType:
+            case SimpleType:
+            case UnionType: {
+                return this.isSubtype(TypeDefinition, supertype);
+            }
+            case Conjunction:
+            case Disjunction:
+            case LiteralCondition:
+            case Negation:
+            case ParameterReference: {
+                return this.isSubtype(Condition, supertype);
+            }
+            case Interface:
+            case Type: {
+                return this.isSubtype(AbstractType, supertype);
+            }
+            case ParserRule: {
+                return this.isSubtype(AbstractRule, supertype) || this.isSubtype(AbstractType, supertype);
+            }
+            case TerminalRule: {
+                return this.isSubtype(AbstractRule, supertype);
+            }
             default: {
                 return false;
             }
@@ -580,10 +632,10 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
         const referenceId = `${refInfo.container.$type}:${refInfo.property}`;
         switch (referenceId) {
             case 'Action:type':
-            case 'AtomType:refType':
             case 'CrossReference:type':
             case 'Interface:superTypes':
-            case 'ParserRule:returnType': {
+            case 'ParserRule:returnType':
+            case 'SimpleType:typeRef': {
                 return AbstractType;
             }
             case 'Grammar:hiddenTokens':
@@ -609,15 +661,6 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
-            case 'AtomType': {
-                return {
-                    name: 'AtomType',
-                    mandatory: [
-                        { name: 'isArray', type: 'boolean' },
-                        { name: 'isRef', type: 'boolean' }
-                    ]
-                };
-            }
             case 'Grammar': {
                 return {
                     name: 'Grammar',
@@ -680,20 +723,19 @@ export class LangiumGrammarAstReflection extends AbstractAstReflection {
                     ]
                 };
             }
-            case 'Type': {
-                return {
-                    name: 'Type',
-                    mandatory: [
-                        { name: 'typeAlternatives', type: 'array' }
-                    ]
-                };
-            }
             case 'TypeAttribute': {
                 return {
                     name: 'TypeAttribute',
                     mandatory: [
-                        { name: 'isOptional', type: 'boolean' },
-                        { name: 'typeAlternatives', type: 'array' }
+                        { name: 'isOptional', type: 'boolean' }
+                    ]
+                };
+            }
+            case 'UnionType': {
+                return {
+                    name: 'UnionType',
+                    mandatory: [
+                        { name: 'types', type: 'array' }
                     ]
                 };
             }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@56"
+                    "$ref": "#/rules@59"
                   },
                   "arguments": []
                 }
@@ -62,7 +62,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@56"
+                          "$ref": "#/rules@59"
                         },
                         "arguments": []
                       },
@@ -88,7 +88,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@56"
+                              "$ref": "#/rules@59"
                             },
                             "arguments": []
                           },
@@ -127,12 +127,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "#/rules@8"
+                            "$ref": "#/rules@11"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@56"
+                              "$ref": "#/rules@59"
                             },
                             "arguments": []
                           },
@@ -153,12 +153,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                             "terminal": {
                               "$type": "CrossReference",
                               "type": {
-                                "$ref": "#/rules@8"
+                                "$ref": "#/rules@11"
                               },
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$ref": "#/rules@56"
+                                  "$ref": "#/rules@59"
                                 },
                                 "arguments": []
                               },
@@ -188,7 +188,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@9"
+                "$ref": "#/rules@12"
               },
               "arguments": []
             },
@@ -204,7 +204,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@8"
+                    "$ref": "#/rules@11"
                   },
                   "arguments": []
                 }
@@ -228,7 +228,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@7"
+                    "$ref": "#/rules@10"
                   },
                   "arguments": []
                 }
@@ -261,7 +261,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@56"
+                "$ref": "#/rules@59"
               },
               "arguments": []
             }
@@ -282,6 +282,13 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "type": {
                     "$ref": "#/types@0"
                   },
+                  "terminal": {
+                    "$type": "RuleCall",
+                    "rule": {
+                      "$ref": "#/rules@59"
+                    },
+                    "arguments": []
+                  },
                   "deprecatedSyntax": false
                 }
               },
@@ -300,6 +307,13 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "$type": "CrossReference",
                       "type": {
                         "$ref": "#/types@0"
+                      },
+                      "terminal": {
+                        "$type": "RuleCall",
+                        "rule": {
+                          "$ref": "#/rules@59"
+                        },
+                        "arguments": []
                       },
                       "deprecatedSyntax": false
                     }
@@ -380,7 +394,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@55"
+                "$ref": "#/rules@58"
               },
               "arguments": []
             }
@@ -400,11 +414,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "value": ":"
           },
           {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@4"
-            },
-            "arguments": []
+            "$type": "Assignment",
+            "feature": "type",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@4"
+              },
+              "arguments": []
+            }
           },
           {
             "$type": "Keyword",
@@ -422,69 +441,61 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
     },
     {
       "$type": "ParserRule",
-      "name": "TypeAlternatives",
-      "fragment": true,
+      "name": "TypeDefinition",
       "definition": {
-        "$type": "Group",
-        "elements": [
-          {
-            "$type": "Assignment",
-            "feature": "typeAlternatives",
-            "operator": "+=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@5"
-              },
-              "arguments": []
-            }
-          },
-          {
-            "$type": "Group",
-            "elements": [
-              {
-                "$type": "Keyword",
-                "value": "|"
-              },
-              {
-                "$type": "Assignment",
-                "feature": "typeAlternatives",
-                "operator": "+=",
-                "terminal": {
-                  "$type": "RuleCall",
-                  "rule": {
-                    "$ref": "#/rules@5"
-                  },
-                  "arguments": []
-                }
-              }
-            ],
-            "cardinality": "*"
-          }
-        ]
+        "$type": "RuleCall",
+        "rule": {
+          "$ref": "#/rules@5"
+        },
+        "arguments": []
       },
       "definesHiddenTokens": false,
       "entry": false,
+      "fragment": false,
       "hiddenTokens": [],
       "parameters": [],
       "wildcard": false
     },
     {
       "$type": "ParserRule",
-      "name": "AtomType",
+      "name": "UnionType",
+      "inferredType": {
+        "$type": "InferredType",
+        "name": "TypeDefinition"
+      },
       "definition": {
-        "$type": "Alternatives",
+        "$type": "Group",
         "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@6"
+            },
+            "arguments": []
+          },
           {
             "$type": "Group",
             "elements": [
               {
-                "$type": "Alternatives",
+                "$type": "Action",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "UnionType"
+                },
+                "feature": "types",
+                "operator": "+="
+              },
+              {
+                "$type": "Group",
                 "elements": [
                   {
+                    "$type": "Keyword",
+                    "value": "|"
+                  },
+                  {
                     "$type": "Assignment",
-                    "feature": "primitiveType",
-                    "operator": "=",
+                    "feature": "types",
+                    "operator": "+=",
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
@@ -492,59 +503,214 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       },
                       "arguments": []
                     }
-                  },
-                  {
-                    "$type": "Group",
-                    "elements": [
-                      {
-                        "$type": "Assignment",
-                        "feature": "isRef",
-                        "operator": "?=",
-                        "terminal": {
-                          "$type": "Keyword",
-                          "value": "@"
-                        },
-                        "cardinality": "?"
-                      },
-                      {
-                        "$type": "Assignment",
-                        "feature": "refType",
-                        "operator": "=",
-                        "terminal": {
-                          "$type": "CrossReference",
-                          "type": {
-                            "$ref": "#/types@0"
-                          },
-                          "deprecatedSyntax": false
-                        }
-                      }
-                    ]
                   }
-                ]
+                ],
+                "cardinality": "+"
+              }
+            ],
+            "cardinality": "?"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "ArrayType",
+      "inferredType": {
+        "$type": "InferredType",
+        "name": "TypeDefinition"
+      },
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@7"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Action",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "ArrayType"
+                },
+                "feature": "elementType",
+                "operator": "="
+              },
+              {
+                "$type": "Keyword",
+                "value": "["
+              },
+              {
+                "$type": "Keyword",
+                "value": "]"
+              }
+            ],
+            "cardinality": "?"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "ReferenceType",
+      "inferredType": {
+        "$type": "InferredType",
+        "name": "TypeDefinition"
+      },
+      "definition": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@8"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Action",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "ReferenceType"
+                }
+              },
+              {
+                "$type": "Keyword",
+                "value": "@"
               },
               {
                 "$type": "Assignment",
-                "feature": "isArray",
-                "operator": "?=",
+                "feature": "referenceType",
+                "operator": "=",
                 "terminal": {
-                  "$type": "Keyword",
-                  "value": "[]"
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@8"
+                  },
+                  "arguments": []
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "SimpleType",
+      "inferredType": {
+        "$type": "InferredType",
+        "name": "TypeDefinition"
+      },
+      "definition": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "("
+              },
+              {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@4"
                 },
-                "cardinality": "?"
+                "arguments": []
+              },
+              {
+                "$type": "Keyword",
+                "value": ")"
               }
             ]
           },
           {
-            "$type": "Assignment",
-            "feature": "keywordType",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@22"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Action",
+                "inferredType": {
+                  "$type": "InferredType",
+                  "name": "SimpleType"
+                }
               },
-              "arguments": []
-            }
+              {
+                "$type": "Alternatives",
+                "elements": [
+                  {
+                    "$type": "Assignment",
+                    "feature": "typeRef",
+                    "operator": "=",
+                    "terminal": {
+                      "$type": "CrossReference",
+                      "type": {
+                        "$ref": "#/types@0"
+                      },
+                      "terminal": {
+                        "$type": "RuleCall",
+                        "rule": {
+                          "$ref": "#/rules@59"
+                        },
+                        "arguments": []
+                      },
+                      "deprecatedSyntax": false
+                    }
+                  },
+                  {
+                    "$type": "Assignment",
+                    "feature": "primitiveType",
+                    "operator": "=",
+                    "terminal": {
+                      "$type": "RuleCall",
+                      "rule": {
+                        "$ref": "#/rules@9"
+                      },
+                      "arguments": []
+                    }
+                  },
+                  {
+                    "$type": "Assignment",
+                    "feature": "stringType",
+                    "operator": "=",
+                    "terminal": {
+                      "$type": "RuleCall",
+                      "rule": {
+                        "$ref": "#/rules@60"
+                      },
+                      "arguments": []
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -608,7 +774,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@56"
+                "$ref": "#/rules@59"
               },
               "arguments": []
             }
@@ -618,11 +784,16 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "value": "="
           },
           {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@4"
-            },
-            "arguments": []
+            "$type": "Assignment",
+            "feature": "type",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@4"
+              },
+              "arguments": []
+            }
           },
           {
             "$type": "Keyword",
@@ -647,14 +818,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@10"
+              "$ref": "#/rules@13"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@43"
+              "$ref": "#/rules@46"
             },
             "arguments": []
           }
@@ -684,7 +855,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@60"
               },
               "arguments": []
             }
@@ -736,7 +907,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@12"
+              "$ref": "#/rules@15"
             },
             "arguments": []
           },
@@ -774,7 +945,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@56"
+                              "$ref": "#/rules@59"
                             },
                             "arguments": []
                           },
@@ -788,7 +959,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@6"
+                            "$ref": "#/rules@9"
                           },
                           "arguments": []
                         }
@@ -804,7 +975,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@11"
+                    "$ref": "#/rules@14"
                   },
                   "arguments": [
                     {
@@ -847,12 +1018,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "#/rules@8"
+                        "$ref": "#/rules@11"
                       },
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@56"
+                          "$ref": "#/rules@59"
                         },
                         "arguments": []
                       },
@@ -873,12 +1044,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "#/rules@8"
+                            "$ref": "#/rules@11"
                           },
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@56"
+                              "$ref": "#/rules@59"
                             },
                             "arguments": []
                           },
@@ -909,7 +1080,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@14"
+                "$ref": "#/rules@17"
               },
               "arguments": []
             }
@@ -947,7 +1118,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "guardCondition": {
                   "$type": "ParameterReference",
                   "parameter": {
-                    "$ref": "#/rules@11/parameters@0"
+                    "$ref": "#/rules@14/parameters@0"
                   }
                 },
                 "elements": [
@@ -964,7 +1135,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "value": {
                     "$type": "ParameterReference",
                     "parameter": {
-                      "$ref": "#/rules@11/parameters@0"
+                      "$ref": "#/rules@14/parameters@0"
                     }
                   }
                 },
@@ -984,7 +1155,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@56"
+                "$ref": "#/rules@59"
               },
               "arguments": []
             }
@@ -1011,7 +1182,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@56"
+                "$ref": "#/rules@59"
               },
               "arguments": []
             }
@@ -1033,7 +1204,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@13"
+                        "$ref": "#/rules@16"
                       },
                       "arguments": []
                     }
@@ -1052,7 +1223,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@13"
+                            "$ref": "#/rules@16"
                           },
                           "arguments": []
                         }
@@ -1088,7 +1259,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@56"
+            "$ref": "#/rules@59"
           },
           "arguments": []
         }
@@ -1113,7 +1284,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@18"
             },
             "arguments": []
           },
@@ -1143,7 +1314,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@15"
+                        "$ref": "#/rules@18"
                       },
                       "arguments": []
                     }
@@ -1176,7 +1347,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@16"
+              "$ref": "#/rules@19"
             },
             "arguments": []
           },
@@ -1201,7 +1372,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@26"
+                    "$ref": "#/rules@29"
                   },
                   "arguments": []
                 }
@@ -1217,7 +1388,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@18"
+                    "$ref": "#/rules@21"
                   },
                   "arguments": []
                 },
@@ -1247,7 +1418,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@17"
+              "$ref": "#/rules@20"
             },
             "arguments": []
           },
@@ -1277,7 +1448,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@17"
+                        "$ref": "#/rules@20"
                       },
                       "arguments": []
                     }
@@ -1310,7 +1481,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@18"
+              "$ref": "#/rules@21"
             },
             "arguments": []
           },
@@ -1333,7 +1504,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@18"
+                    "$ref": "#/rules@21"
                   },
                   "arguments": []
                 },
@@ -1364,14 +1535,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@19"
+              "$ref": "#/rules@22"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@20"
+              "$ref": "#/rules@23"
             },
             "arguments": []
           }
@@ -1400,14 +1571,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@34"
+                  "$ref": "#/rules@37"
                 },
                 "arguments": []
               },
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@21"
+                  "$ref": "#/rules@24"
                 },
                 "arguments": []
               }
@@ -1481,7 +1652,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@56"
+                      "$ref": "#/rules@59"
                     },
                     "arguments": []
                   },
@@ -1495,7 +1666,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@11"
+                    "$ref": "#/rules@14"
                   },
                   "arguments": [
                     {
@@ -1525,7 +1696,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@55"
+                    "$ref": "#/rules@58"
                   },
                   "arguments": []
                 }
@@ -1581,42 +1752,42 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@22"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@23"
+              "$ref": "#/rules@26"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@40"
+              "$ref": "#/rules@43"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@32"
+              "$ref": "#/rules@35"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@33"
+              "$ref": "#/rules@36"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@41"
+              "$ref": "#/rules@44"
             },
             "arguments": []
           }
@@ -1639,7 +1810,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@57"
+            "$ref": "#/rules@60"
           },
           "arguments": []
         }
@@ -1664,12 +1835,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@8"
+                "$ref": "#/rules@11"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@56"
+                  "$ref": "#/rules@59"
                 },
                 "arguments": []
               },
@@ -1690,7 +1861,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@24"
+                    "$ref": "#/rules@27"
                   },
                   "arguments": []
                 }
@@ -1709,7 +1880,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@24"
+                        "$ref": "#/rules@27"
                       },
                       "arguments": []
                     }
@@ -1749,12 +1920,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/rules@13"
+                    "$ref": "#/rules@16"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@56"
+                      "$ref": "#/rules@59"
                     },
                     "arguments": []
                   },
@@ -1780,7 +1951,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@26"
+                "$ref": "#/rules@29"
               },
               "arguments": []
             }
@@ -1835,7 +2006,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@27"
+              "$ref": "#/rules@30"
             },
             "arguments": []
           },
@@ -1862,7 +2033,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@27"
+                    "$ref": "#/rules@30"
                   },
                   "arguments": []
                 }
@@ -1892,7 +2063,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@28"
+              "$ref": "#/rules@31"
             },
             "arguments": []
           },
@@ -1919,7 +2090,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@28"
+                    "$ref": "#/rules@31"
                   },
                   "arguments": []
                 }
@@ -1949,7 +2120,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@29"
+              "$ref": "#/rules@32"
             },
             "arguments": []
           },
@@ -1974,7 +2145,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@28"
+                    "$ref": "#/rules@31"
                   },
                   "arguments": []
                 }
@@ -2003,21 +2174,21 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@31"
+              "$ref": "#/rules@34"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@30"
+              "$ref": "#/rules@33"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@25"
+              "$ref": "#/rules@28"
             },
             "arguments": []
           }
@@ -2047,7 +2218,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@26"
+              "$ref": "#/rules@29"
             },
             "arguments": []
           },
@@ -2074,12 +2245,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/rules@13"
+            "$ref": "#/rules@16"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@56"
+              "$ref": "#/rules@59"
             },
             "arguments": []
           },
@@ -2123,7 +2294,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@60"
               },
               "arguments": []
             }
@@ -2167,12 +2338,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@8"
+                "$ref": "#/rules@11"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@56"
+                  "$ref": "#/rules@59"
                 },
                 "arguments": []
               },
@@ -2193,7 +2364,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@24"
+                    "$ref": "#/rules@27"
                   },
                   "arguments": []
                 }
@@ -2212,7 +2383,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@24"
+                        "$ref": "#/rules@27"
                       },
                       "arguments": []
                     }
@@ -2274,7 +2445,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@55"
+                "$ref": "#/rules@58"
               },
               "arguments": []
             }
@@ -2308,7 +2479,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@35"
+                "$ref": "#/rules@38"
               },
               "arguments": []
             }
@@ -2335,28 +2506,28 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@22"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@23"
+              "$ref": "#/rules@26"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@36"
+              "$ref": "#/rules@39"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@38"
+              "$ref": "#/rules@41"
             },
             "arguments": []
           }
@@ -2386,7 +2557,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@37"
+              "$ref": "#/rules@40"
             },
             "arguments": []
           },
@@ -2416,7 +2587,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@35"
+              "$ref": "#/rules@38"
             },
             "arguments": []
           },
@@ -2446,7 +2617,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@35"
+                        "$ref": "#/rules@38"
                       },
                       "arguments": []
                     }
@@ -2527,7 +2698,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@39"
+                    "$ref": "#/rules@42"
                   },
                   "arguments": []
                 }
@@ -2561,14 +2732,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@22"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@23"
+              "$ref": "#/rules@26"
             },
             "arguments": []
           }
@@ -2598,7 +2769,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@14"
+              "$ref": "#/rules@17"
             },
             "arguments": []
           },
@@ -2649,7 +2820,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@14"
+                "$ref": "#/rules@17"
               },
               "arguments": []
             }
@@ -2680,14 +2851,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@6"
+                "$ref": "#/rules@9"
               },
               "arguments": []
             },
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@56"
+                "$ref": "#/rules@59"
               },
               "arguments": []
             }
@@ -2743,7 +2914,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@56"
+                        "$ref": "#/rules@59"
                       },
                       "arguments": []
                     }
@@ -2760,7 +2931,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@56"
+                        "$ref": "#/rules@59"
                       },
                       "arguments": []
                     }
@@ -2779,7 +2950,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                         "terminal": {
                           "$type": "RuleCall",
                           "rule": {
-                            "$ref": "#/rules@42"
+                            "$ref": "#/rules@45"
                           },
                           "arguments": []
                         }
@@ -2802,7 +2973,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@44"
+                "$ref": "#/rules@47"
               },
               "arguments": []
             }
@@ -2833,7 +3004,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@45"
+              "$ref": "#/rules@48"
             },
             "arguments": []
           },
@@ -2860,7 +3031,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@45"
+                    "$ref": "#/rules@48"
                   },
                   "arguments": []
                 }
@@ -2890,7 +3061,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@46"
+              "$ref": "#/rules@49"
             },
             "arguments": []
           },
@@ -2913,7 +3084,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@46"
+                    "$ref": "#/rules@49"
                   },
                   "arguments": []
                 },
@@ -2944,7 +3115,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@47"
+              "$ref": "#/rules@50"
             },
             "arguments": []
           },
@@ -2993,35 +3164,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@54"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@49"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@48"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@50"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@51"
+              "$ref": "#/rules@57"
             },
             "arguments": []
           },
@@ -3035,7 +3178,35 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
+              "$ref": "#/rules@51"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
               "$ref": "#/rules@53"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@54"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@55"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@56"
             },
             "arguments": []
           }
@@ -3065,7 +3236,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@44"
+              "$ref": "#/rules@47"
             },
             "arguments": []
           },
@@ -3106,12 +3277,12 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@43"
+                "$ref": "#/rules@46"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@56"
+                  "$ref": "#/rules@59"
                 },
                 "arguments": []
               },
@@ -3155,7 +3326,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@47"
+                "$ref": "#/rules@50"
               },
               "arguments": []
             }
@@ -3197,7 +3368,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@47"
+                "$ref": "#/rules@50"
               },
               "arguments": []
             }
@@ -3235,7 +3406,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@58"
+                "$ref": "#/rules@61"
               },
               "arguments": []
             }
@@ -3303,7 +3474,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@22"
+                "$ref": "#/rules@25"
               },
               "arguments": []
             }
@@ -3322,7 +3493,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@22"
+                    "$ref": "#/rules@25"
                   },
                   "arguments": []
                 }
@@ -3413,14 +3584,14 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@6"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@56"
+              "$ref": "#/rules@59"
             },
             "arguments": []
           }
@@ -3501,41 +3672,36 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
   "types": [
     {
       "$type": "Type",
-      "typeAlternatives": [
-        {
-          "$type": "AtomType",
-          "refType": {
-            "$ref": "#/rules@1"
+      "name": "AbstractType",
+      "type": {
+        "$type": "UnionType",
+        "types": [
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@1"
+            }
           },
-          "isArray": false,
-          "isRef": false
-        },
-        {
-          "$type": "AtomType",
-          "refType": {
-            "$ref": "#/rules@7"
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@10"
+            }
           },
-          "isArray": false,
-          "isRef": false
-        },
-        {
-          "$type": "AtomType",
-          "refType": {
-            "$ref": "#/rules@20/definition/elements@0"
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@23/definition/elements@0"
+            }
           },
-          "isArray": false,
-          "isRef": false
-        },
-        {
-          "$type": "AtomType",
-          "refType": {
-            "$ref": "#/rules@10"
-          },
-          "isArray": false,
-          "isRef": false
-        }
-      ],
-      "name": "AbstractType"
+          {
+            "$type": "SimpleType",
+            "typeRef": {
+              "$ref": "#/rules@13"
+            }
+          }
+        ]
+      }
     }
   ],
   "definesHiddenTokens": false,

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -97,11 +97,14 @@ export function getTypeName(type: ast.AbstractType | ast.InferredType): string {
     throw new TypeResolutionError('Cannot get name of Unknown Type', type.$cstNode);
 }
 
-export function getTypeNameWithoutError(type: ast.AbstractType | ast.InferredType): string {
+export function getTypeNameWithoutError(type?: ast.AbstractType | ast.InferredType): string | undefined {
+    if (!type) {
+        return undefined;
+    }
     try {
         return getTypeName(type);
     } catch {
-        return 'never';
+        return undefined;
     }
 }
 

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -15,20 +15,30 @@ entry Grammar:
 
 Interface:
     'interface' name=ID
-    ('extends' superTypes+=[AbstractType] (',' superTypes+=[AbstractType])*)?
+    ('extends' superTypes+=[AbstractType:ID] (',' superTypes+=[AbstractType:ID])*)?
     SchemaType;
 
 fragment SchemaType:
     '{' attributes+=TypeAttribute* '}' ';'?;
 
 TypeAttribute:
-    name=FeatureName (isOptional?='?')? ':' TypeAlternatives ';'?;
+    name=FeatureName (isOptional?='?')? ':' type=TypeDefinition ';'?;
 
-fragment TypeAlternatives:
-    typeAlternatives+=AtomType ('|' typeAlternatives+=AtomType)*;
+TypeDefinition: UnionType;
 
-AtomType:
-    (primitiveType=PrimitiveType | isRef?='@'? refType=[AbstractType]) isArray?='[]'? | keywordType=Keyword;
+UnionType infers TypeDefinition:
+    ArrayType ({infer UnionType.types+=current} ('|' types+=ArrayType)+)?;
+
+ArrayType infers TypeDefinition:
+    ReferenceType ({infer ArrayType.elementType=current} '[' ']')? ;
+
+ReferenceType infers TypeDefinition:
+    SimpleType |
+    {infer ReferenceType} '@' referenceType=SimpleType;
+
+SimpleType infers TypeDefinition:
+    '(' TypeDefinition ')' |
+    {infer SimpleType} (typeRef=[AbstractType:ID] | primitiveType=PrimitiveType | stringType=STRING);
 
 PrimitiveType returns string:
     'string' | 'number' | 'boolean' | 'Date' | 'bigint';
@@ -36,7 +46,7 @@ PrimitiveType returns string:
 type AbstractType = Interface | Type | Action | ParserRule;
 
 Type:
-    'type' name=ID '=' TypeAlternatives ';'?;
+    'type' name=ID '=' type=TypeDefinition ';'?;
 
 AbstractRule:
     ParserRule | TerminalRule;

--- a/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
+++ b/packages/langium/src/grammar/lsp/grammar-semantic-tokens.ts
@@ -7,7 +7,7 @@
 import { SemanticTokenTypes } from 'vscode-languageserver';
 import { AstNode } from '../../syntax-tree';
 import { AbstractSemanticTokenProvider, SemanticTokenAcceptor } from '../../lsp/semantic-token-provider';
-import { isAction, isAssignment, isAtomType, isParameter, isParameterReference, isReturnType, isRuleCall, isTypeAttribute } from '../generated/ast';
+import { isAction, isAssignment, isParameter, isParameterReference, isReturnType, isRuleCall, isSimpleType, isTypeAttribute } from '../generated/ast';
 
 export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenProvider {
 
@@ -32,11 +32,11 @@ export class LangiumGrammarSemanticTokenProvider extends AbstractSemanticTokenPr
                 property: 'name',
                 type: SemanticTokenTypes.type
             });
-        } else if (isAtomType(node)) {
-            if (node.primitiveType || node.refType) {
+        } else if (isSimpleType(node)) {
+            if (node.primitiveType || node.typeRef) {
                 acceptor({
                     node,
-                    property: node.primitiveType ? 'primitiveType' : 'refType',
+                    property: node.primitiveType ? 'primitiveType' : 'typeRef',
                     type: SemanticTokenTypes.type
                 });
             }

--- a/packages/langium/src/grammar/type-system/type-collector/plain-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/plain-types.ts
@@ -1,0 +1,236 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { Action, Assignment, TypeAttribute } from '../../generated/ast';
+import { AstTypes, InterfaceType, Property, PropertyType, UnionType } from './types';
+
+export interface PlainAstTypes {
+    interfaces: PlainInterface[];
+    unions: PlainUnion[];
+}
+
+export type PlainType = PlainInterface | PlainUnion;
+
+export interface PlainInterface {
+    name: string;
+    superTypes: Set<string>;
+    subTypes: Set<string>;
+    properties: PlainProperty[];
+    declared: boolean;
+    abstract: boolean;
+}
+
+export function isPlainInterface(type: PlainType): type is PlainInterface {
+    return !isPlainUnion(type);
+}
+
+export interface PlainUnion {
+    name: string;
+    superTypes: Set<string>;
+    subTypes: Set<string>;
+    type: PlainPropertyType;
+    reflection: boolean;
+    declared: boolean;
+}
+
+export function isPlainUnion(type: PlainType): type is PlainUnion {
+    return 'type' in type;
+}
+
+export interface PlainProperty {
+    name: string;
+    optional: boolean;
+    astNodes: Set<Assignment | Action | TypeAttribute>;
+    type: PlainPropertyType;
+}
+
+export type PlainPropertyType =
+    | PlainReferenceType
+    | PlainArrayType
+    | PlainPropertyUnion
+    | PlainValueType
+    | PlainPrimitiveType
+    | PlainStringType;
+
+export interface PlainReferenceType {
+    referenceType: PlainPropertyType;
+}
+
+export function isPlainReferenceType(propertyType: PlainPropertyType): propertyType is PlainReferenceType {
+    return 'referenceType' in propertyType;
+}
+
+export interface PlainArrayType {
+    elementType: PlainPropertyType;
+}
+
+export function isPlainArrayType(propertyType: PlainPropertyType): propertyType is PlainArrayType {
+    return 'elementType' in propertyType;
+}
+
+export interface PlainPropertyUnion {
+    types: PlainPropertyType[];
+}
+
+export function isPlainPropertyUnion(propertyType: PlainPropertyType): propertyType is PlainPropertyUnion {
+    return 'types' in propertyType;
+}
+
+export interface PlainValueType {
+    value: string;
+}
+
+export function isPlainValueType(propertyType: PlainPropertyType): propertyType is PlainValueType {
+    return 'value' in propertyType;
+}
+
+export interface PlainPrimitiveType {
+    primitive: string;
+}
+
+export function isPlainPrimitiveType(propertyType: PlainPropertyType): propertyType is PlainPrimitiveType {
+    return 'primitive' in propertyType;
+}
+
+export interface PlainStringType {
+    string: string;
+}
+
+export function isPlainStringType(propertyType: PlainPropertyType): propertyType is PlainStringType {
+    return 'string' in propertyType;
+}
+
+export function plainToTypes(plain: PlainAstTypes): AstTypes {
+    const interfaceTypes = new Map<string, InterfaceType>();
+    const unionTypes = new Map<string, UnionType>();
+    for (const interfaceValue of plain.interfaces) {
+        const type = new InterfaceType(interfaceValue.name, interfaceValue.declared, interfaceValue.abstract);
+        interfaceTypes.set(interfaceValue.name, type);
+    }
+    for (const unionValue of plain.unions) {
+        const type = new UnionType(unionValue.name, {
+            reflection: unionValue.reflection,
+            declared: unionValue.declared
+        });
+        unionTypes.set(unionValue.name, type);
+    }
+    for (const interfaceValue of plain.interfaces) {
+        const type = interfaceTypes.get(interfaceValue.name)!;
+        for (const superTypeName of interfaceValue.superTypes) {
+            const superType = interfaceTypes.get(superTypeName) || unionTypes.get(superTypeName);
+            if (superType) {
+                type.superTypes.add(superType);
+            }
+        }
+        for (const subTypeName of interfaceValue.subTypes) {
+            const subType = interfaceTypes.get(subTypeName) || unionTypes.get(subTypeName);
+            if (subType) {
+                type.subTypes.add(subType);
+            }
+        }
+        for (const property of interfaceValue.properties) {
+            const prop = plainToProperty(property, interfaceTypes, unionTypes);
+            type.properties.push(prop);
+        }
+    }
+    for (const unionValue of plain.unions) {
+        const type = unionTypes.get(unionValue.name)!;
+        type.type = plainToPropertyType(unionValue.type, type, interfaceTypes, unionTypes);
+    }
+    return {
+        interfaces: Array.from(interfaceTypes.values()),
+        unions: Array.from(unionTypes.values())
+    };
+}
+
+function plainToProperty(property: PlainProperty, interfaces: Map<string, InterfaceType>, unions: Map<string, UnionType>): Property {
+    return {
+        name: property.name,
+        optional: property.optional,
+        astNodes: property.astNodes,
+        type: plainToPropertyType(property.type, undefined, interfaces, unions)
+    };
+}
+
+function plainToPropertyType(type: PlainPropertyType, union: UnionType | undefined, interfaces: Map<string, InterfaceType>, unions: Map<string, UnionType>): PropertyType {
+    if (isPlainArrayType(type)) {
+        return {
+            elementType: plainToPropertyType(type.elementType, union, interfaces, unions)
+        };
+    } else if (isPlainReferenceType(type)) {
+        return {
+            referenceType: plainToPropertyType(type.referenceType, undefined, interfaces, unions)
+        };
+    } else if (isPlainPropertyUnion(type)) {
+        return {
+            types: type.types.map(e => plainToPropertyType(e, union, interfaces, unions))
+        };
+    } else if (isPlainStringType(type)) {
+        return {
+            string: type.string
+        };
+    } else if (isPlainPrimitiveType(type)) {
+        return {
+            primitive: type.primitive
+        };
+    } else if (isPlainValueType(type)) {
+        const value = interfaces.get(type.value) || unions.get(type.value);
+        if (!value) {
+            return {
+                primitive: 'unknown'
+            };
+        }
+        if (union) {
+            union.subTypes.add(value);
+        }
+        return {
+            value
+        };
+    } else {
+        throw new Error('Invalid property type');
+    }
+}
+
+export function mergePropertyTypes(first: PlainPropertyType, second: PlainPropertyType): PlainPropertyType {
+    const flattenedFirst = flattenPlainType(first);
+    const flattenedSecond = flattenPlainType(second);
+    for (const second of flattenedSecond) {
+        if (!includesType(flattenedFirst, second)) {
+            flattenedFirst.push(second);
+        }
+    }
+    if (flattenedFirst.length === 1) {
+        return flattenedFirst[0];
+    } else {
+        return {
+            types: flattenedFirst
+        };
+    }
+}
+
+function includesType(list: PlainPropertyType[], value: PlainPropertyType): boolean {
+    return list.some(e => typeEquals(e, value));
+}
+
+function typeEquals(first: PlainPropertyType, second: PlainPropertyType): boolean {
+    if (isPlainArrayType(first) && isPlainArrayType(second)) {
+        return typeEquals(first.elementType, second.elementType);
+    } else if (isPlainReferenceType(first) && isPlainReferenceType(second)) {
+        return typeEquals(first.referenceType, second.referenceType);
+    } else if (isPlainValueType(first) && isPlainValueType(second)) {
+        return first.value === second.value;
+    } else {
+        return false;
+    }
+}
+
+export function flattenPlainType(type: PlainPropertyType): PlainPropertyType[] {
+    if (isPlainPropertyUnion(type)) {
+        return type.types.flatMap(e => flattenPlainType(e));
+    } else {
+        return [type];
+    }
+}

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -268,7 +268,7 @@ export function isTypeAssignable(from: PropertyType, to: PropertyType): boolean 
         if (isUnionType(to.value)) {
             return isTypeAssignable(from, to.value.type);
         } else {
-            return isInterfaceAssignable(from.value, to.value);
+            return isInterfaceAssignable(from.value, to.value, new Set());
         }
     } else if (isPrimitiveType(from)) {
         return isPrimitiveType(to) && from.primitive === to.primitive;
@@ -279,12 +279,16 @@ export function isTypeAssignable(from: PropertyType, to: PropertyType): boolean 
     return false;
 }
 
-function isInterfaceAssignable(from: InterfaceType, to: InterfaceType): boolean {
+function isInterfaceAssignable(from: InterfaceType, to: InterfaceType, visited: Set<string>): boolean {
+    if (visited.has(from.name)) {
+        return true;
+    }
+    visited.add(from.name);
     if (from.name === to.name) {
         return true;
     }
     for (const superType of from.superTypes) {
-        if (isInterfaceType(superType) && isInterfaceAssignable(superType, to)) {
+        if (isInterfaceType(superType) && isInterfaceAssignable(superType, to, visited)) {
             return true;
         }
     }

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -5,22 +5,84 @@
  ******************************************************************************/
 
 import { CompositeGeneratorNode, NL, toString } from '../../../generator/generator-node';
+import { processGeneratorNode } from '../../../generator/node-processor';
 import { CstNode } from '../../../syntax-tree';
-import { MultiMap } from '../../../utils/collections';
 import { Assignment, Action, TypeAttribute } from '../../generated/ast';
 import { distinctAndSorted } from '../types-util';
 
 export type Property = {
     name: string,
     optional: boolean,
-    typeAlternatives: PropertyType[],
+    type: PropertyType,
     astNodes: Set<Assignment | Action | TypeAttribute>,
 }
 
-export type PropertyType = {
-    types: string[],
-    reference: boolean,
-    array: boolean,
+export type PropertyType =
+    | ReferenceType
+    | ArrayType
+    | PropertyUnion
+    | ValueType
+    | PrimitiveType
+    | StringType;
+
+export interface ReferenceType {
+    referenceType: PropertyType
+}
+
+export function isReferenceType(propertyType: PropertyType): propertyType is ReferenceType {
+    return 'referenceType' in propertyType;
+}
+
+export interface ArrayType {
+    elementType: PropertyType
+}
+
+export function isArrayType(propertyType: PropertyType): propertyType is ArrayType {
+    return 'elementType' in propertyType;
+}
+
+export interface PropertyUnion {
+    types: PropertyType[]
+}
+
+export function isPropertyUnion(propertyType: PropertyType): propertyType is PropertyUnion {
+    return 'types' in propertyType;
+}
+
+export function flattenPropertyUnion(propertyType: PropertyType): PropertyType[] {
+    if (isPropertyUnion(propertyType)) {
+        const items: PropertyType[] = [];
+        for (const type of propertyType.types) {
+            items.push(...flattenPropertyUnion(type));
+        }
+        return items;
+    } else {
+        return [propertyType];
+    }
+}
+
+export interface ValueType {
+    value: TypeOption
+}
+
+export function isValueType(propertyType: PropertyType): propertyType is ValueType {
+    return 'value' in propertyType;
+}
+
+export interface PrimitiveType {
+    primitive: string
+}
+
+export function isPrimitiveType(propertyType: PropertyType): propertyType is PrimitiveType {
+    return 'primitive' in propertyType;
+}
+
+export interface StringType {
+    string: string
+}
+
+export function isStringType(propertyType: PropertyType): propertyType is StringType {
+    return 'string' in propertyType;
 }
 
 export type AstTypes = {
@@ -29,7 +91,7 @@ export type AstTypes = {
 }
 
 export function isUnionType(type: TypeOption): type is UnionType {
-    return type && 'alternatives' in type;
+    return type && 'type' in type;
 }
 
 export function isInterfaceType(type: TypeOption): type is InterfaceType {
@@ -40,25 +102,28 @@ export type TypeOption = InterfaceType | UnionType;
 
 export class UnionType {
     name: string;
-    realSuperTypes = new Set<string>();
-    subTypes = new Set<string>();
-    containerTypes = new Set<string>();
-    typeTypes = new Set<string>();
-
-    alternatives: PropertyType[];
+    type: PropertyType;
+    superTypes = new Set<TypeOption>();
+    subTypes = new Set<TypeOption>();
+    containerTypes = new Set<TypeOption>();
+    typeNames = new Set<string>();
     reflection: boolean;
+    declared: boolean;
 
-    constructor(name: string, alts: PropertyType[], options?: { reflection: boolean }) {
+    constructor(name: string, options?: {
+        reflection: boolean
+        declared: boolean
+    }) {
         this.name = name;
-        this.alternatives = alts;
         this.reflection = options?.reflection ?? false;
+        this.declared = options?.declared ?? false;
     }
 
-    toAstTypesString(): string {
+    toAstTypesString(reflectionInfo: boolean): string {
         const unionNode = new CompositeGeneratorNode();
-        unionNode.append(`export type ${this.name} = ${propertyTypesToString(this.alternatives, 'AstType')};`, NL);
+        unionNode.append(`export type ${this.name} = ${propertyTypeToString(this.type, 'AstType')};`, NL);
 
-        if (this.reflection) {
+        if (this.reflection && reflectionInfo) {
             unionNode.append(NL);
             pushReflectionInfo(unionNode, this.name);
         }
@@ -67,49 +132,92 @@ export class UnionType {
 
     toDeclaredTypesString(reservedWords: Set<string>): string {
         const unionNode = new CompositeGeneratorNode();
-        unionNode.append(`type ${escapeReservedWords(this.name, reservedWords)} = ${propertyTypesToString(this.alternatives, 'DeclaredType')};`, NL);
-        return toString(unionNode);
+        unionNode.append(`type ${escapeReservedWords(this.name, reservedWords)} = ${propertyTypeToString(this.type, 'DeclaredType')};`, NL);
+        return processGeneratorNode(unionNode);
     }
 }
 
 export class InterfaceType {
     name: string;
-    realSuperTypes = new Set<string>();
-    subTypes = new Set<string>();
-    containerTypes = new Set<string>();
-    typeTypes = new Set<string>();
+    superTypes = new Set<TypeOption>();
+    subTypes = new Set<TypeOption>();
+    containerTypes = new Set<TypeOption>();
+    typeNames = new Set<string>();
+    declared = false;
+    abstract = false;
 
-    printingSuperTypes: string[] = [];
-    properties: Property[];
-    superProperties: MultiMap<string, Property> = new MultiMap();
+    properties: Property[] = [];
 
-    constructor(name: string, superTypes: string[], properties: Property[]) {
-        this.name = name;
-        this.realSuperTypes = new Set(superTypes);
-        this.printingSuperTypes = [...superTypes];
-        this.properties = properties;
-        properties.forEach(prop => this.superProperties.add(prop.name, prop));
+    get superProperties(): Property[] {
+        const map = new Map<string, Property>();
+        for (const property of this.properties) {
+            map.set(property.name, property);
+        }
+        for (const superType of this.interfaceSuperTypes) {
+            const allSuperProperties = superType.superProperties;
+            for (const superProp of allSuperProperties) {
+                if (!map.has(superProp.name)) {
+                    map.set(superProp.name, superProp);
+                }
+            }
+        }
+        return Array.from(map.values());
     }
 
-    toAstTypesString(): string {
+    get allProperties(): Property[] {
+        const map = new Map(this.superProperties.map(e => [e.name, e]));
+        for (const subType of this.subTypes) {
+            this.getSubTypeProperties(subType, map);
+        }
+        const superProps = Array.from(map.values());
+        return superProps;
+    }
+
+    private getSubTypeProperties(type: TypeOption, map: Map<string, Property>): void {
+        const props = isInterfaceType(type) ? type.properties : [];
+        for (const prop of props) {
+            if (!map.has(prop.name)) {
+                map.set(prop.name, prop);
+            }
+        }
+        for (const subType of type.subTypes) {
+            this.getSubTypeProperties(subType, map);
+        }
+    }
+
+    get interfaceSuperTypes(): InterfaceType[] {
+        return Array.from(this.superTypes).filter((e): e is InterfaceType => e instanceof InterfaceType);
+    }
+
+    constructor(name: string, declared: boolean, abstract: boolean) {
+        this.name = name;
+        this.declared = declared;
+        this.abstract = abstract;
+    }
+
+    toAstTypesString(reflectionInfo: boolean): string {
         const interfaceNode = new CompositeGeneratorNode();
 
-        const superTypes = this.printingSuperTypes.length > 0 ? distinctAndSorted([...this.printingSuperTypes]) : ['AstNode'];
+        const interfaceSuperTypes = this.interfaceSuperTypes.map(e => e.name);
+        const superTypes = interfaceSuperTypes.length > 0 ? distinctAndSorted([...interfaceSuperTypes]) : ['AstNode'];
         interfaceNode.append(`export interface ${this.name} extends ${superTypes.join(', ')} {`, NL);
 
         interfaceNode.indent(body => {
             if (this.containerTypes.size > 0) {
-                body.append(`readonly $container: ${distinctAndSorted([...this.containerTypes]).join(' | ')};`, NL);
+                body.append(`readonly $container: ${distinctAndSorted([...this.containerTypes].map(e => e.name)).join(' | ')};`, NL);
             }
-            if (this.typeTypes.size > 0) {
-                body.append(`readonly $type: ${distinctAndSorted([...this.typeTypes]).map(e => `'${e}'`).join(' | ')};`, NL);
+            if (this.typeNames.size > 0) {
+                body.append(`readonly $type: ${distinctAndSorted([...this.typeNames]).map(e => `'${e}'`).join(' | ')};`, NL);
             }
             pushProperties(body, this.properties, 'AstType');
         });
         interfaceNode.append('}', NL);
 
-        interfaceNode.append(NL);
-        pushReflectionInfo(interfaceNode, this.name);
+        if (reflectionInfo) {
+            interfaceNode.append(NL);
+            pushReflectionInfo(interfaceNode, this.name);
+        }
+
         return toString(interfaceNode);
     }
 
@@ -117,7 +225,7 @@ export class InterfaceType {
         const interfaceNode = new CompositeGeneratorNode();
 
         const name = escapeReservedWords(this.name, reservedWords);
-        const superTypes = Array.from(this.printingSuperTypes).join(', ');
+        const superTypes = distinctAndSorted(this.interfaceSuperTypes.map(e => e.name)).join(', ');
         interfaceNode.append(`interface ${name}${superTypes.length > 0 ? ` extends ${superTypes}` : ''} {`, NL);
 
         interfaceNode.indent(body => pushProperties(body, this.properties, 'DeclaredType', reservedWords));
@@ -138,31 +246,110 @@ export class TypeResolutionError extends Error {
 
 }
 
-export function propertyTypesToString(alternatives: PropertyType[], mode: 'AstType' | 'DeclaredType'='AstType'): string {
-    function propertyTypeToString(propertyType: PropertyType): string {
-        let res = distinctAndSorted(propertyType.types).join(' | ');
-        res = propertyType.reference ? (mode === 'AstType' ? `Reference<${res}>` : `@${res}`) : res;
-        res = propertyType.array ? (mode === 'AstType' ? `Array<${res}>` : `${res}[]`) : res;
-        return res;
+export function isTypeAssignable(from: PropertyType, to: PropertyType): boolean {
+    if (isPropertyUnion(from)) {
+        return from.types.every(fromType => isTypeAssignable(fromType, to));
+    } else if (isPropertyUnion(to)) {
+        return to.types.some(toType => isTypeAssignable(from, toType));
+    } else if (isReferenceType(from)) {
+        return isReferenceType(to) && isTypeAssignable(from.referenceType, to.referenceType);
+    } else if (isArrayType(from)) {
+        return isArrayType(to) && isTypeAssignable(from.elementType, to.elementType);
+    } else if (isValueType(from)) {
+        if (isUnionType(from.value)) {
+            if (isValueType(to) && to.value.name === from.value.name) {
+                return true;
+            }
+            return isTypeAssignable(from.value.type, to);
+        }
+        if (!isValueType(to)) {
+            return false;
+        }
+        if (isUnionType(to.value)) {
+            return isTypeAssignable(from, to.value.type);
+        } else {
+            return isInterfaceAssignable(from.value, to.value);
+        }
+    } else if (isPrimitiveType(from)) {
+        return isPrimitiveType(to) && from.primitive === to.primitive;
     }
-
-    return distinctAndSorted(alternatives.map(propertyTypeToString)).join(' | ');
+    else if (isStringType(from)) {
+        return (isPrimitiveType(to) && to.primitive === 'string') || (isStringType(to) && to.string === from.string);
+    }
+    return false;
 }
 
-function pushProperties(node: CompositeGeneratorNode, properties: Property[],
-    mode: 'AstType' | 'DeclaredType', reserved = new Set<string>()) {
+function isInterfaceAssignable(from: InterfaceType, to: InterfaceType): boolean {
+    if (from.name === to.name) {
+        return true;
+    }
+    for (const superType of from.superTypes) {
+        if (isInterfaceType(superType) && isInterfaceAssignable(superType, to)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function propertyTypeToString(type: PropertyType, mode: 'AstType' | 'DeclaredType' = 'AstType'): string {
+    if (isReferenceType(type)) {
+        const refType = propertyTypeToString(type.referenceType, mode);
+        return mode === 'AstType' ? `Reference<${refType}>` : `@${typeParenthesis(type.referenceType, refType)}`;
+    } else if (isArrayType(type)) {
+        const arrayType = propertyTypeToString(type.elementType, mode);
+        return mode === 'AstType' ? `Array<${arrayType}>` : `${typeParenthesis(type.elementType, arrayType)}[]`;
+    } else if (isPropertyUnion(type)) {
+        const types = type.types.map(e => typeParenthesis(e, propertyTypeToString(e, mode)));
+        return distinctAndSorted(types).join(' | ');
+    } else if (isValueType(type)) {
+        return type.value.name;
+    } else if (isPrimitiveType(type)) {
+        return type.primitive;
+    } else if (isStringType(type)) {
+        return `'${type.string}'`;
+    }
+    throw new Error('Invalid type');
+}
+
+function typeParenthesis(type: PropertyType, name: string): string {
+    const needsParenthesis = isPropertyUnion(type);
+    if (needsParenthesis) {
+        name = `(${name})`;
+    }
+    return name;
+}
+
+function pushProperties(
+    node: CompositeGeneratorNode,
+    properties: Property[],
+    mode: 'AstType' | 'DeclaredType',
+    reserved = new Set<string>()
+) {
 
     function propertyToString(property: Property): string {
         const name = mode === 'AstType' ? property.name : escapeReservedWords(property.name, reserved);
-        const optional = property.optional &&
-            !property.typeAlternatives.some(e => e.array) &&
-            !property.typeAlternatives.every(e => e.types.length === 1 && e.types[0] === 'boolean');
-        const propType = propertyTypesToString(property.typeAlternatives, mode);
+        const optional = property.optional && !isMandatoryPropertyType(property.type);
+        const propType = propertyTypeToString(property.type, mode);
         return `${name}${optional ? '?' : ''}: ${propType}`;
     }
 
     distinctAndSorted(properties, (a, b) => a.name.localeCompare(b.name))
         .forEach(property => node.append(propertyToString(property), NL));
+}
+
+function isMandatoryPropertyType(propertyType: PropertyType): boolean {
+    if (isArrayType(propertyType)) {
+        return true;
+    } else if (isReferenceType(propertyType)) {
+        return false;
+    } else if (isPropertyUnion(propertyType)) {
+        return propertyType.types.every(e => isMandatoryPropertyType(e));
+    } else if (isPrimitiveType(propertyType)) {
+        const value = propertyType.primitive;
+        return value === 'boolean';
+    } else {
+        return false;
+    }
 }
 
 function pushReflectionInfo(node: CompositeGeneratorNode, name: string) {

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -8,20 +8,21 @@ import { References } from '../../references/references';
 import { MultiMap } from '../../utils/collections';
 import { AstNodeLocator } from '../../workspace/ast-node-locator';
 import { LangiumDocuments } from '../../workspace/documents';
-import { Interface, Type, AbstractType, isInterface, isType } from '../generated/ast';
-import { AstTypes, InterfaceType, Property, PropertyType, TypeOption } from './type-collector/types';
+import { Interface, Type, AbstractType, isInterface, isType, TypeDefinition, isUnionType, isSimpleType } from '../generated/ast';
+import { PlainInterface, PlainProperty } from './type-collector/plain-types';
+import { AstTypes, InterfaceType, isArrayType, isPrimitiveType, isPropertyUnion, isReferenceType, isValueType, PropertyType, TypeOption } from './type-collector/types';
 
 /**
  * Collects all properties of all interface types. Includes super type properties.
  * @param interfaces A topologically sorted array of interfaces.
  */
-export function collectAllProperties(interfaces: InterfaceType[]): MultiMap<string, Property> {
-    const map = new MultiMap<string, Property>();
+export function collectAllPlainProperties(interfaces: PlainInterface[]): MultiMap<string, PlainProperty> {
+    const map = new MultiMap<string, PlainProperty>();
     for (const interfaceType of interfaces) {
         map.addAll(interfaceType.name, interfaceType.properties);
     }
     for (const interfaceType of interfaces) {
-        for (const superType of interfaceType.printingSuperTypes) {
+        for (const superType of interfaceType.superTypes) {
             const superTypeProperties = map.get(superType);
             if (superTypeProperties) {
                 map.addAll(interfaceType.name, superTypeProperties);
@@ -53,6 +54,37 @@ export function collectChildrenTypes(interfaceNode: Interface, references: Refer
     return childrenTypes;
 }
 
+export function collectTypeHierarchy(types: TypeOption[]): {
+    superTypes: MultiMap<string, string>
+    subTypes: MultiMap<string, string>
+} {
+    const duplicateSuperTypes = new MultiMap<string, string>();
+    const duplicateSubTypes = new MultiMap<string, string>();
+    for (const type of types) {
+        for (const superType of type.superTypes) {
+            duplicateSuperTypes.add(type.name, superType.name);
+            duplicateSubTypes.add(superType.name, type.name);
+        }
+        for (const subType of type.subTypes) {
+            duplicateSuperTypes.add(subType.name, type.name);
+            duplicateSubTypes.add(type.name, subType.name);
+        }
+    }
+    const superTypes = new MultiMap<string, string>();
+    const subTypes = new MultiMap<string, string>();
+    // Deduplicate and sort
+    for (const [name, superTypeList] of Array.from(duplicateSuperTypes.entriesGroupedByKey()).sort(([aName], [bName]) => aName.localeCompare(bName))) {
+        superTypes.addAll(name, Array.from(new Set(superTypeList)));
+    }
+    for (const [name, subTypeList] of Array.from(duplicateSubTypes.entriesGroupedByKey()).sort(([aName], [bName]) => aName.localeCompare(bName))) {
+        subTypes.addAll(name, Array.from(new Set(subTypeList)));
+    }
+    return {
+        superTypes,
+        subTypes
+    };
+}
+
 export function collectSuperTypes(ruleNode: AbstractType): Set<Interface> {
     const superTypes = new Set<Interface>();
     if (isInterface(ruleNode)) {
@@ -67,31 +99,27 @@ export function collectSuperTypes(ruleNode: AbstractType): Set<Interface> {
             }
         });
     } else if (isType(ruleNode)) {
-        ruleNode.typeAlternatives.forEach(typeAlternative => {
-            if (typeAlternative.refType?.ref) {
-                if (isInterface(typeAlternative.refType.ref) || isType(typeAlternative.refType.ref)) {
-                    const collectedSuperTypes = collectSuperTypes(typeAlternative.refType.ref);
-                    for (const superType of collectedSuperTypes) {
-                        superTypes.add(superType);
-                    }
-                }
+        const usedTypes = collectUsedTypes(ruleNode.type);
+        for (const usedType of usedTypes) {
+            const collectedSuperTypes = collectSuperTypes(usedType);
+            for (const superType of collectedSuperTypes) {
+                superTypes.add(superType);
             }
-        });
+        }
     }
     return superTypes;
 }
 
-export function comparePropertyType(a: PropertyType, b: PropertyType): boolean {
-    return a.array === b.array &&
-        a.reference === b.reference &&
-        compareLists(a.types, b.types);
-}
-
-function compareLists<T>(a: T[], b: T[], eq: (x: T, y: T) => boolean = (x, y) => x === y): boolean {
-    const distinctAndSortedA = distinctAndSorted(a);
-    const distinctAndSortedB = distinctAndSorted(b);
-    if (distinctAndSortedA.length !== distinctAndSortedB.length) return false;
-    return distinctAndSortedB.every((e, i) => eq(e, distinctAndSortedA[i]));
+function collectUsedTypes(typeDefinition: TypeDefinition): Array<Interface | Type> {
+    if (isUnionType(typeDefinition)) {
+        return typeDefinition.types.flatMap(e => collectUsedTypes(e));
+    } else if (isSimpleType(typeDefinition)) {
+        const value = typeDefinition.typeRef?.ref;
+        if (isType(value) || isInterface(value)) {
+            return [value];
+        }
+    }
+    return [];
 }
 
 export function mergeInterfaces(inferred: AstTypes, declared: AstTypes): InterfaceType[] {
@@ -107,9 +135,9 @@ export function mergeTypesAndInterfaces(astTypes: AstTypes): TypeOption[] {
  * @param interfaces The interfaces to sort topologically.
  * @returns A topologically sorted set of interfaces.
  */
-export function sortInterfacesTopologically(interfaces: InterfaceType[]): InterfaceType[] {
+export function sortInterfacesTopologically(interfaces: PlainInterface[]): PlainInterface[] {
     type TypeNode = {
-        value: InterfaceType;
+        value: PlainInterface;
         nodes: TypeNode[];
     }
 
@@ -117,12 +145,11 @@ export function sortInterfacesTopologically(interfaces: InterfaceType[]): Interf
         .sort((a, b) => a.name.localeCompare(b.name))
         .map(e => <TypeNode>{ value: e, nodes: [] });
     for (const node of nodes) {
-        node.nodes = nodes.filter(e => node.value.realSuperTypes.has(e.value.name));
+        node.nodes = nodes.filter(e => node.value.superTypes.has(e.value.name));
     }
     const l: TypeNode[] = [];
     const s = nodes.filter(e => e.nodes.length === 0);
     while (s.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const n = s.shift()!;
         if (!l.includes(n)) {
             l.push(n);
@@ -134,11 +161,36 @@ export function sortInterfacesTopologically(interfaces: InterfaceType[]): Interf
     return l.map(e => e.value);
 }
 
-export function addSubTypes(nameToType: Map<string, TypeOption>) {
-    for (const interfaceType of nameToType.values()) {
-        for (const superTypeName of interfaceType.realSuperTypes) {
-            nameToType.get(superTypeName)
-                ?.subTypes.add(interfaceType.name);
-        }
+export function hasArrayType(type: PropertyType): boolean {
+    if (isPropertyUnion(type)) {
+        return type.types.some(e => hasArrayType(e));
+    } else if (isArrayType(type)) {
+        return true;
+    } else {
+        return false;
     }
+}
+
+export function hasBooleanType(type: PropertyType): boolean {
+    if (isPropertyUnion(type)) {
+        return type.types.some(e => hasBooleanType(e));
+    } else if (isPrimitiveType(type)) {
+        return type.primitive === 'boolean';
+    } else {
+        return false;
+    }
+}
+
+export function findReferenceTypes(type: PropertyType): string[] {
+    if (isPropertyUnion(type)) {
+        return type.types.flatMap(e => findReferenceTypes(e));
+    } else if (isReferenceType(type)) {
+        const refType = type.referenceType;
+        if (isValueType(refType)) {
+            return [refType.value.name];
+        }
+    } else if (isArrayType(type)) {
+        return findReferenceTypes(type.elementType);
+    }
+    return [];
 }

--- a/packages/langium/src/grammar/validation/types-validator.ts
+++ b/packages/langium/src/grammar/validation/types-validator.ts
@@ -4,14 +4,13 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import * as ast from '../generated/ast';
 import { MultiMap } from '../../utils/collections';
 import { DiagnosticInfo, ValidationAcceptor, ValidationChecks } from '../../validation/validation-registry';
-import * as ast from '../generated/ast';
 import { extractAssignments } from '../internal-grammar-util';
 import { LangiumGrammarServices } from '../langium-grammar-module';
-import { InterfaceType, isInterfaceType, isUnionType, Property, PropertyType, propertyTypesToString } from '../type-system/type-collector/types';
-import { distinctAndSorted } from '../type-system/types-util';
-import { DeclaredInfo, InferredInfo, isDeclared, isInferred, isInferredAndDeclared, LangiumGrammarDocument, TypeToValidationInfo } from '../workspace/documents';
+import { flattenPropertyUnion, InterfaceType, isInterfaceType, isReferenceType, isTypeAssignable, isUnionType, Property, PropertyType, propertyTypeToString } from '../type-system/type-collector/types';
+import { DeclaredInfo, InferredInfo, isDeclared, isInferred, isInferredAndDeclared, LangiumGrammarDocument } from '../workspace/documents';
 
 export function registerTypeValidationChecks(services: LangiumGrammarServices): void {
     const registry = services.validation.ValidationRegistry;
@@ -36,8 +35,8 @@ export class LangiumGrammarTypesValidator {
             for (const typeInfo of validationResources.typeToValidationInfo.values()) {
                 if (isDeclared(typeInfo) && isInterfaceType(typeInfo.declared) && ast.isInterface(typeInfo.declaredNode)) {
                     const declInterface = typeInfo as { declared: InterfaceType, declaredNode: ast.Interface };
-                    validateInterfaceSuperTypes(declInterface, validationResources.typeToValidationInfo, accept);
-                    validateSuperTypesConsistency(declInterface, validationResources.typeToSuperProperties, accept);
+                    validateInterfaceSuperTypes(declInterface, accept);
+                    validateSuperTypesConsistency(declInterface, accept);
                 }
             }
         }
@@ -51,7 +50,7 @@ export class LangiumGrammarTypesValidator {
                     validateInferredInterface(typeInfo.inferred as InterfaceType, accept);
                 }
                 if (isInferredAndDeclared(typeInfo)) {
-                    validateDeclaredAndInferredConsistency(typeInfo, validationResources.typeToAliases, accept);
+                    validateDeclaredAndInferredConsistency(typeInfo, accept);
                 }
             }
         }
@@ -67,17 +66,20 @@ export class LangiumGrammarTypesValidator {
 ///////////////////////////////////////////////////////////////////////////////
 
 function validateInferredInterface(inferredInterface: InterfaceType, accept: ValidationAcceptor): void {
-    inferredInterface.properties.filter(prop => prop.typeAlternatives.length > 1).forEach(prop => {
-        const typeKind = (type: PropertyType) => type.reference ? 'ref' : 'other';
-        const firstKind = typeKind(prop.typeAlternatives[0]);
-        if (prop.typeAlternatives.slice(1).some(type => typeKind(type) !== firstKind)) {
-            const targetNode = prop.astNodes.values().next().value;
-            if(targetNode) {
-                accept(
-                    'error',
-                    `Mixing a cross-reference with other types is not supported. Consider splitting property "${prop.name}" into two or more different properties.`,
-                    { node: targetNode }
-                );
+    inferredInterface.properties.forEach(prop => {
+        const flattened = flattenPropertyUnion(prop.type);
+        if (flattened.length > 1) {
+            const typeKind = (type: PropertyType) => isReferenceType(type) ? 'ref' : 'other';
+            const firstKind = typeKind(flattened[0]);
+            if (flattened.slice(1).some(type => typeKind(type) !== firstKind)) {
+                const targetNode = prop.astNodes.values().next()?.value;
+                if(targetNode) {
+                    accept(
+                        'error',
+                        `Mixing a cross-reference with other types is not supported. Consider splitting property "${prop.name}" into two or more different properties.`,
+                        { node:  targetNode}
+                    );
+                }
             }
         }
     });
@@ -85,16 +87,14 @@ function validateInferredInterface(inferredInterface: InterfaceType, accept: Val
 
 function validateInterfaceSuperTypes(
     { declared, declaredNode }: { declared: InterfaceType, declaredNode: ast.Interface },
-    validationInfo: TypeToValidationInfo,
     accept: ValidationAcceptor): void {
 
-    declared.printingSuperTypes.forEach((superTypeName, i) => {
-        const superType = validationInfo.get(superTypeName);
+    Array.from(declared.superTypes).forEach((superType, i) => {
         if (superType) {
-            if (isInferred(superType) && isUnionType(superType.inferred) || isDeclared(superType) && isUnionType(superType.declared)) {
+            if (isUnionType(superType)) {
                 accept('error', 'Interfaces cannot extend union types.', { node: declaredNode, property: 'superTypes', index: i });
             }
-            if (isInferred(superType) && !isDeclared(superType)) {
+            if (!superType.declared) {
                 accept('error', 'Extending an inferred type is discouraged.', { node: declaredNode, property: 'superTypes', index: i });
             }
         }
@@ -102,8 +102,7 @@ function validateInterfaceSuperTypes(
 }
 
 function validateSuperTypesConsistency(
-    { declared, declaredNode }: { declared: InterfaceType, declaredNode: ast.Interface},
-    properties: Map<string, Property[]>,
+    { declared, declaredNode }: { declared: InterfaceType, declaredNode: ast.Interface },
     accept: ValidationAcceptor): void {
 
     const nameToProp = declared.properties.reduce((acc, e) => acc.add(e.name, e), new MultiMap<string, Property>());
@@ -118,13 +117,13 @@ function validateSuperTypesConsistency(
         }
     }
 
-    const allSuperTypes = declared.printingSuperTypes;
+    const allSuperTypes = Array.from(declared.superTypes);
     for (let i = 0; i < allSuperTypes.length; i++) {
         for (let j = i + 1; j < allSuperTypes.length; j++) {
             const outerType = allSuperTypes[i];
             const innerType = allSuperTypes[j];
-            const outerProps = properties.get(outerType) ?? [];
-            const innerProps = properties.get(innerType) ?? [];
+            const outerProps = isInterfaceType(outerType) ? outerType.superProperties : [];
+            const innerProps = isInterfaceType(innerType) ? innerType.superProperties : [];
             const nonIdentical = getNonIdenticalProps(outerProps, innerProps);
             if (nonIdentical.length > 0) {
                 accept('error', `Cannot simultaneously inherit from '${outerType}' and '${innerType}'. Their ${nonIdentical.map(e => "'" + e + "'").join(', ')} properties are not identical.`, {
@@ -136,15 +135,14 @@ function validateSuperTypesConsistency(
     }
     const allSuperProps = new Set<string>();
     for (const superType of allSuperTypes) {
-        const props = properties.get(superType) ?? [];
+        const props = isInterfaceType(superType) ? superType.superProperties : [];
         for (const prop of props) {
             allSuperProps.add(prop.name);
         }
     }
     for (const ownProp of declared.properties) {
         if (allSuperProps.has(ownProp.name)) {
-            const interfaceNode = declaredNode as ast.Interface;
-            const propNode = interfaceNode.attributes.find(e => e.name === ownProp.name);
+            const propNode = declaredNode.attributes.find(e => e.name === ownProp.name);
             if (propNode) {
                 accept('error', `Cannot redeclare property '${ownProp.name}'. It is already inherited from another interface.`, {
                     node: propNode,
@@ -167,28 +165,17 @@ function getNonIdenticalProps(a: readonly Property[], b: readonly Property[]): s
 }
 
 function arePropTypesIdentical(a: Property, b: Property): boolean {
-    if (a.optional !== b.optional || a.typeAlternatives.length !== b.typeAlternatives.length) {
-        return false;
-    }
-    for (const firstTypes of a.typeAlternatives) {
-        const found = b.typeAlternatives.some(otherTypes => {
-            return otherTypes.array === firstTypes.array
-                && otherTypes.reference === firstTypes.reference
-                && otherTypes.types.length === firstTypes.types.length
-                && otherTypes.types.every(e => firstTypes.types.includes(e));
-        });
-        if (!found) return false;
-    }
-    return true;
+    return isTypeAssignable(a.type, b.type) && isTypeAssignable(b.type, a.type);
 }
 
-function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & DeclaredInfo, typeToAliases: Map<string, Set<string>>, accept: ValidationAcceptor) {
+///////////////////////////////////////////////////////////////////////////////
+
+function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & DeclaredInfo, accept: ValidationAcceptor) {
     const { inferred, declared, declaredNode, inferredNodes } = typeInfo;
     const typeName = declared.name;
 
     const applyErrorToRulesAndActions = (msgPostfix?: string) => (errorMsg: string) =>
-        inferredNodes.forEach(node => accept('error',
-            `${errorMsg[-1] === '.' ? errorMsg.slice(0, -1) : errorMsg}${msgPostfix ? ` ${msgPostfix}` : ''}.`,
+        inferredNodes.forEach(node => accept('error', `${errorMsg}${msgPostfix ? ` ${msgPostfix}` : ''}.`,
             (node?.inferredType) ?
                 <DiagnosticInfo<ast.InferredType, string>>{ node: node?.inferredType, property: 'name' } :
                 <DiagnosticInfo<ast.ParserRule | ast.Action | ast.InferredType, string>>{ node, property: ast.isAction(node) ? 'type' : 'name' }
@@ -199,15 +186,20 @@ function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & Declare
             accept('error', errorMessage, { node, property: ast.isAssignment(node) || ast.isAction(node) ? 'feature' : 'name' })
         );
 
+    // todo add actions
     // currently we don't track which assignments belong to which actions and can't apply this error
     const applyMissingPropErrorToRules = (missingProp: string) => {
         inferredNodes.forEach(node => {
             if (ast.isParserRule(node)) {
                 const assignments = extractAssignments(node.definition);
                 if (assignments.find(e => e.feature === missingProp) === undefined) {
-                    accept('error',
+                    accept(
+                        'error',
                         `Property '${missingProp}' is missing in a rule '${node.name}', but is required in type '${typeName}'.`,
-                        {node, property: 'parameters'}
+                        {
+                            node,
+                            property: 'parameters'
+                        }
                     );
                 }
             }
@@ -215,13 +207,11 @@ function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & Declare
     };
 
     if (isUnionType(inferred) && isUnionType(declared)) {
-        validateAlternativesConsistency(inferred.alternatives, declared.alternatives,
-            typeToAliases,
+        validateAlternativesConsistency(inferred.type, declared.type,
             applyErrorToRulesAndActions(`in a rule that returns type '${typeName}'`),
         );
     } else if (isInterfaceType(inferred) && isInterfaceType(declared)) {
-        validatePropertiesConsistency(inferred.superProperties, declared.superProperties,
-            typeToAliases,
+        validatePropertiesConsistency(inferred, declared,
             applyErrorToRulesAndActions(`in a rule that returns type '${typeName}'`),
             applyErrorToProperties,
             applyMissingPropErrorToRules
@@ -233,120 +223,63 @@ function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & Declare
     }
 }
 
-type ErrorInfo = {
-    errorMessage: string;
-    typeAsString: string;
-}
-
-function validateAlternativesConsistency(inferred: PropertyType[], declared: PropertyType[],
-    typeToAliases: Map<string, Set<string>>,
-    applyErrorToInferredTypes: (errorMessage: string) => void) {
-
-    const errorsInfo = checkAlternativesConsistencyHelper(inferred, declared, typeToAliases);
-    for (const errorInfo of errorsInfo) {
-        applyErrorToInferredTypes(`A type '${errorInfo.typeAsString}' ${errorInfo.errorMessage}`);
+function validateAlternativesConsistency(
+    inferred: PropertyType,
+    declared: PropertyType,
+    applyErrorToInferredTypes: (errorMessage: string) => void
+) {
+    if (!isTypeAssignable(inferred, declared)) {
+        applyErrorToInferredTypes(`Cannot assign type '${propertyTypeToString(inferred, 'DeclaredType')}' to '${propertyTypeToString(declared, 'DeclaredType')}'`);
     }
 }
 
-function getAllAliases(expected: PropertyType, typeToAliases: Map<string, Set<string>>): string[] {
-    const allAliases = expected.types.map(typeName => Array.from(typeToAliases.get(typeName) ?? new Set([typeName])));
-    let branches: string[][] = [];
-    for (const aliasGroup of allAliases) {
-        if (branches.length === 0) {
-            branches.push([]);
-        }
-        if (aliasGroup.length === 1) {
-            branches.forEach(branch => branch.push(aliasGroup[0]));
-        } else {
-            const backup_branches = JSON.parse(JSON.stringify(branches));
-            branches = [];
-            for (const alias of aliasGroup) {
-                const alias_branches: string[][] = JSON.parse(JSON.stringify(backup_branches));
-                alias_branches.forEach(alias_branch => alias_branch.push(alias));
-                branches.push(...alias_branches);
-            }
-        }
-    }
-    return branches.map(branch => distinctAndSorted(branch).join(' | '));
-}
-
-function typeAsStringKeywordsReplacement(found: PropertyType): string {
-    const propTypeWithStr = found.types.filter(e => !e.startsWith('\''));
-    propTypeWithStr.push('string');
-    return distinctAndSorted(propTypeWithStr).join(' | ');
-}
-
-function checkAlternativesConsistencyHelper(found: PropertyType[], expected: PropertyType[], typeToAliases: Map<string, Set<string>>): ErrorInfo[] {
-    const arrayReferenceError = (found: PropertyType, expected: PropertyType) =>
-        found.array && !expected.array && found.reference && !expected.reference ? 'can\'t be an array and a reference' :
-            !found.array && expected.array && !found.reference && expected.reference ? 'has to be an array and a reference' :
-                found.array && !expected.array ? 'can\'t be an array' :
-                    !found.array && expected.array ? 'has to be an array' :
-                        found.reference && !expected.reference ? 'can\'t be a reference' :
-                            !found.reference && expected.reference ? 'has to be a reference' : '';
-
-    const stringToFound = found.reduce((acc, propType) => acc.set(distinctAndSorted(propType.types).join(' | '), propType),
-        new Map<string, PropertyType>());
-
-    const stringToExpected = expected.reduce((acc, propType) => {
-        getAllAliases(propType, typeToAliases).forEach(alias => acc.set(alias, propType));
-        return acc;
-    }, new Map<string, PropertyType>());
-    const errorsInfo: ErrorInfo[] = [];
-
-    // detects extra type alternatives & check matched ones on consistency by 'array' and 'reference'
-    for (const [typeAsString, foundPropertyType] of stringToFound) {
-        const expectedPropertyType = stringToExpected.get(typeAsString) ?? stringToExpected.get(typeAsStringKeywordsReplacement(foundPropertyType));
-        if (!expectedPropertyType) {
-            errorsInfo.push({ typeAsString, errorMessage: 'is not expected' });
-        } else if (expectedPropertyType.array !== foundPropertyType.array || expectedPropertyType.reference !== foundPropertyType.reference) {
-            errorsInfo.push({ typeAsString, errorMessage: arrayReferenceError(foundPropertyType, expectedPropertyType) });
-        }
-    }
-    return errorsInfo;
-}
-
-function validatePropertiesConsistency(inferred: MultiMap<string, Property>, declared: MultiMap<string, Property>,
-    typeToAliases: Map<string, Set<string>>,
+function validatePropertiesConsistency(
+    inferred: InterfaceType,
+    declared: InterfaceType,
     applyErrorToType: (errorMessage: string) => void,
     applyErrorToProperties: (nodes: Set<ast.Assignment | ast.Action | ast.TypeAttribute>, errorMessage: string) => void,
     applyMissingPropErrorToRules: (missingProp: string) => void
 ) {
-    const areBothNotArrays = (found: Property, expected: Property) =>
-        !(found.typeAlternatives.length === 1 && found.typeAlternatives[0].array) &&
-            !(expected.typeAlternatives.length === 1 && expected.typeAlternatives[0].array);
+    const ownInferredProps = new Set(inferred.properties.map(e => e.name));
+    // This field also contains properties of sub types
+    const allInferredProps = new Map(inferred.allProperties.map(e => [e.name, e]));
+    // This field only contains properties of itself or super types
+    const declaredProps = new Map(declared.superProperties.map(e => [e.name, e]));
 
     // detects extra properties & validates matched ones on consistency by the 'optional' property
-    for (const [name, foundProps] of inferred.entriesGroupedByKey()) {
-        const foundProp = foundProps[0];
-        const expectedProp = declared.get(name)[0];
+    for (const [name, foundProp] of allInferredProps.entries()) {
+        const expectedProp = declaredProps.get(name);
         if (expectedProp) {
-            const foundTypeAsStr = propertyTypesToString(foundProp.typeAlternatives);
-            const expectedTypeAsStr = propertyTypesToString(expectedProp.typeAlternatives);
-            if (foundTypeAsStr !== expectedTypeAsStr) {
-                const typeAlternativesErrors = checkAlternativesConsistencyHelper(foundProp.typeAlternatives, expectedProp.typeAlternatives, typeToAliases);
-                if (typeAlternativesErrors.length > 0) {
-                    const errorMsgPrefix = `The assigned type '${foundTypeAsStr}' is not compatible with the declared property '${name}' of type '${expectedTypeAsStr}'`;
-                    const propErrors = typeAlternativesErrors
-                        .map(errorInfo => ` '${errorInfo.typeAsString}' ${errorInfo.errorMessage}`)
-                        .join('; ');
-                    applyErrorToProperties(foundProp.astNodes, `${errorMsgPrefix}: ${propErrors}.`);
-                }
+            const foundTypeAsStr = propertyTypeToString(foundProp.type, 'DeclaredType');
+            const expectedTypeAsStr = propertyTypeToString(expectedProp.type, 'DeclaredType');
+            const typeAlternativesErrors = isTypeAssignable(foundProp.type, expectedProp.type);
+            if (!typeAlternativesErrors) {
+                const errorMsgPrefix = `The assigned type '${foundTypeAsStr}' is not compatible with the declared property '${name}' of type '${expectedTypeAsStr}'.`;
+                applyErrorToProperties(foundProp.astNodes, errorMsgPrefix);
             }
 
-            if (!expectedProp.optional && foundProp.optional && areBothNotArrays(foundProp, expectedProp)) {
+            if (!expectedProp.optional && foundProp.optional) {
                 applyMissingPropErrorToRules(name);
             }
-        } else {
+        } else if (ownInferredProps.has(name)) {
+            // Only apply the superfluous property error on properties which are actually declared on the current type
             applyErrorToProperties(foundProp.astNodes, `A property '${name}' is not expected.`);
         }
     }
 
-    // detects lack of properties
-    for (const [name, expectedProperties] of declared.entriesGroupedByKey()) {
-        const foundProperty = inferred.get(name);
-        if (foundProperty.length === 0 && !expectedProperties.some(e => e.optional)) {
-            applyErrorToType(`A property '${name}' is expected.`);
+    // Detect any missing properties
+    const missingProps = new Set<string>();
+    for (const [name, expectedProperties] of declaredProps.entries()) {
+        const foundProperty = allInferredProps.get(name);
+        if (!foundProperty && !expectedProperties.optional) {
+            missingProps.add(name);
         }
+    }
+
+    if (missingProps.size > 0) {
+        const prefix = missingProps.size > 1 ? 'Properties' : 'A property';
+        const postfix = missingProps.size > 1 ? 'are expected' : 'is expected';
+        const props = Array.from(missingProps).map(e => `'${e}'`).sort().join(', ');
+        applyErrorToType(`${prefix} ${props} ${postfix}.`);
     }
 }

--- a/packages/langium/src/grammar/workspace/documents.ts
+++ b/packages/langium/src/grammar/workspace/documents.ts
@@ -6,7 +6,7 @@
 
 import { LangiumDocument } from '../../workspace/documents';
 import { Action, Grammar, Interface, ParserRule, Type } from '../generated/ast';
-import { Property, TypeOption } from '../type-system/type-collector/types';
+import { Property, TypeOption } from '../type-system';
 
 /**
  * A Langium document holds the parse result (AST and CST) and any additional state that is derived
@@ -19,7 +19,6 @@ export interface LangiumGrammarDocument extends LangiumDocument<Grammar> {
 export type ValidationResources = {
     typeToValidationInfo: TypeToValidationInfo,
     typeToSuperProperties: Map<string, Property[]>,
-    typeToAliases: Map<string, Set<string>>,
 }
 
 export type TypeToValidationInfo = Map<string, InferredInfo | DeclaredInfo | InferredInfo & DeclaredInfo>;

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -426,9 +426,9 @@ export function expectWarning<T extends AstNode = AstNode, N extends AstNode = A
     });
 }
 
-export function clearDocuments(services: LangiumServices): void {
+export function clearDocuments(services: LangiumServices): Promise<void> {
     const allDocs = services.shared.workspace.LangiumDocuments.all.map(x => x.uri).toArray();
-    services.shared.workspace.DocumentBuilder.update([], allDocs);
+    return services.shared.workspace.DocumentBuilder.update([], allDocs);
 }
 
 export interface DecodedSemanticTokensWithRanges {

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -270,8 +270,8 @@ function findNameAssignmentInternal(type: ast.AbstractType, cache: Map<ast.Abstr
             return node;
         } else if (ast.isRuleCall(node) && ast.isParserRule(node.rule.ref)) {
             return go(node, node.rule.ref);
-        } else if (ast.isAtomType(node) && node?.refType?.ref) {
-            return go(node, node.refType.ref);
+        } else if (ast.isSimpleType(node) && node.typeRef?.ref) {
+            return go(node, node.typeRef.ref);
         }
     }
     return undefined;

--- a/packages/langium/test/grammar/ast-reflection-interpreter.test.ts
+++ b/packages/langium/test/grammar/ast-reflection-interpreter.test.ts
@@ -12,41 +12,40 @@ describe('AST reflection interpreter', () => {
 
     describe('Inheritance with sub- and super-types', () => {
 
-        const superType = new InterfaceType('Super', [], [
-            {
-                name: 'A',
-                optional: false,
-                typeAlternatives: [{
-                    array: true,
-                    reference: false,
-                    types: ['string']
-                }],
-                astNodes: new Set()
-            },
-            {
-                name: 'Ref',
-                optional: true,
-                typeAlternatives: [{
-                    array: false,
-                    reference: true,
-                    types: ['RefTarget']
-                }],
-                astNodes: new Set()
-            }
-        ]);
+        const superType = new InterfaceType('Super', false, false);
 
-        const subType = new InterfaceType('Sub', ['Super'], [
-            {
-                name: 'B',
-                optional: false,
-                typeAlternatives: [{
-                    array: true,
-                    reference: false,
-                    types: ['string']
-                }],
-                astNodes: new Set()
+        superType.properties.push({
+            name: 'A',
+            astNodes: new Set(),
+            optional: false,
+            type: {
+                elementType: {
+                    primitive: 'string'
+                }
             }
-        ]);
+        }, {
+            name: 'Ref',
+            astNodes: new Set(),
+            optional: true,
+            type: {
+                referenceType: {
+                    value: superType
+                }
+            }
+        });
+
+        const subType = new InterfaceType('Sub', false, false);
+        subType.properties.push({
+            name: 'B',
+            astNodes: new Set(),
+            optional: false,
+            type: {
+                elementType: {
+                    primitive: 'string'
+                }
+            }
+        });
+        subType.superTypes.add(superType);
 
         const reflectionForInheritance = interpretAstReflection({
             interfaces: [superType, subType],
@@ -71,14 +70,14 @@ describe('AST reflection interpreter', () => {
                 },
                 property: 'Ref',
                 reference: undefined!
-            })).toBe('RefTarget');
+            })).toBe('Super');
             expect(reflectionForInheritance.getReferenceType({
                 container: {
                     $type: 'Sub'
                 },
                 property: 'Ref',
                 reference: undefined!
-            })).toBe('RefTarget');
+            })).toBe('Super');
         });
 
         test('Creates metadata with super types', () => {

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { AstNode, createLangiumGrammarServices, EmptyFileSystem, GrammarAST, Properties, streamAllContents, streamContents } from '../../src';
-import { Assignment, isAssignment } from '../../src/grammar/generated/ast';
+import { Assignment, isAssignment, UnionType } from '../../src/grammar/generated/ast';
 import { IssueCodes } from '../../src/grammar/validation/validator';
 import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper, ValidationResult } from '../../src/test';
 
@@ -177,10 +177,10 @@ describe('checkReferenceToRuleButNotType', () => {
     });
 
     test('AtomType validation', () => {
-        const type = validationResult.document.parseResult.value.types[0];
+        const unionType = validationResult.document.parseResult.value.types[0].type as UnionType;
+        const missingType = unionType.types[0];
         expectError(validationResult, "Could not resolve reference to AbstractType named 'Reference'.", {
-            node: type,
-            property: 'typeAlternatives'
+            node: missingType
         });
     });
 

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -366,8 +366,7 @@ describe('Property type is not a mix of cross-ref and non-cross-ref types.', () 
         expect(attribute).not.toBe(undefined);
 
         expectError(validation, /Mixing a cross-reference with other types is not supported. Consider splitting property /, {
-            node: attribute!,
-            property: 'typeAlternatives'
+            node: attribute
         });
     });
 });
@@ -492,7 +491,7 @@ describe('Property types validation takes in account types hierarchy', () => {
         `);
 
         const assignment = streamAllContents(validation.document.parseResult.value).filter(isAssignment).toArray()[0];
-        expectError(validation, "The assigned type 'Z2' is not compatible with the declared property 'y' of type 'Z1':  'Z2' is not expected.", {
+        expectError(validation, "The assigned type 'Z2' is not compatible with the declared property 'y' of type 'Z1'.", {
             node: assignment,
             property: 'feature'
         });

--- a/packages/langium/test/lsp/find-references.test.ts
+++ b/packages/langium/test/lsp/find-references.test.ts
@@ -265,7 +265,7 @@ describe('findReferences', () => {
 
         type C = A | B ;
 
-        ruleC returns C: <|na<|>me|>=ID;
+        ruleC returns C: {A} <|na<|>me|>=ID;
         `;
 
         await findReferences({
@@ -304,30 +304,6 @@ describe('findReferences', () => {
         interface B extends A {}
 
         ActionRule: {B} <|na<|>me|>=ID;
-        `;
-
-        await findReferences({
-            text: grammar,
-            includeDeclaration: true
-        });
-    });
-
-    test('Must find references to a property assigned in action returning union type', async () => {
-        const grammar = `grammar test
-        hidden terminal WS: /\\s+/;
-        terminal ID: /\\w+/;
-
-        interface A {
-            <|na<|>me|>: string
-        }
-
-        interface B {
-            foo: string
-        }
-
-        type C = A | B;
-
-        ActionRule: {C} <|na<|>me|>=ID;
         `;
 
         await findReferences({

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -315,7 +315,7 @@ describe('Boolean value converter', () => {
 describe('BigInt Parser value converter', () => {
     const content = `
     grammar G
-    entry M: value=BIGINT;
+    entry M: value=BIGINT?;
     terminal BIGINT returns bigint: /[0-9]+/;
     hidden terminal WS: /\\s+/;
     `;
@@ -338,6 +338,10 @@ describe('BigInt Parser value converter', () => {
     test('Parsed BigInt is correct', () => {
         expectValue('149587349587234971', BigInt('149587349587234971'));
         expectValue('9007199254740991', BigInt('9007199254740991')); // === 0x1fffffffffffff
+    });
+
+    test('Missing value is implicitly undefined', () => {
+        expectValue('', undefined);
     });
 });
 
@@ -438,25 +442,25 @@ describe('Parser calls value converter', () => {
 
     test('Should parse bool correctly', () => {
         expectValue('b true', true);
-        // this is the current 'boolean' behavior when a prop type can't be resolved to just a boolean
-        // either true/undefined, no false in this case
-        expectValue('b false', undefined);
-        // ...then no distinguishing between the bad parse case when the type is unclear
-        expectValue('b asdfg', undefined);
+        expectValue('b false', false);
+        // Any value that cannot be parsed correctly is automatically false
+        expectValue('b asdfg', false);
     });
 
     test('Should parse BigInt correctly', () => {
         expectValue('big 9007199254740991n', BigInt('9007199254740991'));
-        expectValue('big 9007199254740991', undefined);
-        expectValue('big 1.1', undefined);
-        expectValue('big -19458438592374', undefined);
+        // Any value that cannot be parsed correctly is automatically false
+        expectValue('big 9007199254740991', false);
+        expectValue('big 1.1', false);
+        expectValue('big -19458438592374', false);
     });
 
     test('Should parse Date correctly', () => {
         expectEqual('d 2020-01-01', new Date('2020-01-01'));
         expectEqual('d 2020-01-01T00:00', new Date('2020-01-01T00:00'));
         expectEqual('d 2022-10-04T12:13', new Date('2022-10-04T12:13'));
-        expectEqual('d 2022-Peach', undefined);
+        // Any value that cannot be parsed correctly is automatically false
+        expectEqual('d 2022-Peach', false);
     });
 });
 


### PR DESCRIPTION
This change splits the type system into a "plain" (string-based) type system and a concrete (reference-based) type system. Splitting the types allows for easier handling of purely generated information (i.e. container types, union/interface hierarchies and type names). It also has an impact on how we deal with property types and union types in general, which are now way more flexible.

Aims to resolve multiple issues:
* Closes https://github.com/langium/langium/issues/511 (The grammar has been slightly modified)
* Closes https://github.com/langium/langium/issues/476
* Closes https://github.com/langium/langium/issues/752
* Closes https://github.com/langium/langium/issues/534
* Closes https://github.com/langium/langium/issues/868