### PR TITLE
Support string escaping

### DIFF
--- a/examples/domainmodel/src/language-server/domain-model.langium
+++ b/examples/domainmodel/src/language-server/domain-model.langium
@@ -30,8 +30,6 @@ QualifiedName returns string:
 
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
-terminal INT returns number: /[0-9]+/;
-terminal STRING: /"[^"]*"|'[^']*'/;
 
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -378,30 +378,6 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
     },
     {
       "$type": "TerminalRule",
-      "name": "INT",
-      "type": {
-        "$type": "ReturnType",
-        "name": "number"
-      },
-      "definition": {
-        "$type": "RegexToken",
-        "regex": "[0-9]+"
-      },
-      "fragment": false,
-      "hidden": false
-    },
-    {
-      "$type": "TerminalRule",
-      "name": "STRING",
-      "definition": {
-        "$type": "RegexToken",
-        "regex": "\\"[^\\"]*\\"|'[^']*'"
-      },
-      "fragment": false,
-      "hidden": false
-    },
-    {
-      "$type": "TerminalRule",
       "hidden": true,
       "name": "ML_COMMENT",
       "definition": {

--- a/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
+++ b/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
@@ -11,16 +11,6 @@
     {
       "name": "keyword.control.domain-model",
       "match": "\\b(datatype|entity|extends|many|package)\\b"
-    },
-    {
-      "name": "string.quoted.double.domain-model",
-      "begin": "\"",
-      "end": "\""
-    },
-    {
-      "name": "string.quoted.single.domain-model",
-      "begin": "'",
-      "end": "'"
     }
   ],
   "repository": {

--- a/examples/domainmodel/syntaxes/domainmodel.monarch.ts
+++ b/examples/domainmodel/syntaxes/domainmodel.monarch.ts
@@ -11,8 +11,6 @@ export default {
     tokenizer: {
         initial: [
             { regex: /[_a-zA-Z][\w_]*/, action: { cases: { '@keywords': {"token":"keyword"}, '@default': {"token":"ID"} }} },
-            { regex: /[0-9]+/, action: {"token":"number"} },
-            { regex: /"[^"]*"|'[^']*'/, action: {"token":"string"} },
             { include: '@whitespace' },
             { regex: /@symbols/, action: { cases: { '@operators': {"token":"operator"}, '@default': {"token":""} }} },
         ],

--- a/examples/requirements/src/language-server/common.langium
+++ b/examples/requirements/src/language-server/common.langium
@@ -3,7 +3,7 @@ Contact: 'contact' ':' user_name=STRING;
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal INT returns number: /[0-9]+/;
-terminal STRING: /"[^"]*"|'[^']*'/;
+terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
 
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/examples/requirements/src/language-server/generated/grammar.ts
+++ b/examples/requirements/src/language-server/generated/grammar.ts
@@ -278,7 +278,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\"[^\\"]*\\"|'[^']*'"
+        "regex": "\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'"
       },
       "fragment": false,
       "hidden": false
@@ -590,7 +590,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\"[^\\"]*\\"|'[^']*'"
+        "regex": "\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'"
       },
       "fragment": false,
       "hidden": false

--- a/examples/requirements/syntaxes/requirements.tmLanguage.json
+++ b/examples/requirements/syntaxes/requirements.tmLanguage.json
@@ -15,12 +15,22 @@
     {
       "name": "string.quoted.double.requirements-lang",
       "begin": "\"",
-      "end": "\""
+      "end": "\"",
+      "patterns": [
+        {
+          "include": "#string-character-escape"
+        }
+      ]
     },
     {
       "name": "string.quoted.single.requirements-lang",
       "begin": "'",
-      "end": "'"
+      "end": "'",
+      "patterns": [
+        {
+          "include": "#string-character-escape"
+        }
+      ]
     }
   ],
   "repository": {
@@ -52,6 +62,10 @@
           "name": "comment.line.requirements-lang"
         }
       ]
+    },
+    "string-character-escape": {
+      "name": "constant.character.escape.requirements-lang",
+      "match": "\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\\{[0-9A-Fa-f]+\\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
     }
   }
 }

