### PR TITLE
POC: Use same development version in complete workspace

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,5 +24,6 @@ jobs:
       shell: bash
       run: |
         npm ci
+        npm run build
         npm test
         npm run lint

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -140,6 +140,14 @@
             "args": ["run", "${relativeFile}"],
             "smartStep": true,
             "console": "integratedTerminal",
-        }
+        },
+        {
+            "name": "Version Upgrade",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/versions.mjs",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        },
     ]
 }

--- a/examples/arithmetics/package.json
+++ b/examples/arithmetics/package.json
@@ -1,7 +1,7 @@
 {
     "name": "langium-arithmetics-dsl",
     "displayName": "Arithmetics DSL",
-    "version": "1.0.0",
+    "version": "1.0.0-dev.0",
     "description": "Example language built with Langium",
     "homepage": "https://langium.org",
     "engines": {
@@ -60,12 +60,12 @@
     "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
     },
     "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
     },
     "repository": {
         "type": "git",

--- a/examples/domainmodel/package.json
+++ b/examples/domainmodel/package.json
@@ -1,7 +1,7 @@
 {
     "name": "langium-domainmodel-dsl",
     "displayName": "Domain Model DSL",
-    "version": "1.0.0",
+    "version": "1.0.0-dev.0",
     "description": "Example language built with Langium",
     "homepage": "https://langium.org",
     "engines": {
@@ -60,13 +60,13 @@
     "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
     },
     "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
     },
     "repository": {
         "type": "git",

--- a/examples/requirements/package.json
+++ b/examples/requirements/package.json
@@ -2,7 +2,7 @@
     "name": "langium-requirements-dsl",
     "displayName": "Requirements DSL",
     "description": "A demo showing how to combine two DSLs",
-    "version": "1.0.0",
+    "version": "1.0.0-dev.0",
     "engines": {
         "vscode": "^1.56.0"
     },
@@ -10,26 +10,42 @@
         "Programming Languages"
     ],
     "contributes": {
-        "languages": [{
-            "id": "requirements-lang",
-            "aliases": ["Requirements Language", "requirements-lang"],
-            "extensions": [".req"],
-            "configuration": "./language-configuration.json"
-        },{
-            "id": "tests-lang",
-            "aliases": ["Tests Language", "tests-lang"],
-            "extensions": [".tst"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "requirements-lang",
-            "scopeName": "source.requirements-lang",
-            "path": "./syntaxes/requirements.tmLanguage.json"
-        },{
-            "language": "tests-lang",
-            "scopeName": "source.tests-lang",
-            "path": "./syntaxes/tests.tmLanguage.json"
-        }]
+        "languages": [
+            {
+                "id": "requirements-lang",
+                "aliases": [
+                    "Requirements Language",
+                    "requirements-lang"
+                ],
+                "extensions": [
+                    ".req"
+                ],
+                "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "tests-lang",
+                "aliases": [
+                    "Tests Language",
+                    "tests-lang"
+                ],
+                "extensions": [
+                    ".tst"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "requirements-lang",
+                "scopeName": "source.requirements-lang",
+                "path": "./syntaxes/requirements.tmLanguage.json"
+            },
+            {
+                "language": "tests-lang",
+                "scopeName": "source.tests-lang",
+                "path": "./syntaxes/tests.tmLanguage.json"
+            }
+        ]
     },
     "activationEvents": [
         "onLanguage:requirements-and-tests",
@@ -56,12 +72,12 @@
     "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.1",
         "vscode-languageserver": "^8.0.1"
     },
     "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
     }
 }

--- a/examples/statemachine/package.json
+++ b/examples/statemachine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "langium-statemachine-dsl",
     "displayName": "State Machine DSL",
-    "version": "1.0.0",
+    "version": "1.0.0-dev.0",
     "description": "Example language built with Langium",
     "homepage": "https://langium.org",
     "engines": {
@@ -61,13 +61,13 @@
     "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
     },
     "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
     },
     "repository": {
         "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
       "devDependencies": {
         "@types/jest": "^29.0.3",
         "@types/jest-expect-message": "^1.0.4",
+        "@types/shelljs": "~0.8.11",
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "@vitest/coverage-c8": "^0.23.2",
         "@vitest/ui": "^0.23.4",
         "eslint": "^8.17.0",
         "eslint-plugin-header": "^3.1.1",
+        "shelljs": "~0.8.5",
         "shx": "^0.3.4",
         "typescript": "^4.9.4",
         "vitest": "^0.23.2"
@@ -28,12 +30,12 @@
     },
     "examples/arithmetics": {
       "name": "langium-arithmetics-dsl",
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
       },
@@ -41,7 +43,7 @@
         "arithmetics-cli": "bin/cli"
       },
       "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -49,12 +51,12 @@
     },
     "examples/domainmodel": {
       "name": "langium-domainmodel-dsl",
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
@@ -63,7 +65,7 @@
         "domainmodel-cli": "bin/cli"
       },
       "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -71,11 +73,11 @@
     },
     "examples/requirements": {
       "name": "langium-requirements-dsl",
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.1",
         "vscode-languageserver": "^8.0.1"
@@ -84,7 +86,7 @@
         "requirements-and-tests-lang-cli": "bin/cli"
       },
       "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -92,12 +94,12 @@
     },
     "examples/statemachine": {
       "name": "langium-statemachine-dsl",
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
@@ -106,7 +108,7 @@
         "statemachine-cli": "bin/cli"
       },
       "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -1025,6 +1027,16 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+    },
