### PR TITLE
Small bugfixes

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/all-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/all-types.ts
@@ -56,8 +56,9 @@ function addSuperProperties(allTypes: InterfaceType[]) {
         }
     }
 
+    const visited = new Set<InterfaceType>();
     for (const type of allTypes) {
-        addSuperPropertiesInternal(type);
+        addSuperPropertiesInternal(type, visited);
     }
 }
 

--- a/packages/langium/src/lsp/semantic-token-provider.ts
+++ b/packages/langium/src/lsp/semantic-token-provider.ts
@@ -280,7 +280,11 @@ export abstract class AbstractSemanticTokenProvider implements SemanticTokenProv
                     break;
                 }
                 const node = result.value;
-                const nodeRange = node.$cstNode!.range;
+
+                // CST nodes can be undefined, e.g. programmatically created AST
+                const nodeRange = node.$cstNode?.range;
+                if (!nodeRange) continue;
+
                 const comparedRange = this.compareRange(nodeRange);
                 if (comparedRange === 1) {
                     break; // Every following element will not be in range, so end the loop


### PR DESCRIPTION
Fixes 2 small bugs encountered in https://gitlab.com/sensmetry/public/sysml-2ls:

- Infinite recursion in `addSuperPropertiesInternal`, the grammar instead fails missing property checks rather than due to maximum call stack exceeded
- Missing undefined check in `semantic-token-provider` for `<AstNode>.$cstNode.range`, e.g. programmatically created AST