--- a/examples/requirements/syntaxes/tests.tmLanguage.json
+++ b/examples/requirements/syntaxes/tests.tmLanguage.json
@@ -15,12 +15,22 @@
     {
       "name": "string.quoted.double.tests-lang",
       "begin": "\"",
-      "end": "\""
+      "end": "\"",
+      "patterns": [
+        {
+          "include": "#string-character-escape"
+        }
+      ]
     },
     {
       "name": "string.quoted.single.tests-lang",
       "begin": "'",
-      "end": "'"
+      "end": "'",
+      "patterns": [
+        {
+          "include": "#string-character-escape"
+        }
+      ]
     }
   ],
   "repository": {
@@ -52,6 +62,10 @@
           "name": "comment.line.tests-lang"
         }
       ]
+    },
+    "string-character-escape": {
+      "name": "constant.character.escape.tests-lang",
+      "match": "\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\\{[0-9A-Fa-f]+\\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
     }
   }
 }

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -305,30 +305,6 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
     },
     {
       "$type": "TerminalRule",
-      "name": "INT",
-      "type": {
-        "$type": "ReturnType",
-        "name": "number"
-      },
-      "definition": {
-        "$type": "RegexToken",
-        "regex": "[0-9]+"
-      },
-      "fragment": false,
-      "hidden": false
-    },
-    {
-      "$type": "TerminalRule",
-      "name": "STRING",
-      "definition": {
-        "$type": "RegexToken",
-        "regex": "\\"[^\\"]*\\"|'[^']*'"
-      },
-      "fragment": false,
-      "hidden": false
-    },
-    {
-      "$type": "TerminalRule",
       "hidden": true,
       "name": "ML_COMMENT",
       "definition": {

--- a/examples/statemachine/src/language-server/statemachine.langium
+++ b/examples/statemachine/src/language-server/statemachine.langium
@@ -24,8 +24,6 @@ Transition:
 
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
-terminal INT returns number: /[0-9]+/;
-terminal STRING: /"[^"]*"|'[^']*'/;
 
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/examples/statemachine/syntaxes/statemachine.monarch.ts
+++ b/examples/statemachine/syntaxes/statemachine.monarch.ts
@@ -11,8 +11,6 @@ export default {
     tokenizer: {
         initial: [
             { regex: /[_a-zA-Z][\w_]*/, action: { cases: { '@keywords': {"token":"keyword"}, '@default': {"token":"ID"} }} },
-            { regex: /[0-9]+/, action: {"token":"number"} },
-            { regex: /"[^"]*"|'[^']*'/, action: {"token":"string"} },
             { include: '@whitespace' },
             { regex: /@symbols/, action: { cases: { '@operators': {"token":"operator"}, '@default': {"token":""} }} },
         ],

--- a/examples/statemachine/syntaxes/statemachine.tmLanguage.json
+++ b/examples/statemachine/syntaxes/statemachine.tmLanguage.json
@@ -11,16 +11,6 @@
     {
       "name": "keyword.control.statemachine",
       "match": "\\b(actions|commands|end|events|initialState|state|statemachine)\\b"
-    },
-    {
-      "name": "string.quoted.double.statemachine",
-      "begin": "\"",
-      "end": "\""
-    },
-    {
-      "name": "string.quoted.single.statemachine",
-      "begin": "'",
-      "end": "'"
     }
   ],
   "repository": {

--- a/packages/generator-langium/langium-template/src/language-server/language-id.langium
+++ b/packages/generator-langium/langium-template/src/language-server/language-id.langium
@@ -12,7 +12,7 @@ Greeting:
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal INT returns number: /[0-9]+/;
-terminal STRING: /"[^"]*"|'[^']*'/;
+terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
 
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/packages/langium-vscode/data/langium.tmLanguage.json
+++ b/packages/langium-vscode/data/langium.tmLanguage.json
@@ -26,12 +26,22 @@
         {
             "name": "string.quoted.double.langium",
             "begin": "\"",
-            "end": "\""
+            "end": "\"",
+            "patterns": [
+				{
+					"include": "#string-character-escape"
+				}
+			]
         },
         {
             "name": "string.quoted.single.langium",
             "begin": "'",
-            "end": "'"
+            "end": "'",
+            "patterns": [
+				{
+					"include": "#string-character-escape"
+				}
+			]
         }
     ],
     "repository": {
@@ -64,23 +74,27 @@
                 }
             ]
         },