+    "node_modules/@types/shelljs": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.11.tgz",
+      "integrity": "sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -7802,7 +7814,7 @@
       }
     },
     "packages/langium": {
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^10.4.1",
@@ -7812,21 +7824,21 @@
         "vscode-uri": "^3.0.2"
       },
       "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "1.0.0-dev.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "packages/langium-cli": {
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
         "fs-extra": "^9.1.0",
         "jsonschema": "^1.4.0",
-        "langium": "~1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21"
       },
       "bin": {
@@ -7840,19 +7852,19 @@
       }
     },
     "packages/langium-sprotty": {
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
-        "langium": "~1.0.0",
+        "langium": "1.0.0-dev.0",
         "sprotty-protocol": "^0.12.0"
       }
     },
     "packages/langium-vscode": {
-      "version": "1.0.0",
+      "version": "1.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "ignore": "~5.2.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "vscode-languageserver": "^8.0.2"
       },
       "devDependencies": {
@@ -8677,6 +8689,16 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+    },
+    "@types/shelljs": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.11.tgz",
+      "integrity": "sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -10943,7 +10965,7 @@
       "requires": {
         "chevrotain": "^10.4.1",
         "chevrotain-allstar": "^0.1.1",
-        "langium-cli": "1.0.0",
+        "langium-cli": "1.0.0-dev.0",
         "vscode-languageserver": "^8.0.2",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-uri": "^3.0.2"
@@ -10954,8 +10976,8 @@
       "requires": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
-        "langium-cli": "1.0.0",
+        "langium": "1.0.0-dev.0",
+        "langium-cli": "1.0.0-dev.0",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
       }
@@ -10968,7 +10990,7 @@
         "commander": "^8.0.0",
         "fs-extra": "^9.1.0",
         "jsonschema": "^1.4.0",
-        "langium": "~1.0.0",
+        "langium": "1.0.0-dev.0",
         "lodash": "^4.17.21"
       }
     },
@@ -10977,8 +10999,8 @@
       "requires": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
-        "langium-cli": "1.0.0",
+        "langium": "1.0.0-dev.0",
+        "langium-cli": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
@@ -10989,8 +11011,8 @@
       "requires": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
-        "langium-cli": "1.0.0",
+        "langium": "1.0.0-dev.0",
+        "langium-cli": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.1",
         "vscode-languageserver": "^8.0.1"
@@ -10999,7 +11021,7 @@
     "langium-sprotty": {
       "version": "file:packages/langium-sprotty",
       "requires": {
-        "langium": "~1.0.0",
+        "langium": "1.0.0-dev.0",
         "sprotty-protocol": "^0.12.0"
       }
     },
