### PR TITLE
Remove unions from container types calculation

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -31,7 +31,6 @@ export function isStatement(item: unknown): item is Statement {
 }
 
 export interface BinaryExpression extends AstNode {
-    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'BinaryExpression';
     left: Expression
     operator: '*' | '+' | '-' | '/'
@@ -45,7 +44,7 @@ export function isBinaryExpression(item: unknown): item is BinaryExpression {
 }
 
 export interface DeclaredParameter extends AstNode {
-    readonly $container: Definition | Module;
+    readonly $container: Definition;
     readonly $type: 'DeclaredParameter';
     name: string
 }
@@ -57,7 +56,6 @@ export function isDeclaredParameter(item: unknown): item is DeclaredParameter {
 }
 
 export interface Definition extends AstNode {
-    readonly $container: Definition | Module;
     readonly $type: 'Definition';
     args: Array<DeclaredParameter>
     expr: Expression
@@ -71,7 +69,6 @@ export function isDefinition(item: unknown): item is Definition {
 }
 
 export interface Evaluation extends AstNode {
-    readonly $container: Definition | Module;
     readonly $type: 'Evaluation';
     expression: Expression
 }
@@ -83,7 +80,6 @@ export function isEvaluation(item: unknown): item is Evaluation {
 }
 
 export interface FunctionCall extends AstNode {
-    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'FunctionCall';
     args: Array<Expression>
     func: Reference<AbstractDefinition>
@@ -108,7 +104,6 @@ export function isModule(item: unknown): item is Module {
 }
 
 export interface NumberLiteral extends AstNode {
-    readonly $container: BinaryExpression | Definition | Evaluation | FunctionCall;
     readonly $type: 'NumberLiteral';
     value: number
 }

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -25,7 +25,6 @@ export function isType(item: unknown): item is Type {
 }
 
 export interface DataType extends AstNode {
-    readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'DataType';
     name: string
 }
@@ -48,7 +47,6 @@ export function isDomainmodel(item: unknown): item is Domainmodel {
 }
 
 export interface Entity extends AstNode {
-    readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'Entity';
     features: Array<Feature>
     name: string
@@ -76,7 +74,6 @@ export function isFeature(item: unknown): item is Feature {
 }
 
 export interface PackageDeclaration extends AstNode {
-    readonly $container: Domainmodel | PackageDeclaration;
     readonly $type: 'PackageDeclaration';
     elements: Array<AbstractElement>
     name: QualifiedName

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -35,7 +35,7 @@ export type FeatureName = string;
 export type PrimitiveType = 'Date' | 'bigint' | 'boolean' | 'number' | 'string';
 
 export interface AbstractElement extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?'
 }
@@ -63,7 +63,6 @@ export function isAtomType(item: unknown): item is AtomType {
 }
 
 export interface Conjunction extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Conjunction';
     left: Condition
     right: Condition
@@ -76,7 +75,6 @@ export function isConjunction(item: unknown): item is Conjunction {
 }
 
 export interface Disjunction extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Disjunction';
     left: Condition
     right: Condition
@@ -132,7 +130,7 @@ export function isInferredType(item: unknown): item is InferredType {
 }
 
 export interface Interface extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Grammar;
     readonly $type: 'Interface';
     attributes: Array<TypeAttribute>
     name: string
@@ -146,7 +144,6 @@ export function isInterface(item: unknown): item is Interface {
 }
 
 export interface LiteralCondition extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'LiteralCondition';
     true: boolean
 }
@@ -172,7 +169,6 @@ export function isNamedArgument(item: unknown): item is NamedArgument {
 }
 
 export interface Negation extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'Negation';
     value: Condition
 }
@@ -196,7 +192,6 @@ export function isParameter(item: unknown): item is Parameter {
 }
 
 export interface ParameterReference extends AstNode {
-    readonly $container: Conjunction | Disjunction | Group | NamedArgument | Negation;
     readonly $type: 'ParameterReference';
     parameter: Reference<Parameter>
 }
@@ -208,7 +203,6 @@ export function isParameterReference(item: unknown): item is ParameterReference 
 }
 
 export interface ParserRule extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'ParserRule';
     dataType?: PrimitiveType
     definesHiddenTokens: boolean
@@ -242,7 +236,6 @@ export function isReturnType(item: unknown): item is ReturnType {
 }
 
 export interface TerminalRule extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalRule';
     definition: AbstractElement
     fragment: boolean
@@ -258,7 +251,7 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
 }
 
 export interface Type extends AstNode {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Grammar;
     readonly $type: 'Type';
     name: string
     typeAlternatives: Array<AtomType>
@@ -285,7 +278,7 @@ export function isTypeAttribute(item: unknown): item is TypeAttribute {
 }
 
 export interface Action extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Action';
     feature?: FeatureName
     inferredType?: InferredType
@@ -300,7 +293,7 @@ export function isAction(item: unknown): item is Action {
 }
 
 export interface Alternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Alternatives';
     elements: Array<AbstractElement>
 }
@@ -312,7 +305,7 @@ export function isAlternatives(item: unknown): item is Alternatives {
 }
 
 export interface Assignment extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Assignment';
     feature: FeatureName
     operator: '+=' | '=' | '?='
