### PR TITLE
Fix array assignment in fragment rules

### DIFF
--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -325,9 +325,13 @@ export class LangiumParser extends AbstractLangiumParser {
     }
 
     private assignWithoutOverride(target: any, source: any): any {
-        for (const [name, value] of Object.entries(source)) {
-            if (target[name] === undefined) {
-                target[name] = value;
+        for (const [name, existingValue] of Object.entries(source)) {
+            const newValue = target[name];
+            if (newValue === undefined) {
+                target[name] = existingValue;
+            } else if (Array.isArray(newValue) && Array.isArray(existingValue)) {
+                existingValue.push(...newValue);
+                target[name] = existingValue;
             }
         }
         return target;

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -597,6 +597,25 @@ describe('MultiMode Lexing', () => {
 
 });
 
+describe('Fragment rules', () => {
+
+    test('Fragment rules with arrays are correctly assigned to property', async () => {
+        const parser = await parserFromGrammar(`
+        grammar FragmentRuleArrays
+        entry Entry: Fragment*;
+        fragment Fragment: values+=ID;
+        terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
+
+        hidden terminal WS: /\\s+/;
+        `);
+        const result = parser.parse('ab cd ef');
+        expect(result.lexerErrors).toHaveLength(0);
+        expect(result.parserErrors).toHaveLength(0);
+        expect(result.value).toHaveProperty('values', ['ab', 'cd', 'ef']);
+    });
+
+});
+
 describe('ALL(*) parser', () => {
 
     const grammar = `


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/896

Previously, only the full property was assigned for unassigned subrule calls (both fragment/non-fragment). This change addresses this by correctly merging the array values.