### PR TITLE
generation support: tracing API and implementation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,6 +56,7 @@
             "default": "array-simple"
         }],
         "@typescript-eslint/ban-types": "error",                    // bans types like String in favor of string
+        "@typescript-eslint/no-inferrable-types": "off",            // don't blame decls like "index: number = 0", esp. in api signatures!
         "@typescript-eslint/indent": "error",                       // consistent indentation
         "@typescript-eslint/no-explicit-any": "error",              // don't use :any type
         "@typescript-eslint/no-misused-new": "error",               // no constructors for interfaces or new for classes

--- a/examples/arithmetics/src/language-server/main-browser.ts
+++ b/examples/arithmetics/src/language-server/main-browser.ts
@@ -26,7 +26,10 @@ const documentChangeNotification = new NotificationType<DocumentChange>('browser
 const jsonSerializer = arithmetics.serializer.JsonSerializer;
 shared.workspace.DocumentBuilder.onBuildPhase(DocumentState.Validated, documents => {
     for (const document of documents) {
-        const json = jsonSerializer.serialize(document.parseResult.value);
+        const json = jsonSerializer.serialize(document.parseResult.value, {
+            sourceText: true,
+            textRegions: true,
+        });
         connection.sendNotification(documentChangeNotification, {
             uri: document.uri.toString(),
             content: json,

--- a/packages/langium/src/generator/generator-node.ts
+++ b/packages/langium/src/generator/generator-node.ts
@@ -4,8 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import type { AstNode, Properties } from '../syntax-tree';
+import type { TraceRegion, TraceSourceSpec } from './generator-tracing';
 import { processGeneratorNode } from './node-processor';
-import { expandToNode } from './template-node';
+import { expandToNode, expandTracedToNode } from './template-node';
 
 export const EOL = (typeof process === 'undefined') ? '\n' : (process.platform === 'win32') ? '\r\n' : '\n';
 
@@ -41,12 +43,27 @@ export function isNewLineNode(node: unknown): node is NewLineNode {
  * @param defaultIndentation the indentation to be applied if no explicit indentation is configured
  *  for particular {@link IndentNode IndentNodes}, either a `string` or a `number` of repeated single spaces,
  *  defaults to 4 single spaces, see {@link processGeneratorNode} -> `Context`.
+ *
+ * @returns the plain `string` represented by the given input.
  */
 export function toString(input: unknown, defaultIndentation?: string | number): string {
     if (isGeneratorNode(input))
-        return processGeneratorNode(input, defaultIndentation);
+        return processGeneratorNode(input, defaultIndentation).text;
     else
         return String(input);
+}
+
+/**
+ * Converts instances of {@link GeneratorNode} into `text` accompanied by a corresponding `trace`.
+ *
+ * @param defaultIndentation the indentation to be applied if no explicit indentation is configured
+ *  for particular {@link IndentNode IndentNodes}, either a `string` or a `number` of repeated single spaces,
+ *  defaults to 4 single spaces, see {@link processGeneratorNode} -> `Context`.
+ *
+ * @returns an object of type `{ text: string, trace: TraceRegion }` containing the desired `text` and `trace` data
+ */
+export function toStringAndTrace(input: GeneratorNode, defaultIndentation?: string | number): { text: string, trace: TraceRegion } {
+    return processGeneratorNode(input, defaultIndentation);
 }
 
 /**
@@ -58,6 +75,8 @@ export function toString(input: unknown, defaultIndentation?: string | number): 
 export class CompositeGeneratorNode {
 
     readonly contents: Array<(GeneratorNode | string)> = [];
+
+    tracedSource?: TraceSourceSpec;
 
     /**
      * Constructor.
@@ -76,6 +95,31 @@ export class CompositeGeneratorNode {
 
     isEmpty(): boolean {
         return this.contents.length === 0;
+    }
+
+    /**
+     * Adds tracing information to `this` generator node. Overwrites existing trace data, if set previously.
+     *
+     * The given data are kept as they are, the actual resolution of text positions within the DSL text
+     * is done at the final processing of `this` node as part of {@link toStringAndTrace()}.
+     *
+     * @param astNode the AstNode corresponding to `this` node's content
+     *
+     * @param property the value property name (string) corresponding to `this` node's content,
+     *  e.g. if this node's content corresponds to some `string` or `number` property; is optional
+     *
+     * @param index the index of the value within a list property corresponding to `this` node's content,
+     * if the property contains a list of elements, is ignored otherwise,
+     * must not be given if no `property` is given ; is optinal
+     *
+     * @returns `this` {@link CompositeGeneratorNode} for convenience.
+     */
+    trace<T extends AstNode>(astNode: T, property?: Properties<T>, index?: number): this {
+        this.tracedSource = <TraceSourceSpec>{ astNode, property, index };
+        if (this.tracedSource.property === undefined && this.tracedSource.index !== undefined && this.tracedSource.index > -1) {
+            throw new Error("Generation support: 'property' argument must not be 'undefined' if a non-negative value is assigned to 'index' in 'CompositeGeneratorNode.trace(...)'.");
+        }
+        return this;
     }
 
     /**
@@ -105,8 +149,7 @@ export class CompositeGeneratorNode {
     }
 
     /**
-     * Appends `strings` and instances of {@link GeneratorNode} to `this` generator node, if `condition` is `truthy`.
-     * The aim of this method is to extend this class' fluent interface API by enabling chained method calls for conditionally appended parts.
+     * Appends `strings` and instances of {@link GeneratorNode} to `this` generator node, if `condition` is equal to `true`.
      *
      * If `condition` is satisfied this method delegates to {@link append}, otherwise it returns just `this`.
      *
@@ -144,7 +187,7 @@ export class CompositeGeneratorNode {
     }
 
     /**
-     * Appends a strict {@link NewLineNode} to `this` node, if `condition` is `truthy`.
+     * Appends a strict {@link NewLineNode} to `this` node, if `condition` is equal to `true`.
      * Strict {@link NewLineNode}s yield mandatory linebreaks in the derived generated text.
      *
      * @param condition a boolean value indicating whether to append a {@link NewLineNode} to `this`.
@@ -179,7 +222,7 @@ export class CompositeGeneratorNode {
     }
 
     /**
-     * Appends a soft {@link NewLineNode} to `this` node, if `condition` is `truthy`.
+     * Appends a soft {@link NewLineNode} to `this` node, if `condition` is equal to `true`.
      * Soft {@link NewLineNode}s yield linebreaks in the derived generated text only if the preceding line is non-empty,
      * i.e. there are non-whitespace characters added to the generated text since the last linebreak.
      *
@@ -199,8 +242,7 @@ export class CompositeGeneratorNode {
     }
 
     /**
-     * Tag function appending content in form of a template to `this` generation node.
-     * The aim of this method is to extend this class' fluent interface API by enabling chained method calls for appending templates.
+     * Convenience method for appending content in form of a template to `this` generation node.
      *
      * See {@link expandToNode} for details.
      *
@@ -218,8 +260,9 @@ export class CompositeGeneratorNode {
     }
 
     /**
-     * Returns a tag function for appending content in form of a template to `this` generator node, if `condition` is `truthy`.
-     * The aim of this method is to extend this class' fluent interface API by enabling chained method calls for conditionally appending templates.
+     * Convenience method for appending content in form of a template to `this` generator node, if `condition` is equal to `true`.
+     *
+     * This method returns a tag function that takes the desired template and does the processing.
      *
      * If `condition` is satisfied the tagged template delegates to {@link appendTemplate}, otherwise it returns just `this`.
      *
@@ -227,7 +270,7 @@ export class CompositeGeneratorNode {
      *
      * @param condition a boolean value indicating whether to append the template content to `this`.
      *
-     * @returns `this` {@link CompositeGeneratorNode} for convenience.
+     * @returns a tag function behaving as described above, which in turn returns `this` {@link CompositeGeneratorNode} for convenience.
      *
      * @example
      *   new CompositeGeneratorNode().appendTemplate
@@ -289,6 +332,177 @@ export class CompositeGeneratorNode {
         }
         return this;
     }
+
+    /**
+     * Convenience method for appending content to `this` generator node including tracing information.
+     *
+     * This method returns a helper function that takes the desired `content` and does the processing.
+     * The returned function delegates to {@link append}, with the provided `content` being
+     *  wrapped by an additional {@link CompositeGeneratorNode} configured with the tracing information.
+     *
+     * @param astNode the AstNode corresponding to the appended content
+     *
+     * @param property the value property name (string) corresponding to the appended content,
+     *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+     *
+     * @param index the index of the value within a list property corresponding to the appended content,
+     *  if the property contains a list of elements, is ignored otherwise, is optinal,
+     *  should not be given if no `property` is given
+     *
+     * @returns a function behaving as described above, which in turn returns `this` {@link CompositeGeneratorNode} for convenience.
+     *
+     * @example
+     *   new CompositeGeneratorNode().appendTemplate
+     *       `Hello World!`
+     *   .appendNewLine().append('Hello ').appendTraced(entity, 'name')(entity.name)
+     *   .appendNewLineIfNotEmpty()
+     */
+    appendTraced<T extends AstNode>(astNode: T, property?: Properties<T>, index?: number): (...content: Array<Generated | ((node: CompositeGeneratorNode) => void)>) => this {
+        return content => {
+            return this.append(
+                new CompositeGeneratorNode().trace(astNode, property, index).append(content)
+            );
+        };
+    }
+
+    /**
+     * Convenience method for appending content to `this` generator node including tracing information, if `condition` is equal to `true`.
+     *
+     * This method returns a tag function that takes the desired template and does the processing.
+     *
+     * If `condition` is satisfied the returned function delegates to {@link appendTraced}, otherwise it returns just `this`.
+     *
+     * @param condition a boolean value indicating whether to append the template content to `this`.
+     *
+     * @param astNode the AstNode corresponding to the appended content
+     *
+     * @param property the value property name (string) corresponding to the appended content,
+     *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+     *
+     * @param index the index of the value within a list property corresponding to the appended content,
+     *  if the property contains a list of elements, is ignored otherwise, is optinal,
+     *  should not be given if no `property` is given
+     *
+     * @returns a function behaving as described above, which in turn returns `this` {@link CompositeGeneratorNode} for convenience.
+     *
+     * @example
+     *   new CompositeGeneratorNode().appendTemplate
+     *       `Hello World!`
+     *   .appendNewLine().appendIf(entity !== undefined, 'Hello ').appendTracedIf(entity !== undefined, entity, 'name')(entity?.name)
+     *   .appendNewLineIfNotEmpty()
+     */
+    appendTracedIf<T extends AstNode>(condition: boolean, astNode: T, property?: Properties<T>, index?: number): (...content: Array<Generated | ((node: CompositeGeneratorNode) => void)>) => this {
+        return content => {
+            return condition ? this.appendTraced(astNode, property, index)(content) : this;
+        };
+    }
+
+    /**
+     * Convenience method for appending content in form of a template to `this` generator node including tracing information.
+     *
+     * This method returns a tag function that takes the desired template and does the processing by delegating to
+     * {@link expandTracedToNode}.
+     *
+     * @param astNode the AstNode corresponding to the appended content
+     *
+     * @param property the value property name (string) corresponding to the appended content,
+     *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+     *
+     * @param index the index of the value within a list property corresponding to the appended content,
+     *  if the property contains a list of elements, is ignored otherwise, is optinal,
+     *  should not be given if no `property` is given
+     *
+     * @returns a tag function behaving as described above, which in turn returns `this` {@link CompositeGeneratorNode} for convenience.
+     *
+     * @example
+     *   new CompositeGeneratorNode().appendTemplate
+     *       `Hello World!`
+     *   .appendNewLine().appendTracedTemplate(entity, 'name')
+     *       `Hello ${entity?.name}!`
+     *   .appendNewLineIfNotEmpty()
+     */
+    appendTracedTemplate<T extends AstNode>(astNode: T, property?: Properties<T>, index?: number): (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => this {
+        return (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => {
+            return this.append(
+                expandTracedToNode( astNode, property, index )(staticParts, ...substitutions)
+            );
+        };
+    }
+
+    /**
+     * Convenience method for appending content in form of a template to `this` generator node including tracing information, if `condition` is equal to `true`.
+     *
+     * This method returns a tag function that takes the desired template and does the processing.
+     *
+     * If `condition` is satisfied the tagged template delegates to {@link appendTracedTemplate}, otherwise it returns just `this`.
+     *
+     * See {@link expandTracedToNode} for details.
+     *
+     * @param condition a boolean value indicating whether to append the template content to `this`.
+     *
+     * @param astNode the AstNode corresponding to the appended content
+     *
+     * @param property the value property name (string) corresponding to the appended content,
+     *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+     *
+     * @param index the index of the value within a list property corresponding to the appended content,
+     *  if the property contains a list of elements, is ignored otherwise, is optinal,
+     *  should not be given if no `property` is given
+     *
+     * @returns a tag function behaving as described above, which in turn returns `this` {@link CompositeGeneratorNode} for convenience.
+     *
+     * @example
+     *   new CompositeGeneratorNode().appendTemplate
+     *       `Hello World!`
+     *   .appendNewLine().appendTracedTemplateIf(entity?.name !== undefined, entity)
+     *       `Hello ${entity?.name}!`
+     *   .appendNewLineIfNotEmpty()
+     */
+    appendTracedTemplateIf<T extends AstNode>(condition: boolean, astNode: T, property?: Properties<T>, index?: number): (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => this {
+        return (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => {
+            return condition ? this.appendTracedTemplate(astNode, property, index)(staticParts, ...substitutions) : this;
+        };
+    }
+}
+
+/**
+ * Convenience function for attaching tracing information to content of type `Generated`.
+ *
+ * This method returns a helper function that takes the desired `content` and does the processing.
+ * The returned function will create and return a new {@link CompositeGeneratorNode} being initialized
+ *  with the given tracing information and add some `content`, if provided.
+ *
+ * Exception: if `content` is already a {@link CompositeGeneratorNode} containing no tracing information,
+ *  that node is enriched with the given tracing information and returned, and no wrapping node is created.
+ *
+ * @param astNode the AstNode corresponding to the appended content
+ *
+ * @param property the value property name (string) corresponding to the appended content,
+ *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+ *
+ * @param index the index of the value within a list property corresponding to the appended content,
+ *  if the property contains a list of elements, is ignored otherwise, is optinal,
+ *  should not be given if no `property` is given
+ *
+ * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   new CompositeGeneratorNode().appendTemplate
+ *       `Hello World!`
+ *   .appendNewLine().appendTracedTemplate(entity)
+ *       `Hello ${ traceToNode(entity, name)(entity.name) }`
+ *   .appendNewLineIfNotEmpty()
+ */
+export function traceToNode<T extends AstNode>(astNode: T, property?: Properties<T>, index?: number): (content?: Generated | ((node: CompositeGeneratorNode) => void)) => CompositeGeneratorNode {
+    return content => {
+        if (content instanceof CompositeGeneratorNode && content.tracedSource === undefined) {
+            return content.trace(astNode, property, index);
+        } else {
+            // a `content !== undefined` check is skipped here on purpose in order to let this method always return a result;
+            // dropping empty generator nodes is considered a post processing optimization.
+            return new CompositeGeneratorNode().trace(astNode, property, index).append(content);
+        }
+    };
 }
 
 /**

--- a/packages/langium/src/generator/generator-tracing.ts
+++ b/packages/langium/src/generator/generator-tracing.ts
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { AstNodeRegionWithAssignments, AstNodeWithTextRegion } from '../serializer/json-serializer';
+import type { AstNode, GenericAstNode } from '../syntax-tree';
+import { getDocument } from '../utils/ast-util';
+import { findNodesForProperty } from '../utils/grammar-util';
+import { TreeStreamImpl } from '../utils/stream';
+import type { DocumentSegment } from '../workspace/documents';
+
+export interface TraceSourceSpec {
+    astNode: AstNode;
+    property?: string;
+    index?: number;
+}
+
+export interface TextRange {
+    fileURI?: string;
+    offset: number;
+    length: number;
+}
+
+export interface TraceRegion {
+    sourceRegion?: TextRange;
+    targetRegion: TextRange;
+    children?: TraceRegion[];
+}
+
+export interface DocumentSegmentWithFileURI extends DocumentSegment {
+    fileURI?: string;
+}
+
+export function getSourceRegion(sourceSpec: TraceSourceSpec | undefined): DocumentSegmentWithFileURI | undefined {
+    const { astNode, property, index } = sourceSpec ?? {};
+    const textRegion: AstNodeRegionWithAssignments | undefined = astNode?.$cstNode ?? (astNode as AstNodeWithTextRegion)?.$textRegion;
+
+    if (astNode === undefined || textRegion === undefined) {
+        return undefined;
+
+    } else if (property === undefined) {
+        return copyDocumentSegment(textRegion, getDocumentURI(astNode));
+
+    } else {
+        const getSingleOrCompoundRegion = (regions: DocumentSegment[]) => {
+            if (index !== undefined && index > -1 && Array.isArray((astNode as GenericAstNode)[property])) {
+                return index < regions.length ? regions[index] : undefined;
+
+            } else {
+                return regions.reduce( mergeDocumentSegment );
+            }
+        };
+
+        if (textRegion.assignments?.[property]) {
+            const region = getSingleOrCompoundRegion(
+                textRegion.assignments[property]
+            );
+            return region && { ...region, fileURI: getDocumentURI(astNode) };
+
+        } else if (astNode.$cstNode) {
+            const region = getSingleOrCompoundRegion(
+                findNodesForProperty(astNode.$cstNode, property)
+            );
+            return region && copyDocumentSegment(region, getDocument(astNode)?.uri?.toString());
+
+        } else {
+            return undefined;
+        }
+    }
+}
+
+function getDocumentURI(astNode: AstNodeWithTextRegion): string | undefined {
+    if (astNode.$cstNode) {
+        return getDocument(astNode)?.uri?.toString();
+
+    } else if (astNode.$textRegion) {
+        return astNode.$textRegion.documentURI
+            || new TreeStreamImpl(astNode, n => n.$container ? [ n.$container ] : []).find( n => n.$textRegion?.documentURI )?.$textRegion?.documentURI;
+
+    } else {
+        return undefined;
+    }
+}
+
+function copyDocumentSegment(region: DocumentSegment, fileURI?: string): DocumentSegmentWithFileURI {
+    return {
+        offset: region.offset,
+        end: region.end,
+        length: region.length,
+        range: region.range,
+        fileURI
+    };
+}
+
+function mergeDocumentSegment(prev: DocumentSegment, curr: DocumentSegment): DocumentSegment {
+    const result = <DocumentSegment>{
+        offset: Math.min(prev.offset, curr.offset),
+        end: Math.max(prev.end, curr.end),
+        get length() {
+            return result.end - result.offset;
+        },
+        range: {
+            start: curr.range.start.line < prev.range.start.line
+                    || curr.range.start.line === prev.range.start.line && curr.range.start.character < prev.range.start.character
+                ? curr.range.start : prev.range.start,
+            end: curr.range.end.line > prev.range.end.line
+                    || curr.range.end.line === prev.range.end.line && curr.range.end.character > prev.range.end.character
+                ? curr.range.end : prev.range.end
+        }
+    };
+    return result;
+}

--- a/packages/langium/src/generator/index.ts
+++ b/packages/langium/src/generator/index.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 export * from './generator-node';
-export { TextRange, TraceRegion, TraceSourceSpec } from './generator-tracing';
+export { SourceRegion, TextRegion, TraceRegion, TraceSourceSpec } from './generator-tracing';
+export * from './node-joiner';
 export * from './template-node';
 export { expandToString, expandToStringWithNL, normalizeEOL } from './template-string';

--- a/packages/langium/src/generator/index.ts
+++ b/packages/langium/src/generator/index.ts
@@ -5,5 +5,6 @@
  ******************************************************************************/
 
 export * from './generator-node';
+export { TextRange, TraceRegion, TraceSourceSpec } from './generator-tracing';
 export * from './template-node';
 export { expandToString, expandToStringWithNL, normalizeEOL } from './template-string';

--- a/packages/langium/src/generator/node-joiner.ts
+++ b/packages/langium/src/generator/node-joiner.ts
@@ -1,0 +1,303 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { AstNode, Properties } from '../syntax-tree';
+import { CompositeGeneratorNode, Generated, traceToNode } from './generator-node';
+import type { SourceRegion } from './generator-tracing';
+
+export interface JoinOptions<T> {
+    filter?: (element: T, index: number, isLast: boolean) => boolean;
+    prefix?: (element: T, index: number, isLast: boolean) => Generated|undefined;
+    suffix?: (element: T, index: number, isLast: boolean) => Generated|undefined;
+    separator?: Generated;
+    appendNewLineIfNotEmpty?: true;
+}
+
+/**
+ * Joins the elements of the given `iterable` by applying `toGenerated` to each element
+ * and appending the results to a {@link CompositeGeneratorNode} being returned finally.
+ *
+ * Note: empty strings being returned by `toGenerated` are treated as ordinary string
+ * representations, while the result of `undefined` makes this function to ignore the
+ * corresponding item and no separator is appended, if configured.
+ *
+ * Examples:
+ * ```
+ *   exandToNode`
+ *       ${ joinToNode(['a', 'b'], String, { appendNewLineIfNotEmpty: true }) }
+ *
+ *       ${ joinToNode(new Set(['a', undefined, 'b']), e => e && String(e), { separator: ',', appendNewLineIfNotEmpty: true }) }
+ *   `
+ * ```
+ *
+ * @param iterable an {@link Array} or {@link Iterable} providing the elements to be joined
+ *
+ * @param toGenerated a callback converting each individual element to a string, a
+ *  {@link CompositeGeneratorNode}, or undefined if to be omitted, defaults to {@link String}
+ *
+ * @param options optional config object for defining a `separator`, contributing specialized
+ *  `prefix` and/or `suffix` providers, and activating conditional line-break insertion. In addition,
+ *  a dedicated `filter` function can be provided that is required get provided with the original
+ *  element indices in the aformentioned functions, if the list is to be filtered. If
+ *  {@link Array.filter} would be applied to the original list, the indices will be those of the
+ *  filtered list during subsequent processing that in particular will cause confusion when using
+ *  the tracing variant of this function named ({@link joinTracedToNode}).
+ * @returns the resulting {@link CompositeGeneratorNode} representing `iterable`'s content
+ */
+export function joinToNode<T>(
+    iterable: Iterable<T>|T[],
+    toGenerated: (element: T, index: number, isLast: boolean) => Generated = String,
+    { filter, prefix, suffix, separator, appendNewLineIfNotEmpty }: JoinOptions<T> = {}
+): CompositeGeneratorNode|undefined {
+
+    return reduceWithIsLast(iterable, (node, it, i, isLast) => {
+        if (filter && !filter(it, i, isLast)) {
+            return node;
+        }
+        const content = toGenerated(it, i, isLast);
+        return (node ??= new CompositeGeneratorNode())
+            .append(prefix && prefix(it, i, isLast))
+            .append(content)
+            .append(suffix && suffix(it, i, isLast))
+            .appendIf(!isLast && content !== undefined, separator)
+            .appendNewLineIfNotEmptyIf(
+                // append 'newLineIfNotEmpty' elements only if 'node' has some content already,
+                //  as if the parent is an IndentNode with 'indentImmediately' set to 'false'
+                //  the indentation is not properly applied to the first non-empty line of the (this) child node
+                !node.isEmpty() && !!appendNewLineIfNotEmpty
+            );
+    });
+}
+
+/**
+ * Convenience function for joining the elements of some `iterable` and gathering tracing information.
+ *
+ * This function returns another function that does the processing, and that expects same list of
+ *  arguments as expected by {@link joinToNode}, i.e. an `iterable`, a function `toGenerated`
+ *  converting each element into a `Generated`, as well as some `options`.
+ *
+ * That function than joins the elements of `iterable` by delegating to {@link joinToNode}.
+ * Via {@link traceToNode} the resulting generator node is supplemented with the provided tracing
+ *  information in form of `{astNode, property?, index?}`, and finally returned. In addition,
+ *  if `property` is given each element's generator node representation is augmented with the
+ *  provided tracing information plus the index of the element within `iterable`.
+ *
+ * @param astNode the AstNode corresponding to the appended content
+ *
+ * @param property the value property name (string) corresponding to the appended content,
+ *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+ *
+ * @param index the index of the value within a list property corresponding to the appended content,
+ *  if the property contains a list of elements, is ignored otherwise, is optinal,
+ *  should not be given if no `property` is given
+ *
+ * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandToNode`
+ *       children: ${ joinTracedToNode(entity, 'children')(entity.children, child => child.name, { separator: ' ' }) };
+ *   `.appendNewLine()
+ */
+export function joinTracedToNode<T extends AstNode>(astNode: T, property?: Properties<T>): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined;
+
+/**
+ * Convenience function for joining the elements of some `iterable` and gathering tracing information
+ *  in form of concrete coordinates.
+ *
+ * This function returns another function that does the processing, and that expects same list of
+ *  arguments as expected by {@link joinToNode}, i.e. an `iterable`, a function `toGenerated`
+ *  converting each element into a `Generated`, as well as some `options`.
+ *
+ * That function than joins the elements of `iterable` by delegating to {@link joinToNode}.
+ * Via {@link traceToNode} the resulting generator node is supplemented with the provided tracing
+ *  information, and finally returned. Elementwise tracing need to be implemented by client code
+ *  within `toGenerated`, if required.
+ *
+ * @param sourceRegion a text region within some file in form of concrete coordinates,
+ *  if `undefined` no tracing will happen
+ *
+ * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandToNode`
+ *       children: ${ joinTracedToNode(findNodesForProperty(entity.$cstNode, 'children'))(entity.children, child => child.name, { separator: ' ' }) };
+ *   `.appendNewLine()
+ */
+export function joinTracedToNode(sourceRegion: SourceRegion | undefined): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined;
+
+/**
+ * Convenience function for joining the elements of some `iterable` and gathering tracing information
+ *  in form of a list of concrete coordinates.
+ *
+ * This function returns another function that does the processing, and that expects same list of
+ *  arguments as expected by {@link joinToNode}, i.e. an `iterable`, a function `toGenerated`
+ *  converting each element into a `Generated`, as well as some `options`.
+ *
+ * That function than joins the elements of `iterable` by delegating to {@link joinToNode}.
+ * Via {@link traceToNode} the resulting generator node is supplemented with the provided tracing
+ *  information, and finally returned. Elementwise tracing need to be implemented by client code
+ *  within `toGenerated`, if required.
+ *
+ * The list of regions in `sourceRegions` will later be reduced to the smallest encompassing region
+ *  of all the contained source regions.
+ *
+ * @param sourceRegions a list of text regions within some file in form of concrete coordinates,
+ *  if empty no tracing will happen
+ *
+ * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandToNode`
+ *       children: ${ joinTracedToNode(findNodesForProperty(entity.$cstNode, 'children'))(entity.children, child => child.name, { separator: ' ' }) };
+ *   `.appendNewLine()
+ */
+export function joinTracedToNode(sourceRegions: SourceRegion[]): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined;
+
+// implementation:
+export function joinTracedToNode<T extends AstNode>(source: T | undefined | SourceRegion | SourceRegion[], property?: Properties<T>): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined {
+    return (iterable, toGenerated = String, options) => {
+        return traceToNode(source as T, property)(
+            joinToNode(
+                iterable,
+                source && property ? (element, index, isLast) => traceToNode(source as T, property, index)(toGenerated(element, index, isLast)) : toGenerated,
+                options
+            )
+        );
+    };
+}
+
+/**
+ * Convenience function for joining the elements of some `iterable` and gathering tracing information,
+ *  if `condition` is equal to `true`.
+ *
+ * If `condition` is satisfied, this function returns another function that does the processing,
+ *  and that expects same list of arguments as expected by {@link joinToNode}, i.e. an `iterable`,
+ *  a function `toGenerated` converting each element into a `Generated`, as well as some `options`.
+ *
+ * That function than joins the elements of `iterable` by delegating to {@link joinToNode}.
+ * Via {@link traceToNode} the resulting generator node is supplemented with the provided tracing
+ *  information, and finally returned. In addition, if `property` is given each element's
+ *  generator node representation is augmented with the provided tracing information
+ *  plus the index of the element within `iterable`.
+ *
+ * Otherwise, if `condition` is equal to false, the returned function just returns `undefined`.
+ *
+ * @param condition a boolean value indicating whether to evaluate the provided iterable.
+ *
+ * @param astNode the AstNode corresponding to the appended content
+ *
+ * @param property the value property name (string) corresponding to the appended content,
+ *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+ *
+ * @param index the index of the value within a list property corresponding to the appended content,
+ *  if the property contains a list of elements, is ignored otherwise, is optinal,
+ *  should not be given if no `property` is given
+ *
+ * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode} or `undefined`.
+ *
+ * @example
+ *   expandToNode`
+ *       children: ${ joinTracedToNode(entity, 'children')(entity.children, child => child.name, { separator: ' ' }) };
+ *   `.appendNewLine()
+ */
+export function joinTracedToNodeIf<T extends AstNode>(condition: boolean, astNode: T, property?: Properties<T>): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined;
+
+/**
+ * Convenience function for joining the elements of some `iterable` and gathering tracing information
+ *  in form of a list of concrete coordinates, if `condition` is equal to `true`.
+ *
+ * If `condition` is satisfied, this function returns another function that does the processing,
+ *  and that expects same list of arguments as expected by {@link joinToNode}, i.e. an `iterable`,
+ *  a function `toGenerated` converting each element into a `Generated`, as well as some `options`.
+ *
+ * That function than joins the elements of `iterable` by delegating to {@link joinToNode}.
+ * Via {@link traceToNode} the resulting generator node is supplemented with the provided tracing
+ *  information, and finally returned. Element-wise tracing need to be implemented by client code
+ *  within `toGenerated`, if required.
+ *
+ * Otherwise, if `condition` is equal to false, the returned function just returns `undefined`.
+ *
+ * If `sourceRegion` is a function supplying the corresponding regions, it's only called if `condition` is satisfied.
+ *
+ * @param condition a boolean value indicating whether to evaluate the provided iterable.
+ *
+ * @param sourceRegion a text region within some file in form of concrete coordinates or a supplier function,
+ *  if `undefined` no tracing will happen
+ *
+ * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandToNode`
+ *       children: ${ joinTracedToNodeIf(entity !== undefined, () => entity.$cstNode)(entity.children, child => child.name, { separator: ' ' }) };
+ *   `.appendNewLine()
+ */
+export function joinTracedToNodeIf(condition: boolean, sourceRegion: SourceRegion | undefined | (() => SourceRegion | undefined)): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined;
+
+/**
+ * Convenience function for joining the elements of some `iterable` and gathering tracing information
+ *  in form of a list of concrete coordinates, if `condition` is equal to `true`.
+ *
+ * If `condition` is satisfied, this function returns another function that does the processing,
+ *  and that expects same list of arguments as expected by {@link joinToNode}, i.e. an `iterable`,
+ *  a function `toGenerated` converting each element into a `Generated`, as well as some `options`.
+ *
+ * That function than joins the elements of `iterable` by delegating to {@link joinToNode}.
+ * Via {@link traceToNode} the resulting generator node is supplemented with the provided tracing
+ *  information, and finally returned. Element-wise tracing need to be implemented by client code
+ *  within `toGenerated`, if required.
+ *
+ * Otherwise, if `condition` is equal to false, the returned function just returns `undefined`.
+ *
+ * The list of regions in `sourceRegions` will later be reduced to the smallest encompassing region
+ *  of all the contained source regions.
+ * If `sourceRegions` is a function supplying the corresponding regions, it's only called if `condition` is satisfied.
+ *
+ * @param condition a boolean value indicating whether to evaluate the provided iterable.
+ *
+ * @param sourceRegions a list of text regions within some file in form of concrete coordinates or a supplier function,
+ *  if empty no tracing will happen
+ *
+ * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandToNode`
+ *       children: ${ joinTracedToNodeIf(entity !== undefined, () => findNodesForProperty(entity.$cstNode, 'children'))(entity.children, child => child.name, { separator: ' ' }) };
+ *   `.appendNewLine()
+ */
+export function joinTracedToNodeIf(condition: boolean, sourceRegions: SourceRegion[] | (() => SourceRegion[])): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined;
+
+// implementation:
+export function joinTracedToNodeIf<T extends AstNode>(condition: boolean, source: T | undefined | SourceRegion | SourceRegion[] | (() => undefined | SourceRegion | SourceRegion[]), property?: Properties<T>): // eslint-disable-next-line @typescript-eslint/indent
+        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode | undefined {
+    return condition ? joinTracedToNode((typeof source === 'function' ? source() : source) as T, property) : () => undefined;
+}
+
+function reduceWithIsLast<T, R>(
+    iterable: Iterable<T>|T[],
+    callbackfn: (previous: R|undefined, current: T, currentIndex: number, isLast: boolean) => R | undefined,
+    initial?: R
+) {
+    const iterator = iterable[Symbol.iterator]();
+    let next = iterator.next();
+    let index = 0;
+    let result = initial;
+
+    while (!next.done) {
+        const nextNext = iterator.next();
+        result = callbackfn(result, next.value, index, Boolean(nextNext.done));
+        next = nextNext;
+        index++;
+    }
+
+    return result;
+}

--- a/packages/langium/src/generator/template-node.ts
+++ b/packages/langium/src/generator/template-node.ts
@@ -6,6 +6,7 @@
 
 import type { AstNode, Properties } from '../syntax-tree';
 import { CompositeGeneratorNode, Generated, GeneratorNode, IndentNode, isGeneratorNode, traceToNode } from './generator-node';
+import { SourceRegion } from './generator-tracing';
 import { findIndentation, NEWLINE_REGEXP } from './template-string';
 
 /**
@@ -69,7 +70,8 @@ export function expandToNode(staticParts: TemplateStringsArray, ...substitutions
 
 /**
  * Convenience function for creating a {@link CompositeGeneratorNode} being configured with the
- *  provided tracing information and appending content in form of a template.
+ *  provided tracing information in form of `{astNode, property?, index?}` and appending content
+ *  in form of a template.
  *
  * This function returns a tag function that takes the desired template and does the processing
  *  by delegating to {@link expandToNode} and {@link traceToNode} and finally returning the
@@ -91,12 +93,160 @@ export function expandToNode(staticParts: TemplateStringsArray, ...substitutions
  *       Hello ${ traceToNode(entity, name)(entity.name) }
  *   `.appendNewLine()
  */
-export function expandTracedToNode<T extends AstNode>(astNode: T, property?: Properties<T>, index?: number): (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode {
+export function expandTracedToNode<T extends AstNode>(astNode: T, property?: Properties<T>, index?: number): (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode;
+
+/**
+ * Convenience function for creating a {@link CompositeGeneratorNode} being configured with the
+ *  provided tracing information in form of concrete coordinates and appending content
+ *  in form of a template. Complete coordinates are provided by the {@link AstNode AstNodes}'
+ *  corresponding {@link AstNode.$cstNode AstNode.$cstNodes}.
+ *
+ * This function returns a tag function that takes the desired template and does the processing
+ *  by delegating to {@link expandToNode} and {@link traceToNode} and finally returning the
+ *  resulting generator node.
+ *
+ * @param sourceRegion a text region within some file in form of concrete coordinates,
+ *  if `undefined` no tracing will happen
+ *
+ * @returns a tag function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandTracedToNode(entify.$cstNode)`
+ *       Hello ${ traceToNode(entity, name)(entity.name) }
+ *   `.appendNewLine()
+ */
+export function expandTracedToNode(sourceRegion: SourceRegion | undefined): (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode;
+
+/**
+ * Convenience function for creating a {@link CompositeGeneratorNode} being configured with the
+ *  provided tracing information in form of a list of concrete coordinates and appending content
+ *  in form of a template. Complete coordinates are provided by the {@link AstNode AstNodes}'
+ *  corresponding {@link AstNode.$cstNode AstNode.$cstNodes}.
+ *
+ * This function returns a tag function that takes the desired template and does the processing
+ *  by delegating to {@link expandToNode} and {@link traceToNode} and finally returning the
+ *  resulting generator node.
+ *
+ * The list of regions in `sourceRegions` will later be reduced to the smallest encompassing region
+ *  of all the contained source regions.
+ *
+ * @param sourceRegions a list of text regions within some file in form of concrete coordinates,
+ *  if empty no tracing will happen
+ *
+ * @returns a tag function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandTracedToNode([
+ *      findNodeForKeyword(entity.$cstNode, '{')!,
+ *      findNodeForKeyword(entity.$cstNode, '}')!
+ *   ])`
+ *       Hello ${ traceToNode(entity, name)(entity.name) }
+ *   `.appendNewLine()
+ */
+export function expandTracedToNode(sourceRegions: SourceRegion[]): (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode;
+
+// implementation:
+export function expandTracedToNode<T extends AstNode>(source: T | undefined | SourceRegion | SourceRegion[], property?: Properties<T>, index?: number): (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode {
     return (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => {
-        return traceToNode(astNode, property, index)(
+        return traceToNode(source as T, property, index)(
             expandToNode(staticParts, ...substitutions)
         );
     };
+}
+
+/**
+ * Convenience function for creating a {@link CompositeGeneratorNode} being configured with the
+ *  provided tracing information in form of `{astNode, property?, index?}` and appending content
+ *  in form of a template, if `condition` is equal to `true`.
+ *
+ * If `condition` is satisfied, this function returns a tag function that takes the desired template
+ *  and does the processing by delegating to {@link expandToNode} and {@link traceToNode} and
+ *  finally returning the resulting generator node. Otherwise, the returned function just returns `undefined`.
+ *
+ * @param condition a boolean value indicating whether to evaluate the provided template.
+ *
+ * @param astNode the AstNode corresponding to the appended content
+ *
+ * @param property the value property name (string) corresponding to the appended content,
+ *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
+ *
+ * @param index the index of the value within a list property corresponding to the appended content,
+ *  if the property contains a list of elements, is ignored otherwise, is optinal,
+ *  should not be given if no `property` is given
+ *
+ * @returns a tag function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandTracedToNodeIf(entity !== undefined, entity)`
+ *       Hello ${ traceToNode(entity, name)(entity.name) }
+ *   `.appendNewLine()
+ */
+export function expandTracedToNodeIf<T extends AstNode>(condition: boolean, astNode: T, property?: Properties<T>, index?: number): // eslint-disable-next-line @typescript-eslint/indent
+        (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode | undefined;
+
+/**
+ * Convenience function for creating a {@link CompositeGeneratorNode} being configured with the
+ *  provided tracing information in form of concrete coordinates and appending content in form
+ *  of a template, if `condition` is equal to `true`. Complete coordinates are provided by
+ *  the {@link AstNode AstNodes}' corresponding {@link AstNode.$cstNode AstNode.$cstNodes}.
+ *
+ * This function returns a tag function that takes the desired template and does the processing
+ *  by delegating to {@link expandToNode} and {@link traceToNode} and finally returning the
+ *  resulting generator node.
+ *
+ * If `sourceRegion` is a function supplying the corresponding region, it's only called if `condition` is satisfied.
+ *
+ * @param condition a boolean value indicating whether to evaluate the provided template.
+ *
+ * @param sourceRegion a text region within some file in form of concrete coordinates or a supplier function,
+ *  if `undefined` no tracing will happen
+ *
+ * @returns a tag function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandTracedToNodeIf(entity !== undefined, entify.$cstNode)`
+ *       Hello ${ traceToNode(entity, name)(entity.name) }
+ *   `.appendNewLine()
+ */
+export function expandTracedToNodeIf(condition: boolean, sourceRegion: SourceRegion | undefined | (() => SourceRegion | undefined )): // eslint-disable-next-line @typescript-eslint/indent
+        (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode | undefined;
+
+/**
+ * Convenience function for creating a {@link CompositeGeneratorNode} being configured with the
+ *  provided tracing information in form of a list of concrete coordinates and appending content
+ *  in form of a template, if `condition` is equal to `true`. Complete coordinates are provided
+ *  by the {@link AstNode AstNodes}' corresponding {@link AstNode.$cstNode AstNode.$cstNodes}.
+ *
+ * This function returns a tag function that takes the desired template and does the processing
+ *  by delegating to {@link expandToNode} and {@link traceToNode} and finally returning the
+ *  resulting generator node.
+ *
+ * The list of regions in `sourceRegions` will later be reduced to the smallest encompassing region
+ *  of all the contained source regions.
+ * If `sourceRegions` is a function supplying the corresponding regions, it's only called if `condition` is satisfied.
+ *
+ * @param condition a boolean value indicating whether to evaluate the provided template.
+ *
+ * @param sourceRegions a list of text regions within some file in form of concrete coordinates,
+ *  if empty no tracing will happen
+ *
+ * @returns a tag function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
+ *
+ * @example
+ *   expandTracedToNodeIf(entity !== undefined, [
+ *      findNodeForKeyword(entity.$cstNode, '{')!,
+ *      findNodeForKeyword(entity.$cstNode, '}')!
+ *   ])`
+ *       Hello ${ traceToNode(entity, name)(entity.name) }
+ *   `.appendNewLine()
+ */
+export function expandTracedToNodeIf(condition: boolean, sourceRegions: SourceRegion[]): // eslint-disable-next-line @typescript-eslint/indent
+        (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode | undefined;
+
+// implementation:
+export function expandTracedToNodeIf<T extends AstNode>(condition: boolean, source: T | undefined | SourceRegion | SourceRegion[] | (() => undefined | SourceRegion | SourceRegion[]), property?: Properties<T>, index?: number): // eslint-disable-next-line @typescript-eslint/indent
+        (staticParts: TemplateStringsArray, ...substitutions: unknown[]) => CompositeGeneratorNode | undefined {
+    return condition ? expandTracedToNode((typeof source === 'function' ? source() : source) as T, property, index) : () => undefined;
 }
 
 type TemplateProps = {
@@ -314,130 +464,4 @@ function composeFinalGeneratorNode(splitAndMerged: GeneratedOrMarker[]): Composi
     );
 
     return result.node;
-}
-
-export interface JoinOptions<T> {
-    filter?: (element: T, index: number, isLast: boolean) => boolean;
-    prefix?: (element: T, index: number, isLast: boolean) => Generated|undefined;
-    suffix?: (element: T, index: number, isLast: boolean) => Generated|undefined;
-    separator?: Generated;
-    appendNewLineIfNotEmpty?: true;
-}
-
-/**
- * Joins the elements of the given `iterable` by applying `toGenerated` to each element
- * and appending the results to a {@link CompositeGeneratorNode} being returned finally.
- *
- * Note: empty strings being returned by `toGenerated` are treated as ordinary string
- * representations, while the result of `undefined` makes this function to ignore the
- * corresponding item and no separator is appended, if configured.
- *
- * Examples:
- * ```
- *   exandToNode`
- *       ${ joinToNode(['a', 'b'], String, { appendNewLineIfNotEmpty: true }) }
- *
- *       ${ joinToNode(new Set(['a', undefined, 'b']), e => e && String(e), { separator: ',', appendNewLineIfNotEmpty: true }) }
- *   `
- * ```
- *
- * @param iterable an {@link Array} or {@link Iterable} providing the elements to be joined
- *
- * @param toGenerated a callback converting each individual element to a string, a
- *  {@link CompositeGeneratorNode}, or undefined if to be omitted, defaults to {@link String}
- *
- * @param options optional config object for defining a `separator`, contributing specialized
- *  `prefix` and/or `suffix` providers, and activating conditional line-break insertion. In addition,
- *  a dedicated `filter` function can be provided that is required get provided with the original
- *  element indices in the aformentioned functions, if the list is to be filtered. If
- *  {@link Array.filter} would be applied to the original list, the indices will be those of the
- *  filtered list during subsequent processing that in particular will cause confusion when using
- *  the tracing variant of this function named ({@link joinTracedToNode}).
- * @returns the resulting {@link CompositeGeneratorNode} representing `iterable`'s content
- */
-export function joinToNode<T>(
-    iterable: Iterable<T>|T[],
-    toGenerated: (element: T, index: number, isLast: boolean) => Generated = String,
-    { filter, prefix, suffix, separator, appendNewLineIfNotEmpty }: JoinOptions<T> = {}
-): CompositeGeneratorNode|undefined {
-
-    return reduceWithIsLast(iterable, (node, it, i, isLast) => {
-        if (filter && !filter(it, i, isLast)) {
-            return node;
-        }
-        const content = toGenerated(it, i, isLast);
-        return (node ??= new CompositeGeneratorNode())
-            .append(prefix && prefix(it, i, isLast))
-            .append(content)
-            .append(suffix && suffix(it, i, isLast))
-            .appendIf(!isLast && content !== undefined, separator)
-            .appendNewLineIfNotEmptyIf(
-                // append 'newLineIfNotEmpty' elements only if 'node' has some content already,
-                //  as if the parent is an IndentNode with 'indentImmediately' set to 'false'
-                //  the indentation is not properly applied to the first non-empty line of the (this) child node
-                !node.isEmpty() && !!appendNewLineIfNotEmpty
-            );
-    });
-}
-
-/**
- * Convenience function for joining the elements of some `iterable` and gathering tracing information.
- *
- * This function returns another function that does the processing, and that expects same list of
- *  arguments as expected by {@link joinToNode}, i.e. an `iterable`, a function `toGenerated`
- *  converting each element into a `Generated`, as well as some `options`.
- *
- * That function than joins the elements of `iterable` by delegating to {@link joinToNode}.
- * Via {@link traceToNode} the resulting generator node is supplemented with the provided tracing
- *  information, and finally returned. In addition, if `property` is given each element's
- *  generator node representation is augmented with the provided tracing information
- *  plus the index of the element within `iterable`.
- *
- * @param astNode the AstNode corresponding to the appended content
- *
- * @param property the value property name (string) corresponding to the appended content,
- *  if e.g. the content corresponds to some `string` or `number` property of `astNode`, is optional
- *
- * @param index the index of the value within a list property corresponding to the appended content,
- *  if the property contains a list of elements, is ignored otherwise, is optinal,
- *  should not be given if no `property` is given
- *
- * @returns a function behaving as described above, which in turn returns a {@link CompositeGeneratorNode}.
- *
- * @example
- *   expandToNode`
- *       children: ${ joinTracedToNode(entity, 'children')(entity.children, child => child.name, { separator: ' ' }) };
- *   `.appendNewLine()
- */
-export function joinTracedToNode<T extends AstNode>(astNode: T, property?: Properties<T>): // eslint-disable-next-line @typescript-eslint/indent
-        <E>(iterable: Iterable<E>|E[], toGenerated?: (element: E, index: number, isLast: boolean) => Generated, options?: JoinOptions<E>) => CompositeGeneratorNode|undefined {
-    return (iterable, toGenerated = String, options) => {
-        return traceToNode(astNode, property)(
-            joinToNode(
-                iterable,
-                astNode && property ? (element, index, isLast) => traceToNode(astNode, property, index)(toGenerated(element, index, isLast)) : toGenerated,
-                options
-            )
-        );
-    };
-}
-
-function reduceWithIsLast<T, R>(
-    iterable: Iterable<T>|T[],
-    callbackfn: (previous: R|undefined, current: T, currentIndex: number, isLast: boolean) => R | undefined,
-    initial?: R
-) {
-    const iterator = iterable[Symbol.iterator]();
-    let next = iterator.next();
-    let index = 0;
-    let result = initial;
-
-    while (!next.done) {
-        const nextNext = iterator.next();
-        result = callbackfn(result, next.value, index, Boolean(nextNext.done));
-        next = nextNext;
-        index++;
-    }
-
-    return result;
 }

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -5,7 +5,6 @@
  ******************************************************************************/
 
 import { CompositeGeneratorNode, NL, toString } from '../../../generator/generator-node';
-import { processGeneratorNode } from '../../../generator/node-processor';
 import { CstNode } from '../../../syntax-tree';
 import { Assignment, Action, TypeAttribute } from '../../generated/ast';
 import { distinctAndSorted } from '../types-util';
@@ -133,7 +132,7 @@ export class UnionType {
     toDeclaredTypesString(reservedWords: Set<string>): string {
         const unionNode = new CompositeGeneratorNode();
         unionNode.append(`type ${escapeReservedWords(this.name, reservedWords)} = ${propertyTypeToString(this.type, 'DeclaredType')};`, NL);
-        return processGeneratorNode(unionNode);
+        return toString(unionNode);
     }
 }
 

--- a/packages/langium/test/generator/generation-tracing.test.ts
+++ b/packages/langium/test/generator/generation-tracing.test.ts
@@ -1,0 +1,342 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { beforeAll, describe, expect, test } from 'vitest';
+import { toStringAndTrace, traceToNode } from '../../src/generator/generator-node';
+import { TraceRegion } from '../../src/generator/generator-tracing';
+import { expandToNode, expandTracedToNode, joinTracedToNode } from '../../src/generator/template-node';
+import { AstNodeWithTextRegion } from '../../src/serializer/json-serializer';
+import type { AstNode } from '../../src/syntax-tree';
+import { parseHelper } from '../../src/test';
+import { createServicesForGrammar } from '../../src/utils/grammar-util';
+import { TreeStreamImpl } from '../../src/utils/stream';
+
+let parse: (text: string) => Promise<AstNode>;
+let parse2: (text: string) => Promise<AstNode>;
+beforeAll(async () => {
+    const container = await createServicesForGrammar({
+        grammar: `
+            grammar Test
+            entry Main: ('name=' name=ID)? values+=(ID|STRING|NUMBER)+ ('children' '{' children+=Main+ '}')?;
+
+            terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
+            terminal NUMBER returns number: /([0-9]+)(\\.[0-9]+)?/;
+            terminal STRING: /"[^"]*"|'[^']*'/;
+            hidden terminal WS: /\\s+/;
+        `,
+        parserConfig: {
+            maxLookahead: 3
+        }
+    });
+    const serializer = container.serializer.JsonSerializer;
+
+    parse = async (text: string) => (await parseHelper(container)(text)).parseResult.value;
+    parse2 = relyingOn$cstNode
+        ? parse
+        : async (text: string) => serializer.deserialize(
+            serializer.serialize(
+                await parse(text),
+                { textRegions: true }
+            )
+        );
+});
+
+function persistSourceRegions(trace: TraceRegion): TraceRegion {
+    // simplifies trace mismatch investigation
+    new TreeStreamImpl(trace, tr => tr?.children ?? [], { includeRoot: true }).forEach(
+        tr => tr.sourceRegion = tr.sourceRegion && {
+            offset: tr.sourceRegion.offset,
+            length: tr.sourceRegion.length,
+            fileURI: tr.sourceRegion?.fileURI
+        }
+    );
+    return trace;
+}
+
+// the vscode vitest extension doesn't support describe.each() (or any other tweak I could imagine) that is a real pity,
+//  so we need to manually flip this flag if we want to test '$textRegion' version
+const relyingOn$cstNode = false;
+describe('tracing using $cstNode or $textRegion', () => {
+    function documentURI(root: AstNodeWithTextRegion) {
+        return relyingOn$cstNode ? root.$document?.uri?.toString() : root.$textRegion?.documentURI;
+    }
+
+    test('should trace single node spanning the entire output', async () => {
+        const source = await parse2('AH "IH" OH');
+        const { text, trace } = toStringAndTrace(
+            expandTracedToNode(source)`
+                beginning ... end
+            `
+        );
+        // persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning ... end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            sourceRegion: { offset: 0, length: 10, fileURI: documentURI(source) },
+            targetRegion: { offset: 0, length: 17 },
+        });
+    });
+
+    test('should trace single node to nested regions spanning the entire output', async () => {
+        const source = await parse2('AH "IH" OH');
+        const { text, trace } = toStringAndTrace(
+            expandTracedToNode(source)`
+                ${ expandTracedToNode(source)`
+                    beginning ... end
+                ` }
+            `
+        );
+        persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning ... end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            sourceRegion: { offset: 0, length: 10, fileURI: documentURI(source) },
+            targetRegion: { offset: 0, length: 17 },
+            children: [ {
+                sourceRegion: { offset: 0, length: 10, fileURI: undefined },
+                targetRegion: { offset: 0, length: 17 },
+            } ]
+        });
+    });
+
+    test('should trace single node with preamble in output 1', async () => {
+        const source = await parse2('AH "IH" OH');
+        const { text, trace } = toStringAndTrace(
+            expandToNode`
+                Preamble; 
+            `.appendTraced(source)(
+                'beginning ... end' // eslint-disable-line @typescript-eslint/indent
+            )                       // eslint-disable-line @typescript-eslint/indent
+        );
+        // persistSourceRegions(trace);
+
+        expect( text ).toBe('Preamble; beginning ... end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            targetRegion: { offset: 0, length: 27 },
+            children: [ {
+                sourceRegion: { offset: 0, length: 10, fileURI: documentURI(source) },
+                targetRegion: { offset: 10, length: 17 }
+            } ]
+        });
+    });
+
+    test('should trace single node with preamble in output 2', async () => {
+        const source = await parse2('AH "IH" OH');
+        const { text, trace } = toStringAndTrace(
+            expandToNode`
+                Preamble; 
+            `.appendTracedTemplate(source)`
+                beginning ... end
+            `
+        );
+        // persistSourceRegions(trace);
+
+        expect( text ).toBe('Preamble; beginning ... end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            targetRegion: { offset: 0, length: 27 },
+            children: [ {
+                sourceRegion: { offset: 0, length: 10, fileURI: documentURI(source) },
+                targetRegion: { offset: 10, length: 17 }
+            } ]
+        });
+    });
+
+    test('should trace property value within single node spanning the entire output 1', async () => {
+        const source = await parse2('name=foo AH "IH" OH') as AstNode & { name: string };
+        const { text, trace } = toStringAndTrace(
+            expandTracedToNode(source)`
+                beginning ${ traceToNode(source, 'name')(source.name) } end
+            `
+        );
+        persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning foo end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            sourceRegion: { offset: 0, length: 19, fileURI: documentURI(source) },
+            targetRegion: { offset: 0, length: 17 },
+            children: [ {
+                sourceRegion: { offset: 5, length: 3, fileURI: undefined },
+                targetRegion: { offset: 10, length: 3}
+            } ]
+        });
+    });
+
+    test('should trace property value only 1', async () => {
+        const source = await parse2('name=foo AH "IH" OH') as AstNode & { name: string };
+        const { text, trace } = toStringAndTrace(
+            expandToNode`
+                beginning ${ traceToNode(source, 'name')(source.name) } end
+            `
+        );
+        // persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning foo end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            targetRegion: { offset: 0, length: 17 },
+            children: [ {
+                sourceRegion: { offset: 5, length: 3, fileURI: documentURI(source) },
+                targetRegion: { offset: 10, length: 3}
+            } ]
+        });
+    });
+
+    test('should trace property value only 2', async () => {
+        const source = await parse2('name=foo AH "IH" OH') as AstNode & { name: string };
+        const { text, trace } = toStringAndTrace(
+            expandToNode`
+                beginning ${ expandTracedToNode(source, 'name')`${source.name}` } end
+            `
+        );
+        // persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning foo end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            targetRegion: { offset: 0, length: 17 },
+            children: [ {
+                sourceRegion: { offset: 5, length: 3, fileURI: documentURI(source) },
+                targetRegion: { offset: 10, length: 3}
+            } ]
+        });
+    });
+
+    test('should trace single list value within single node spanning the entire output', async () => {
+        const source = await parse2('AH "IH" OH') as AstNode & { values: string[] };
+        const { text, trace } = toStringAndTrace(
+            expandTracedToNode(source)`
+                beginning ${ traceToNode(source, 'values', 1)(source.values[1]) } end
+            `
+        );
+        persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning IH end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            sourceRegion: { offset: 0, length: 10, fileURI: documentURI(source) },
+            targetRegion: { offset: 0, length: 16 },
+            children: [ {
+                sourceRegion: { offset: 3, length: 4, fileURI: undefined },
+                targetRegion: { offset: 10, length: 2}
+            } ]
+        });
+    });
+
+    test('should trace single list value only', async () => {
+        const source = await parse2('AH "IH" OH') as AstNode & { values: string[] };
+        const { text, trace } = toStringAndTrace(
+            expandToNode`
+                beginning ${ traceToNode(source, 'values', 1)(source.values[1]) } end
+            `
+        );
+        // persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning IH end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            targetRegion: { offset: 0, length: 16 },
+            children: [ {
+                sourceRegion: { offset: 3, length: 4, fileURI: documentURI(source) },
+                targetRegion: { offset: 10, length: 2 }
+            } ]
+        });
+    });
+
+    test('should trace entire list and its particluar elemens within single node spanning the entire output', async () => {
+        const source = await parse2('AH "IH" OH 0815') as AstNode & { values: Array<string | number> };
+        const { text, trace } = toStringAndTrace(
+            expandTracedToNode(source)`
+                beginning ${ joinTracedToNode(source, 'values')(source.values, undefined, { separator: ' ' }) } end
+            `
+        );
+        persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning AH IH OH 815 end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            sourceRegion: { offset: 0, length: 15, fileURI: documentURI(source) },
+            targetRegion: { offset: 0, length: 26 },
+            children: [ {
+                sourceRegion: { offset: 0, length: 15, fileURI: undefined },
+                targetRegion: { offset: 10, length: 12},
+                children: [ {
+                    sourceRegion: { offset: 0, length: 2, fileURI: undefined },
+                    targetRegion: { offset: 10, length: 2 },
+                }, {
+                    sourceRegion: { offset: 3, length: 4, fileURI: undefined },
+                    targetRegion: { offset: 13, length: 2 },
+                }, {
+                    sourceRegion: { offset: 8, length: 2, fileURI: undefined },
+                    targetRegion: { offset: 16, length: 2 },
+                }, {
+                    sourceRegion: { offset: 11, length: 4, fileURI: undefined },
+                    targetRegion: { offset: 19, length: 3 },
+                } ]
+            } ]
+        });
+    });
+
+    test('should trace entire list and its particluar elemens only', async () => {
+        const source = await parse2('AH "IH" OH 0815') as AstNode & { values: Array<string | number> };
+        const { text, trace } = toStringAndTrace(
+            expandToNode`
+                beginning ${ joinTracedToNode(source, 'values')(source.values, undefined, { separator: ' ' }) } end
+            `
+        );
+        persistSourceRegions(trace);
+
+        expect( text ).toBe('beginning AH IH OH 815 end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            targetRegion: { offset: 0, length: 26 },
+            children: [ {
+                sourceRegion: { offset: 0, length: 15, fileURI: documentURI(source) },
+                targetRegion: { offset: 10, length: 12 },
+                children: [ {
+                    sourceRegion: { offset: 0, length: 2, fileURI: undefined },
+                    targetRegion: { offset: 10, length: 2 },
+                }, {
+                    sourceRegion: { offset: 3, length: 4, fileURI: undefined },
+                    targetRegion: { offset: 13, length: 2 },
+                }, {
+                    sourceRegion: { offset: 8, length: 2, fileURI: undefined },
+                    targetRegion: { offset: 16, length: 2 },
+                }, {
+                    sourceRegion: { offset: 11, length: 4, fileURI: undefined },
+                    targetRegion: { offset: 19, length: 3 },
+                } ]
+            } ]
+        });
+    });
+
+    test('should trace conditionally appended elements', async () => {
+        const source = await parse2('AH "IH" OH 0815') as AstNode & { name?: string, values: Array<string | number> };
+        const { text, trace } = toStringAndTrace(
+            expandToNode`
+                Preamble; 
+            `.appendTracedIf(!!source.name, source, 'name')(() => source?.name ?? ' WRONG ') /* expected to be _not_ appended! */
+            // eslint-disable-next-line @typescript-eslint/indent
+            .appendTracedTemplateIf(source.values.length !== 0, source, 'values')`
+                beginning ${ joinTracedToNode(source, 'values')(source.values, undefined, { separator: ' ', filter: (_, i) => i % 2 === 1}) } end
+            `
+        );
+        persistSourceRegions(trace);
+
+        expect( text ).toBe('Preamble; beginning IH 815 end');
+        expect( trace ).toMatchObject( <TraceRegion>{
+            targetRegion: { offset: 0, length: 30 },
+            children: [ {
+                sourceRegion: { offset:  0, length: 15, fileURI: documentURI(source) },
+                targetRegion: { offset: 10, length: 20 },
+                children: [ {
+                    sourceRegion: { offset:  0, length: 15, fileURI: undefined },
+                    targetRegion: { offset: 20, length: 6 },
+                    children: [ {
+                        sourceRegion: { offset:  3, length: 4 }, // "IH"
+                        targetRegion: { offset: 20, length: 2 }, // IH
+                    }, {
+                        sourceRegion: { offset: 11, length: 4 }, // 0815
+                        targetRegion: { offset: 23, length: 3 }, // 815
+                    } ]
+                } ]
+            } ]
+        });
+    });
+});

--- a/packages/langium/test/generator/template-node.test.ts
+++ b/packages/langium/test/generator/template-node.test.ts
@@ -6,7 +6,8 @@
 
 import { describe, expect, test } from 'vitest';
 import { EOL, toString } from '../../src/generator/generator-node';
-import { expandToNode as n, joinToNode } from '../../src/generator/template-node';
+import { joinToNode } from '../../src/generator/node-joiner';
+import { expandToNode as n } from '../../src/generator/template-node';
 import { expandToString as s } from '../../src/generator/template-string';
 import { stream } from '../../src/utils/stream';
 


### PR DESCRIPTION
This PR contributes:
* Definition of the API for gathering tracing information within code generators
* Implementation of the processing of tracing data to pairs of text regions
* Extension of the JsonSerializer to optionally add `$textRegion` properties to the AstNodes while serializing them