@@ -326,7 +319,7 @@ export function isAssignment(item: unknown): item is Assignment {
 }
 
 export interface CharacterRange extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'CharacterRange';
     left: Keyword
     right?: Keyword
@@ -339,7 +332,7 @@ export function isCharacterRange(item: unknown): item is CharacterRange {
 }
 
 export interface CrossReference extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'CrossReference';
     deprecatedSyntax: boolean
     terminal?: AbstractElement
@@ -353,7 +346,7 @@ export function isCrossReference(item: unknown): item is CrossReference {
 }
 
 export interface Group extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Group';
     elements: Array<AbstractElement>
     guardCondition?: Condition
@@ -366,7 +359,7 @@ export function isGroup(item: unknown): item is Group {
 }
 
 export interface Keyword extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Keyword';
     value: string
 }
@@ -378,7 +371,7 @@ export function isKeyword(item: unknown): item is Keyword {
 }
 
 export interface NegatedToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'NegatedToken';
     terminal: AbstractElement
 }
@@ -390,7 +383,7 @@ export function isNegatedToken(item: unknown): item is NegatedToken {
 }
 
 export interface RegexToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'RegexToken';
     regex: string
 }
@@ -402,7 +395,7 @@ export function isRegexToken(item: unknown): item is RegexToken {
 }
 
 export interface RuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'RuleCall';
     arguments: Array<NamedArgument>
     rule: Reference<AbstractRule>
@@ -415,7 +408,7 @@ export function isRuleCall(item: unknown): item is RuleCall {
 }
 
 export interface TerminalAlternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalAlternatives';
     elements: Array<AbstractElement>
 }
@@ -427,7 +420,7 @@ export function isTerminalAlternatives(item: unknown): item is TerminalAlternati
 }
 
 export interface TerminalGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalGroup';
     elements: Array<AbstractElement>
 }
@@ -439,7 +432,7 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
 }
 
 export interface TerminalRuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalRuleCall';
     rule: Reference<TerminalRule>
 }
@@ -451,7 +444,7 @@ export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
 }
 
 export interface UnorderedGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'UnorderedGroup';
     elements: Array<AbstractElement>
 }
@@ -463,7 +456,7 @@ export function isUnorderedGroup(item: unknown): item is UnorderedGroup {
 }
 
 export interface UntilToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'UntilToken';
     terminal: AbstractElement
 }
@@ -475,7 +468,7 @@ export function isUntilToken(item: unknown): item is UntilToken {
 }
 
 export interface Wildcard extends AbstractElement {
-    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Alternatives | Assignment | AtomType | CharacterRange | CrossReference | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Wildcard';
 }
 

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -753,18 +753,15 @@ describe('expression rules with inferred and declared interfaces', () => {
         const inferredInterfacesString = inferred.interfaces.map(toSubstring).join('\n').trim();
         expect(inferredInterfacesString).toBe(expandToString`
             export interface BooleanLiteral extends AstNode {
-                readonly $container: MemberAccess | SuperMemberAccess;
                 readonly $type: 'BooleanLiteral';
                 value: boolean
             }
             export interface MemberAccess extends AstNode {
-                readonly $container: MemberAccess | SuperMemberAccess;
                 readonly $type: 'MemberAccess';
                 member: Reference<Symbol>
                 receiver: PrimaryExpression
             }
             export interface SuperMemberAccess extends AstNode {
-                readonly $container: MemberAccess | SuperMemberAccess;
                 readonly $type: 'SuperMemberAccess';
                 member: Reference<Symbol>
                 receiver: PrimaryExpression
@@ -796,12 +793,10 @@ describe('expression rules with inferred and declared interfaces', () => {
         const allInterfacesString = allTypes.interfaces.map(toSubstring).join('\n').trim();
         expect(allInterfacesString).toBe(expandToString`
             export interface BooleanLiteral extends AstNode {
-                readonly $container: MemberAccess;
                 readonly $type: 'BooleanLiteral';
                 value: boolean
             }
             export interface MemberAccess extends AstNode {
-                readonly $container: MemberAccess;
                 readonly $type: 'MemberAccess' | 'SuperMemberAccess';
                 member: Reference<Symbol>
                 receiver: PrimaryExpression
@@ -810,7 +805,6 @@ describe('expression rules with inferred and declared interfaces', () => {
                 readonly $type: 'Symbol';
             }
             export interface SuperMemberAccess extends MemberAccess {
-                readonly $container: MemberAccess;
                 readonly $type: 'SuperMemberAccess';
             }
         `);
@@ -888,7 +882,6 @@ describe('types of `$container` and `$type` are correct', () => {
         const interfacesString = sortInterfacesTopologically(interfaces).map(toSubstring).join('\n').trim();
         expect(interfacesString).toBe(expandToString`
             export interface C extends AstNode {
-                readonly $container: D | E;
                 readonly $type: 'C';
                 strC: string
             }


### PR DESCRIPTION
Partially closes #150.
Union types very often connect hierarchies what leads to exponential growth of container types number. Ignoring them in the calculation improves the situation.