+        "string-character-escape": {
+            "name": "constant.character.escape.langium",
+            "match": "\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\\{[0-9A-Fa-f]+\\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
+        },
         "regex": {
             "patterns": [
                 {
-                    "name": "string.regex.ts",
+                    "name": "string.regex.langium",
                     "begin": "/(?![/*])(?=(?:[^/\\\\\\[]|\\\\.|\\[([^\\]\\\\]|\\\\.)+\\])+/(?![/*]))",
                     "beginCaptures": {
                         "0": {
-                            "name": "punctuation.definition.string.begin.ts"
+                            "name": "punctuation.definition.string.begin.langium"
                         }
                     },
                     "end": "/",
                     "endCaptures": {
                         "1": {
-                            "name": "punctuation.definition.string.end.ts"
+                            "name": "punctuation.definition.string.end.langium"
                         },
                         "2": {
-                            "name": "keyword.other.ts"
+                            "name": "keyword.other.langium"
                         }
                     },
                     "patterns": [

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -38,7 +38,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@57"
+                    "$ref": "#/rules@56"
                   },
                   "arguments": []
                 }
@@ -62,7 +62,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@57"
+                          "$ref": "#/rules@56"
                         },
                         "arguments": []
                       },
@@ -88,7 +88,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@57"
+                              "$ref": "#/rules@56"
                             },
                             "arguments": []
                           },
@@ -132,7 +132,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@57"
+                              "$ref": "#/rules@56"
                             },
                             "arguments": []
                           },
@@ -158,7 +158,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                               "terminal": {
                                 "$type": "RuleCall",
                                 "rule": {
-                                  "$ref": "#/rules@57"
+                                  "$ref": "#/rules@56"
                                 },
                                 "arguments": []
                               },
@@ -261,7 +261,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@56"
               },
               "arguments": []
             }
@@ -380,7 +380,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@56"
+                "$ref": "#/rules@55"
               },
               "arguments": []
             }
@@ -608,7 +608,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@56"
               },
               "arguments": []
             }
@@ -684,7 +684,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@58"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -774,7 +774,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@57"
+                              "$ref": "#/rules@56"
                             },
                             "arguments": []
                           },
@@ -852,7 +852,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@57"
+                          "$ref": "#/rules@56"
                         },
                         "arguments": []
                       },
@@ -878,7 +878,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                           "terminal": {
                             "$type": "RuleCall",
                             "rule": {
-                              "$ref": "#/rules@57"
+                              "$ref": "#/rules@56"
                             },
                             "arguments": []
                           },
@@ -984,7 +984,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@56"
               },
               "arguments": []
             }
@@ -1011,7 +1011,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@56"
               },
               "arguments": []
             }
@@ -1088,7 +1088,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@57"
+            "$ref": "#/rules@56"
           },
           "arguments": []
         }
@@ -1481,7 +1481,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@57"
+                      "$ref": "#/rules@56"
                     },
                     "arguments": []
                   },
@@ -1525,7 +1525,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@56"
+                    "$ref": "#/rules@55"
                   },
                   "arguments": []
                 }
@@ -1639,7 +1639,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@58"
+            "$ref": "#/rules@57"
           },
           "arguments": []
         }
@@ -1669,7 +1669,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@57"
+                  "$ref": "#/rules@56"
                 },
                 "arguments": []
               },
@@ -1754,7 +1754,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@57"
+                      "$ref": "#/rules@56"
                     },
                     "arguments": []
                   },
@@ -2079,7 +2079,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@57"
+              "$ref": "#/rules@56"
             },
             "arguments": []
           },
@@ -2123,7 +2123,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@58"
+                "$ref": "#/rules@57"
               },
               "arguments": []
             }
