### PR TITLE
Improve rule reachability computation

### DIFF
--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -27,12 +27,15 @@ export function getEntryRule(grammar: ast.Grammar): ast.ParserRule | undefined {
     return grammar.rules.find(e => ast.isParserRule(e) && e.entry) as ast.ParserRule;
 }
 
-export function getHiddenRules(grammar: ast.Grammar): ast.TerminalRule[] {
-    return grammar.rules.filter(e => ast.isTerminalRule(e) && e.hidden) as ast.TerminalRule[];
+/**
+ * Returns all hidden terminal rules of the given grammar, if any.
+ */
+export function getHiddenRules(grammar: ast.Grammar) {
+    return grammar.rules.filter(e => ast.isTerminalRule(e) && e.hidden);
 }
 
 /**
- * Returns all rules that can be reached from the entry point of the specified grammar.
+ * Returns all rules that can be reached from the topmost rules of the specified grammar (entry and hidden terminal rules).
  *
  * @param grammar The grammar that contains all rules
  * @param allTerminals Whether or not to include terminals that are referenced only by other terminals
@@ -46,7 +49,7 @@ export function getAllReachableRules(grammar: ast.Grammar, allTerminals: boolean
         return new Set(grammar.rules);
     }
 
-    const topMostRules = [entryRule as ast.AbstractRule].concat(getHiddenRules(grammar)); //TODO Markus: naming entryRules? rootRules?
+    const topMostRules = [entryRule as ast.AbstractRule].concat(getHiddenRules(grammar));
     for (const rule of topMostRules) {
         ruleDfs(rule, ruleNames, allTerminals);
     }

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -27,6 +27,10 @@ export function getEntryRule(grammar: ast.Grammar): ast.ParserRule | undefined {
     return grammar.rules.find(e => ast.isParserRule(e) && e.entry) as ast.ParserRule;
 }
 
+export function getHiddenRules(grammar: ast.Grammar): ast.TerminalRule[] {
+    return grammar.rules.filter(e => ast.isTerminalRule(e) && e.hidden) as ast.TerminalRule[];
+}
+
 /**
  * Returns all rules that can be reached from the entry point of the specified grammar.
  *
@@ -41,7 +45,12 @@ export function getAllReachableRules(grammar: ast.Grammar, allTerminals: boolean
     if (!entryRule) {
         return new Set(grammar.rules);
     }
-    ruleDfs(entryRule, ruleNames, allTerminals);
+
+    const topMostRules = [entryRule as ast.AbstractRule].concat(getHiddenRules(grammar)); //TODO Markus: naming entryRules? rootRules?
+    for (const rule of topMostRules) {
+        ruleDfs(rule, ruleNames, allTerminals);
+    }
+
     const rules = new Set<ast.AbstractRule>();
     for (const rule of grammar.rules) {
         if (ruleNames.has(rule.name) || (ast.isTerminalRule(rule) && rule.hidden)) {

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -31,7 +31,7 @@ export function getEntryRule(grammar: ast.Grammar): ast.ParserRule | undefined {
  * Returns all hidden terminal rules of the given grammar, if any.
  */
 export function getHiddenRules(grammar: ast.Grammar) {
-    return grammar.rules.filter(e => ast.isTerminalRule(e) && e.hidden);
+    return grammar.rules.filter((e): e is ast.TerminalRule => ast.isTerminalRule(e) && e.hidden);
 }
 
 /**


### PR DESCRIPTION
...to respect terminal fragments that are used within hidden terminal rules.

Closes #865 

Before you approve: One TODO is about the naming of a variable ^^... was not sure what is the best term.