@@ -11008,8 +11030,8 @@
       "requires": {
         "chalk": "^4.1.2",
         "commander": "^8.0.0",
-        "langium": "1.0.0",
-        "langium-cli": "1.0.0",
+        "langium": "1.0.0-dev.0",
+        "langium-cli": "1.0.0-dev.0",
         "lodash": "^4.17.21",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2"
@@ -11021,7 +11043,7 @@
         "@types/vscode": "^1.53.0",
         "esbuild": "^0.14.25",
         "ignore": "~5.2.0",
-        "langium": "1.0.0",
+        "langium": "1.0.0-dev.0",
         "vscode-languageserver": "^8.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,27 +6,29 @@
     "npm": ">= 7.7.0"
   },
   "scripts": {
-    "prepare": "npm run clean && npm run build && npm run build --workspace=langium-vscode",
     "clean": "shx rm -rf packages/**/lib packages/**/out packages/**/tsconfig.tsbuildinfo",
-    "build": "tsc -b tsconfig.build.json",
+    "compile": "tsc -b tsconfig.build.json",
+    "build": "npm run clean && npm run compile && npm run build --workspace=langium-vscode",
     "watch": "tsc -b tsconfig.build.json -w",
     "lint": "npm run lint --workspaces",
     "test": "vitest",
     "test-ui": "vitest --ui",
     "coverage": "vitest run --coverage",
     "langium:generate": "npm run langium:generate --workspace=packages/langium --workspace=examples/domainmodel --workspace=examples/arithmetics --workspace=examples/statemachine --workspace=examples/requirements",
-    "dev-build": "npm run dev-clean && npm install && npm link ./packages/langium && npm link ./packages/langium-cli && npm link ./packages/generator-langium",
-    "dev-clean": "shx rm -rf packages/**/node_modules && npm uninstall -g langium-workspaces langium-cli generator-langium langium && npm unlink langium-workspaces langium-cli generator-langium langium"
+    "dev:clean": "npx shx rm -rf packages/**/node_modules && npm uninstall -g langium-workspaces langium-cli generator-langium langium && npm unlink langium-workspaces langium-cli generator-langium langium",
+    "dev:versions": "node versions.mjs"
   },
   "devDependencies": {
     "@types/jest": "^29.0.3",
     "@types/jest-expect-message": "^1.0.4",
+    "@types/shelljs": "~0.8.11",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "@vitest/coverage-c8": "^0.23.2",
     "@vitest/ui": "^0.23.4",
     "eslint": "^8.17.0",
     "eslint-plugin-header": "^3.1.1",
+    "shelljs": "~0.8.5",
     "shx": "^0.3.4",
     "typescript": "^4.9.4",
     "vitest": "^0.23.2"

--- a/packages/langium-cli/package.json
+++ b/packages/langium-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langium-cli",
-  "version": "1.0.0",
+  "version": "1.0.0-dev.0",
   "description": "CLI for Langium - the language engineering tool",
   "homepage": "https://langium.org",
   "engines": {
@@ -37,7 +37,7 @@
     "commander": "^8.0.0",
     "fs-extra": "^9.1.0",
     "jsonschema": "^1.4.0",
-    "langium": "~1.0.0",
+    "langium": "1.0.0-dev.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/langium-sprotty/package.json
+++ b/packages/langium-sprotty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langium-sprotty",
-  "version": "1.0.0",
+  "version": "1.0.0-dev.0",
   "description": "Use Langium as source for Sprotty diagram models",
   "homepage": "https://langium.org",
   "keywords": [
@@ -29,7 +29,7 @@
     "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {
-    "langium": "~1.0.0",
+    "langium": "1.0.0-dev.0",
     "sprotty-protocol": "^0.12.0"
   },
   "repository": {

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "langium-vscode",
   "publisher": "langium",
-  "version": "1.0.0",
+  "version": "1.0.0-dev.0",
   "displayName": "Langium",
   "description": "Support for the Langium Grammar Language",
   "homepage": "https://langium.org",
@@ -69,7 +69,7 @@
     "lint": "eslint src --ext ts"
   },
   "dependencies": {
-    "langium": "1.0.0",
+    "langium": "1.0.0-dev.0",
     "vscode-languageserver": "^8.0.2",
     "ignore": "~5.2.0"
   },

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langium",
-  "version": "1.0.0",
+  "version": "1.0.0-dev.0",
   "description": "A language engineering tool for the Language Server Protocol",
   "homepage": "https://langium.org",
   "engines": {
@@ -43,7 +43,7 @@
     "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
-    "langium-cli": "1.0.0"
+    "langium-cli": "1.0.0-dev.0"
   },
   "repository": {
     "type": "git",

--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -54,6 +54,7 @@ export interface DefaultModuleContext {
  * set of services that are used by exactly one language.
  */
 export function createDefaultModule(context: DefaultModuleContext): Module<LangiumServices, LangiumDefaultServices> {
+    console.log('tester3');
     return {
         parser: {
             GrammarConfig: (services) => createGrammarConfig(services),

--- a/versions.mjs
+++ b/versions.mjs
@@ -1,0 +1,52 @@
+// eslint-disable-next-line header/header
+import shell from 'shelljs';
+
+const version = '1.0.0-dev.0';
+const versionPattern = '.*[0-9]\\.[0-9]\\.[0-9].*';
+
+function updateLangium() {
+    shell.exec(`npm version --workspace packages/langium ${version}`);
+    shell.sed('-i', `"langium-cli": "${versionPattern}"`, `"langium-cli": "${version}"`, 'packages/langium/package.json');
+}
+
+function updateLangiumCli() {
+    shell.exec(`npm version --workspace packages/langium-cli ${version}`);
+    shell.sed('-i', `"langium": "${versionPattern}"`, `"langium": "${version}"`, 'packages/langium-cli/package.json');
+}
+
+function updateLangiumSprotty() {
+    shell.exec(`npm version --workspace packages/langium-sprotty ${version}`);
+    shell.sed('-i', `"langium": "${versionPattern}"`, `"langium": "${version}"`, 'packages/langium-sprotty/package.json');
+}
+
+function updateLangiumVscode() {
+    shell.exec(`npm version --workspace packages/langium-vscode ${version}`);
+    shell.sed('-i', `"langium": "${versionPattern}"`, `"langium": "${version}"`, 'packages/langium-vscode/package.json');
+}
+
+function updateGenerateLangium() {
+    shell.exec(`npm version --workspace packages/generate-langium ${version}`);
+}
+
+function updateExamples(name) {
+    shell.exec(`npm version --workspace examples/${name} ${version}`);
+    shell.sed('-i', `"langium": "${versionPattern}"`, `"langium": "${version}"`, `examples/${name}/package.json`);
+    shell.sed('-i', `"langium-cli": "${versionPattern}"`, `"langium-cli": "${version}"`, `examples/${name}/package.json`);
+    // should work, but does not
+    //shell.exec(`npm install --workspace examples/${name} langium@${version} --save-exact`);
+    //shell.exec(`npm install --workspace examples/${name} langium-cli@${version} --save-exact --save-dev`);
+}
+
+updateLangium();
+updateLangiumCli();
+updateLangiumSprotty();
+updateLangiumVscode();
+updateGenerateLangium();
+
+updateExamples('arithmetics');
+updateExamples('domainmodel');
+updateExamples('requirements');
+updateExamples('statemachine');
+
+// ensures all sed manipulations are taken into account
+shell.exec('npm install');


### PR DESCRIPTION
This is a proof of concept that allows to reconfigure a new version throughout the workspace.

All packages have and reference the same version. Supplied node js script uses shell js to perform the changes

If this version specified is not available from a registry, then it is resolved locally **without any special adjustments** (like npm link). 
Resolution between examples and langium package works. When `npm run watch` is executed cli execution works: Tested with naive console.log in `default-module.ts` and arithmetics example.

Idea is to move to an "incremented" version immediately after release and then use this in development. WDYT?