@@ -2172,7 +2172,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@57"
+                  "$ref": "#/rules@56"
                 },
                 "arguments": []
               },
@@ -2274,7 +2274,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@56"
+                "$ref": "#/rules@55"
               },
               "arguments": []
             }
@@ -2687,7 +2687,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@57"
+                "$ref": "#/rules@56"
               },
               "arguments": []
             }
@@ -2743,7 +2743,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@57"
+                        "$ref": "#/rules@56"
                       },
                       "arguments": []
                     }
@@ -2760,7 +2760,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@57"
+                        "$ref": "#/rules@56"
                       },
                       "arguments": []
                     }
@@ -2802,7 +2802,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@45"
+                "$ref": "#/rules@44"
               },
               "arguments": []
             }
@@ -2821,20 +2821,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "wildcard": false
     },
     {
-      "$type": "TerminalRule",
-      "name": "RegexLiteral",
-      "type": {
-        "$type": "ReturnType",
-        "name": "string"
-      },
-      "definition": {
-        "$type": "RegexToken",
-        "regex": "\\\\/(?![*+?])(?:[^\\\\r\\\\n\\\\[/\\\\\\\\]|\\\\\\\\.|\\\\[(?:[^\\\\r\\\\n\\\\]\\\\\\\\]|\\\\\\\\.)*\\\\])+\\\\/"
-      },
-      "fragment": false,
-      "hidden": false
-    },
-    {
       "$type": "ParserRule",
       "name": "TerminalAlternatives",
       "inferredType": {
@@ -2847,7 +2833,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@46"
+              "$ref": "#/rules@45"
             },
             "arguments": []
           },
@@ -2874,7 +2860,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@46"
+                    "$ref": "#/rules@45"
                   },
                   "arguments": []
                 }
@@ -2904,7 +2890,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@47"
+              "$ref": "#/rules@46"
             },
             "arguments": []
           },
@@ -2927,7 +2913,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@47"
+                    "$ref": "#/rules@46"
                   },
                   "arguments": []
                 },
@@ -2958,7 +2944,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@48"
+              "$ref": "#/rules@47"
             },
             "arguments": []
           },
@@ -3007,14 +2993,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@55"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@50"
+              "$ref": "#/rules@54"
             },
             "arguments": []
           },
@@ -3022,6 +3001,20 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "$type": "RuleCall",
             "rule": {
               "$ref": "#/rules@49"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@48"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@50"
             },
             "arguments": []
           },
@@ -3043,13 +3036,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "$type": "RuleCall",
             "rule": {
               "$ref": "#/rules@53"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@54"
             },
             "arguments": []
           }
@@ -3079,7 +3065,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@45"
+              "$ref": "#/rules@44"
             },
             "arguments": []
           },
@@ -3125,7 +3111,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@57"
+                  "$ref": "#/rules@56"
                 },
                 "arguments": []
               },
@@ -3169,7 +3155,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@48"
+                "$ref": "#/rules@47"
               },
               "arguments": []
             }
@@ -3211,7 +3197,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@48"
+                "$ref": "#/rules@47"
               },
               "arguments": []
             }
@@ -3249,7 +3235,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@44"
+                "$ref": "#/rules@58"
               },
               "arguments": []
             }
@@ -3434,7 +3420,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@57"
+              "$ref": "#/rules@56"
             },
             "arguments": []
           }
