### PR TITLE
Simplify property check for validation testing

### DIFF
--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -10,7 +10,7 @@ import {
 } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import { LangiumServices } from '../services';
-import { AstNode, Properties } from '../syntax-tree';
+import { AstNode, CstNode, Properties } from '../syntax-tree';
 import { escapeRegExp } from '../utils/regex-util';
 import { LangiumDocument } from '../workspace/documents';
 import { findNodeForProperty } from '../utils/grammar-util';
@@ -328,7 +328,7 @@ export interface ExpectDiagnosticCode {
 
 export interface ExpectDiagnosticAstOptions<T extends AstNode> {
     node: T;
-    property?: { name: Properties<T>, index?: number };
+    property?: Properties<T> | { name: Properties<T>, index?: number };
 }
 
 export interface ExpectDiagnosticRangeOptions {
@@ -356,13 +356,16 @@ function rangeToString(range: Range): string {
 function filterByOptions<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, options: ExpectDiagnosticOptions<N>) {
     const filters: Array<Predicate<Diagnostic>> = [];
     if ('node' in options) {
-        const cstNode = options.property
-            ? findNodeForProperty(options.node?.$cstNode, options.property.name, options.property.index)
-            : options.node.$cstNode;
+        let cstNode: CstNode | undefined = options.node.$cstNode;
+        if (options.property) {
+            const name = typeof options.property === 'string' ? options.property : options.property.name;
+            const index = typeof options.property === 'string' ? undefined : options.property.index;
+            cstNode = findNodeForProperty(cstNode, name, index);
+        }
         if (!cstNode) {
             throw new Error('Cannot find the node!');
         }
-        filters.push(d => isRangeEqual(cstNode.range, d.range));
+        filters.push(d => isRangeEqual(cstNode!.range, d.range));
     }
     if ('offset' in options) {
         const outer = {

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -26,7 +26,7 @@ describe('Langium grammar validation', () => {
         // should get a warning when basing declared types on inferred types
         expectError(validationResult, /Extending an inferred type is discouraged./, {
             node: validationResult.document.parseResult.value.interfaces[0],
-            property: { name: 'superTypes' }
+            property: 'superTypes'
         });
     });
 
@@ -45,7 +45,7 @@ describe('Langium grammar validation', () => {
         // assert
         expectError(validationResult, /Cannot use fragment rule 'B' for assignment of property 'b'./, {
             node: (validationResult.document.parseResult.value.rules[0] as GrammarAST.ParserRule).definition as GrammarAST.Assignment,
-            property: { name: 'terminal' }
+            property: 'terminal'
         });
     });
 
@@ -63,11 +63,11 @@ describe('Langium grammar validation', () => {
 
         expectError(validationResult, /Interfaces cannot extend union types./, {
             node: validationResult.document.parseResult.value.interfaces[0],
-            property: { name: 'superTypes' }
+            property: 'superTypes'
         });
         expectError(validationResult, /Extending an inferred type is discouraged./, {
             node: validationResult.document.parseResult.value.interfaces[0],
-            property: { name: 'superTypes' }
+            property: 'superTypes'
         });
     });
 
@@ -88,11 +88,11 @@ describe('Langium grammar validation', () => {
 
         expectError(validationResult, /Interfaces cannot extend union types./, {
             node: validationResult.document.parseResult.value.interfaces[0],
-            property: { name: 'superTypes' }
+            property: 'superTypes'
         });
         expectError(validationResult, /Extending an inferred type is discouraged./, {
             node: validationResult.document.parseResult.value.interfaces[0],
-            property: { name: 'superTypes' }
+            property: 'superTypes'
         });
     });
 
@@ -123,7 +123,7 @@ describe('Langium grammar validation', () => {
         `);
         expectError(validationResult, /The type 'T' is already explicitly declared and cannot be inferred./, {
             node: validationResult.document.parseResult.value.rules[0],
-            property: {name: 'name'},
+            property: 'name',
             code: IssueCodes.MissingReturns
         });
     });
@@ -171,7 +171,7 @@ describe('checkReferenceToRuleButNotType', () => {
         const crossRef = streamAllContents(validationResult.document.parseResult.value).find(GrammarAST.isCrossReference)!;
         expectError(validationResult, "Could not resolve reference to AbstractType named 'Definition'.", {
             node: crossRef,
-            property: { name: 'type' }
+            property: 'type'
         });
     });
 
@@ -179,7 +179,7 @@ describe('checkReferenceToRuleButNotType', () => {
         const type = validationResult.document.parseResult.value.types[0];
         expectError(validationResult, "Could not resolve reference to AbstractType named 'Reference'.", {
             node: type,
-            property: { name: 'typeAlternatives' }
+            property: 'typeAlternatives'
         });
     });
 
@@ -223,7 +223,7 @@ describe('Checked Named CrossRefs', () => {
         const rule = ((validationResult.document.parseResult.value.rules[1] as GrammarAST.ParserRule).definition as GrammarAST.Group).elements[1] as GrammarAST.Assignment;
         expectWarning(validationResult, 'The "name" property is not recommended for cross-references.', {
             node: rule,
-            property: { name: 'feature' }
+            property: 'feature'
         });
     });
 });
@@ -316,9 +316,7 @@ describe('Unused rules validation', () => {
         const stringTerminal = validation.document.parseResult.value.rules.find(e => e.name === 'STRING')!;
         expectIssue(validation, {
             node: stringTerminal,
-            property: {
-                name: 'name'
-            },
+            property: 'name',
             severity: DiagnosticSeverity.Hint
         });
     });
@@ -337,9 +335,7 @@ describe('Unused rules validation', () => {
         const unusedRule = validation.document.parseResult.value.rules.find(e => e.name === 'Unused')!;
         expectIssue(validation, {
             node: unusedRule,
-            property: {
-                name: 'name'
-            },
+            property: 'name',
             severity: DiagnosticSeverity.Hint
         });
     });
@@ -406,9 +402,7 @@ describe('Reserved names', () => {
         expectIssue(validation, {
             node,
             message: / is a reserved name of the JavaScript runtime\.$/,
-            property: {
-                name: property
-            },
+            property,
             severity: DiagnosticSeverity.Error
         });
     }
@@ -479,9 +473,7 @@ describe('Clashing token names', () => {
         const terminal = locator.getAstNode(validation.document.parseResult.value, '/rules@1')!;
         expectError(validation, 'Terminal name clashes with existing keyword.', {
             node: terminal,
-            property: {
-                name: 'name'
-            }
+            property: 'name'
         });
     });
 
@@ -498,9 +490,7 @@ describe('Clashing token names', () => {
         const terminal = locator.getAstNode(validation.document.parseResult.value, '/rules@0')!;
         expectError(validation, /Terminal name clashes with imported keyword from/, {
             node: terminal,
-            property: {
-                name: 'name'
-            }
+            property: 'name'
         });
     });
 
@@ -517,9 +507,7 @@ describe('Clashing token names', () => {
         const importNode = validation.document.parseResult.value.imports[0];
         expectError(validation, 'Imported terminals (a) clash with locally defined keywords.', {
             node: importNode,
-            property: {
-                name: 'path'
-            }
+            property: 'path'
         });
     });
 
@@ -541,9 +529,7 @@ describe('Clashing token names', () => {
         const importNode = validation.document.parseResult.value.imports[0];
         expectError(validation, 'Imported terminals (a) clash with imported keywords.', {
             node: importNode,
-            property: {
-                name: 'path'
-            }
+            property: 'path'
         });
     });
 
@@ -599,7 +585,7 @@ describe('Property type is not a mix of cross-ref and non-cross-ref types.', () 
 
         expectError(validation, /Mixing a cross-reference with other types is not supported. Consider splitting property /, {
             node: rule1Assignment!,
-            property: { name: 'terminal' }
+            property: 'terminal'
         });
     });
     test('Parser rule property complex mixed.', async () => {
@@ -617,7 +603,7 @@ describe('Property type is not a mix of cross-ref and non-cross-ref types.', () 
 
         expectError(validation, /Mixing a cross-reference with other types is not supported. Consider splitting property /, {
             node: rule1Assignment!,
-            property: { name: 'terminal' }
+            property: 'terminal'
         });
     });
 

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -366,7 +366,7 @@ describe('Property type is not a mix of cross-ref and non-cross-ref types.', () 
 
         expectError(validation, /Mixing a cross-reference with other types is not supported. Consider splitting property /, {
             node: attribute!,
-            property: { name: 'typeAlternatives' }
+            property: 'typeAlternatives'
         });
     });
 });
@@ -493,9 +493,7 @@ describe('Property types validation takes in account types hierarchy', () => {
         const assignment = streamAllContents(validation.document.parseResult.value).filter(isAssignment).toArray()[0];
         expectError(validation, "The assigned type 'Z2' is not compatible with the declared property 'y' of type 'Z1':  'Z2' is not expected.", {
             node: assignment,
-            property: {
-                name: 'feature'
-            }
+            property: 'feature'
         });
     });
 


### PR DESCRIPTION
Currently, users always have to wrap their property name in an object, even when there's no index. This change makes the API a bit more flexible and allows users to just use a string.