### PR TITLE
generation support: some bugfixes and improvements

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -4,8 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CompositeGeneratorNode, NL } from '../../../generator/generator-node';
-import { processGeneratorNode } from '../../../generator/node-processor';
+import { CompositeGeneratorNode, NL, toString } from '../../../generator/generator-node';
 import { CstNode } from '../../../syntax-tree';
 import { MultiMap } from '../../../utils/collections';
 import { Assignment, Action, TypeAttribute } from '../../generated/ast';
@@ -63,13 +62,13 @@ export class UnionType {
             unionNode.append(NL);
             pushReflectionInfo(unionNode, this.name);
         }
-        return processGeneratorNode(unionNode);
+        return toString(unionNode);
     }
 
     toDeclaredTypesString(reservedWords: Set<string>): string {
         const unionNode = new CompositeGeneratorNode();
         unionNode.append(`type ${escapeReservedWords(this.name, reservedWords)} = ${propertyTypesToString(this.alternatives, 'DeclaredType')};`, NL);
-        return processGeneratorNode(unionNode);
+        return toString(unionNode);
     }
 }
 
@@ -111,7 +110,7 @@ export class InterfaceType {
 
         interfaceNode.append(NL);
         pushReflectionInfo(interfaceNode, this.name);
-        return processGeneratorNode(interfaceNode);
+        return toString(interfaceNode);
     }
 
     toDeclaredTypesString(reservedWords: Set<string>): string {
@@ -124,7 +123,7 @@ export class InterfaceType {
         interfaceNode.indent(body => pushProperties(body, this.properties, 'DeclaredType', reservedWords));
 
         interfaceNode.append('}', NL);
-        return processGeneratorNode(interfaceNode);
+        return toString(interfaceNode);
     }
 }
 

--- a/packages/langium/test/generator/node.test.ts
+++ b/packages/langium/test/generator/node.test.ts
@@ -5,8 +5,7 @@
  ******************************************************************************/
 
 import { EOL } from 'os';
-import { CompositeGeneratorNode, NL, NLEmpty, NewLineNode, IndentNode } from '../../src';
-import { processGeneratorNode as process } from '../../src/generator/node-processor';
+import { CompositeGeneratorNode, IndentNode, NewLineNode, NL, NLEmpty, toString as process } from '../../src';
 
 describe('new lines', () => {
 
@@ -70,13 +69,57 @@ describe('indentation', () => {
         expect(node.indentation).toBe('  ');
     });
 
-    test('should indent 4 spaces by default after new line', () => {
+    test('should indent 4 spaces by default after new line (via children array)', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('No indent', NL);
+        comp.indent( [ 'Indent' ]);
+        expect(process(comp)).toBe(`No indent${EOL}    Indent`);
+    });
+
+    test('should indent 4 spaces by default after new line (via callback)', () => {
         const comp = new CompositeGeneratorNode();
         comp.append('No indent', NL);
         comp.indent(node => {
             node.append('Indent');
         });
         expect(process(comp)).toBe(`No indent${EOL}    Indent`);
+    });
+
+    test('should indent 4 spaces by default after new line (via configurator and array)', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('No indent', NL);
+        comp.indent( {
+            indentedChildren:  ['Indent' ]
+        });
+        expect(process(comp)).toBe(`No indent${EOL}    Indent`);
+    });
+
+    test('should indent 4 spaces by default after new line (via configurator and callback)', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('No indent', NL);
+        comp.indent( {
+            indentedChildren:  node => {
+                node.append('Indent');
+            }
+        });
+        expect(process(comp)).toBe(`No indent${EOL}    Indent`);
+    });
+
+    test('should indent [2, 3] spaces (via configurator)', () => {
+        const comp = new CompositeGeneratorNode();
+        comp.append('No indent', NL);
+        comp.indent( {
+            indentation: 2,
+            indentedChildren:  ['Indent 2', NL, NL ]
+        });
+        comp.append('No indent', NL);
+        comp.indent( {
+            indentation: '   ',
+            indentEmptyLines: true,
+            indentImmediately: false,
+            indentedChildren:  node => node.append('Not yet indented', NL, NL, 'Indent 3')
+        });
+        expect(process(comp, 7)).toBe(`No indent${EOL}  Indent 2${EOL}${EOL}No indent${EOL}Not yet indented${EOL}   ${EOL}   Indent 3`);
     });
 
     test('should indent 2 spaces if specified after new line', () => {


### PR DESCRIPTION
... and additional tests

* introduces a 'separator' argument to `joinToNode`
* improves the generation of IndentNodes by `expandToNode`
* refines/fixes the application of (non-immediate) indentation handling in the generator node processor