@@ -3462,7 +3448,21 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\"[^\\"]*\\"|'[^']*'"
+        "regex": "\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'"
+      },
+      "fragment": false,
+      "hidden": false
+    },
+    {
+      "$type": "TerminalRule",
+      "name": "RegexLiteral",
+      "type": {
+        "$type": "ReturnType",
+        "name": "string"
+      },
+      "definition": {
+        "$type": "RegexToken",
+        "regex": "\\\\/(?![*+?])(?:[^\\\\r\\\\n\\\\[/\\\\\\\\]|\\\\\\\\.|\\\\[(?:[^\\\\r\\\\n\\\\]\\\\\\\\]|\\\\\\\\.)*\\\\])+\\\\/"
       },
       "fragment": false,
       "hidden": false

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -160,8 +160,6 @@ TerminalRule:
         definition=TerminalAlternatives
     ';';
 
-terminal RegexLiteral returns string: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\//;
-
 TerminalAlternatives infers AbstractElement:
     TerminalGroup ({infer TerminalAlternatives.elements+=current} '|' elements+=TerminalGroup)*;
 
@@ -199,7 +197,8 @@ FeatureName returns string:
     'current' | 'entry' | 'extends' | 'false' | 'fragment' | 'grammar' | 'hidden' | 'import' | 'interface' | 'returns' | 'terminal' | 'true' | 'type' | 'infer' | 'infers' | 'with' | PrimitiveType | ID;
 
 terminal ID: /\^?[_a-zA-Z][\w_]*/;
-terminal STRING: /"[^"]*"|'[^']*'/;
+terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
+terminal RegexLiteral returns string: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\//;
 
 hidden terminal WS: /\s+/;
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -44,7 +44,7 @@ export class DefaultValueConverter implements ValueConverter {
             case 'INT': return convertInt(input);
             case 'STRING': return convertString(input);
             case 'ID': return convertID(input);
-            case 'REGEXLITERAL': return convertString(input);
+            case 'REGEXLITERAL': return convertRegexLiteral(input);
         }
         switch (getRuleType(rule)?.toLowerCase()) {
             case 'number': return convertNumber(input);
@@ -57,6 +57,33 @@ export class DefaultValueConverter implements ValueConverter {
 }
 
 export function convertString(input: string): string {
+    let result = '';
+    for (let i = 1; i < input.length - 1; i++) {
+        const c = input.charAt(i);
+        if (c === '\\') {
+            const c1 = input.charAt(++i);
+            result += convertEscapeCharacter(c1);
+        } else {
+            result += c;
+        }
+    }
+    return result;
+}
+
+function convertEscapeCharacter(char: string): string {
+    switch (char) {
+        case 'b': return '\b';
+        case 'f': return '\f';
+        case 'n': return '\n';
+        case 'r': return '\r';
+        case 't': return '\t';
+        case 'v': return '\v';
+        case '0': return '\0';
+        default: return char;
+    }
+}
+
+export function convertRegexLiteral(input: string): string {
     return input.substring(1, input.length - 1);
 }
 

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -119,7 +119,7 @@ describe('tokenBuilder#caseInsensitivePattern', () => {
     beforeAll(async () => {
         const text = `
         grammar test
-        Main: 'A' 'ab' 'AbC' | Implement | '\\strange\\';
+        Main: 'A' 'ab' 'AbC' | Implement | '\\\\strange\\\\';
         Implement: '@implement' AB;
         terminal BOOLEAN returns boolean: /true|false/;
         terminal AB: /ABD?/;

--- a/packages/langium/test/parser/value-converter.test.ts
+++ b/packages/langium/test/parser/value-converter.test.ts
@@ -1,0 +1,26 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { createLangiumGrammarServices, Grammar, EmptyFileSystem } from '../../src';
+import { CharacterRange, TerminalRule } from '../../src/grammar/generated/ast';
+import { parseHelper } from '../../src/test';
+
+const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
+const parse = parseHelper<Grammar>(grammarServices);
+
+describe('DefaultValueConverter', () => {
+
+    test('should process escaped characters', async () => {
+        const doc = await parse(`
+            terminal A: 'a\\'\\n\\t\\\\';
+        `);
+        const terminalA = doc.parseResult.value.rules[0] as TerminalRule;
+        expect(terminalA).toBeDefined();
+        expect(terminalA.definition.$type).toBe(CharacterRange);
+        expect((terminalA.definition as CharacterRange).left.value).toBe('a\'\n\t\\');
+    });
+
+});


### PR DESCRIPTION
Closes #885:
 - Add `\` escaping to the `STRING` rule in langium-grammar.langium
 - Process escaped characters in the `convertString` method of DefaultValueConverter
 - Adapt the syntax highlighting config of the grammar language to support escaped characters