### PR TITLE
Respect declared types when infering union types

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/all-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/all-types.ts
@@ -30,8 +30,8 @@ export type TypeResources = {
 
 export function collectTypeResources(grammars: Grammar | Grammar[], documents?: LangiumDocuments): TypeResources {
     const astResources = collectAllAstResources(grammars, documents);
-    const inferred = collectInferredTypes(astResources.parserRules, astResources.datatypeRules);
     const declared = collectDeclaredTypes(astResources.interfaces, astResources.types);
+    const inferred = collectInferredTypes(astResources.parserRules, astResources.datatypeRules, declared);
 
     shareSuperTypesFromUnions(inferred, declared);
     addSuperProperties(mergeInterfaces(inferred, declared));

--- a/packages/langium/src/grammar/type-system/type-collector/all-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/all-types.ts
@@ -48,7 +48,7 @@ function addSuperProperties(allTypes: InterfaceType[]) {
             const superType = allTypes.find(e => e.name === superTypeName);
 
             if (superType && isInterfaceType(superType)) {
-                addSuperPropertiesInternal(superType);
+                addSuperPropertiesInternal(superType, visited);
                 superType.superProperties
                     .entriesGroupedByKey()
                     .forEach(propInfo => type.superProperties.addAll(propInfo[0], propInfo[1]));

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -162,6 +162,19 @@ describe('validate declared types', () => {
         expect(diagnostics.filter(d => d.severity === DiagnosticSeverity.Error)).toHaveLength(0);
 
     });
+
+    test('Can return an interface from a rule that would return a union type', async () => {
+        const grammar = `
+        X returns X: Y | Z;
+        Y: y='y';
+        Z: z='z';
+        // X would normally return a union type of Y | Z
+        // This forces it into an interface
+        interface X { }
+        `;
+        const validation = await validate(grammar);
+        expectNoIssues(validation);
+    });
 });
 
 describe('validate actions that use declared types', () => {


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/844

First computes declared types and uses these types to perform the type inference. While attempting to transform an inferred interface into a union type, we first check whether it's already declared as an interface. If there's no interface with the same name, we continue as usual.