### PR TITLE
Start type generation from given grammar file #864

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8044,7 +8044,7 @@
         "vscode-uri": "~3.0.7"
       },
       "devDependencies": {
-        "langium-cli": "1.0.0"
+        "langium-cli": "~1.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -11371,7 +11371,7 @@
       "requires": {
         "chevrotain": "~10.4.2",
         "chevrotain-allstar": "~0.1.4",
-        "langium-cli": "1.0.0",
+        "langium-cli": "~1.0.0",
         "vscode-languageserver": "~8.0.2",
         "vscode-languageserver-textdocument": "~1.0.8",
         "vscode-uri": "~3.0.7"

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -43,7 +43,7 @@
     "vscode-uri": "~3.0.7"
   },
   "devDependencies": {
-    "langium-cli": "1.0.0"
+    "langium-cli": "~1.0.0"
   },
   "volta": {
     "node": "16.19.0",


### PR DESCRIPTION
Fixes bogus behavior in multi grammar projects described in #864

I'm not sure how we handle versions changes in langium-cli. I could imagine to update langium-cli dependencies in examples to ~1.0.1, but it is not really necessary. 