### PR TITLE
Simplify yeoman generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1366,6 +1366,12 @@
       "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
       "dev": true
     },
+    "node_modules/@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "dev": true
+    },
     "node_modules/@types/yeoman-environment": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/@types/yeoman-environment/-/yeoman-environment-2.10.8.tgz",
@@ -7856,16 +7862,32 @@
       "dependencies": {
         "chalk": "~4.1.2",
         "lodash": "~4.17.21",
+        "which": "~3.0.0",
         "yeoman-generator": "~5.7.0"
       },
       "devDependencies": {
         "@types/lodash": "~4.14.191",
+        "@types/which": "~2.0.1",
         "@types/yeoman-generator": "~5.2.11",
         "@types/yeoman-test": "~4.0.3",
         "yeoman-test": "~7.3.0"
       },
       "engines": {
         "node": ">=12.10.0"
+      }
+    },
+    "packages/generator-langium/node_modules/which": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "packages/langium": {
@@ -8888,6 +8910,12 @@
       "version": "1.67.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
       "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "dev": true
+    },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
     "@types/yeoman-environment": {
@@ -10463,12 +10491,24 @@
       "version": "file:packages/generator-langium",
       "requires": {
         "@types/lodash": "~4.14.191",
+        "@types/which": "~2.0.1",
         "@types/yeoman-generator": "~5.2.11",
         "@types/yeoman-test": "~4.0.3",
         "chalk": "~4.1.2",
         "lodash": "~4.17.21",
+        "which": "~3.0.0",
         "yeoman-generator": "~5.7.0",
         "yeoman-test": "~7.3.0"
+      },
+      "dependencies": {
+        "which": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+          "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "get-caller-file": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7862,7 +7862,7 @@
       "dependencies": {
         "chalk": "~4.1.2",
         "lodash": "~4.17.21",
-        "which": "~3.0.0",
+        "which": "~2.0.2",
         "yeoman-generator": "~5.7.0"
       },
       "devDependencies": {
@@ -10496,14 +10496,13 @@
         "@types/yeoman-test": "~4.0.3",
         "chalk": "~4.1.2",
         "lodash": "~4.17.21",
-        "which": "~3.0.0",
+        "which": "~2.0.2",
         "yeoman-generator": "~5.7.0",
         "yeoman-test": "~7.3.0"
       },
       "dependencies": {
         "which": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
           "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
           "requires": {
             "isexe": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7876,20 +7876,6 @@
         "node": ">=12.10.0"
       }
     },
-    "packages/generator-langium/node_modules/which": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
-      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "packages/langium": {
       "version": "1.0.1",
       "license": "MIT",
@@ -10499,15 +10485,6 @@
         "which": "~2.0.2",
         "yeoman-generator": "~5.7.0",
         "yeoman-test": "~7.3.0"
-      },
-      "dependencies": {
-        "which": {
-          "version": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
-          "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "get-caller-file": {

--- a/packages/generator-langium/package.json
+++ b/packages/generator-langium/package.json
@@ -35,10 +35,12 @@
   "dependencies": {
     "chalk": "~4.1.2",
     "lodash": "~4.17.21",
+    "which": "~3.0.0",
     "yeoman-generator": "~5.7.0"
   },
   "devDependencies": {
     "@types/lodash": "~4.14.191",
+    "@types/which": "~2.0.1",
     "@types/yeoman-generator": "~5.2.11",
     "@types/yeoman-test": "~4.0.3",
     "yeoman-test": "~7.3.0"

--- a/packages/generator-langium/package.json
+++ b/packages/generator-langium/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "chalk": "~4.1.2",
     "lodash": "~4.17.21",
-    "which": "~3.0.0",
+    "which": "~2.0.2",
     "yeoman-generator": "~5.7.0"
   },
   "devDependencies": {

--- a/packages/generator-langium/src/index.ts
+++ b/packages/generator-langium/src/index.ts
@@ -141,7 +141,7 @@ class LangiumGenerator extends Generator {
     }
 
     async end(): Promise<void> {
-        const code = await which('code');
+        const code = await which('code').catch(() => undefined);
         if (code) {
             const answer = await this.prompt({
                 type: 'list',

--- a/packages/generator-langium/test/yeoman-generator.test.ts
+++ b/packages/generator-langium/test/yeoman-generator.test.ts
@@ -12,7 +12,8 @@ import { createHelpers } from 'yeoman-test';
 const defaultAnswers = {
     extensionName: 'hello-world',
     rawLanguageName: 'Hello World',
-    fileExtension: '.hello'
+    fileExtension: '.hello',
+    openWith: false
 };
 
 describe('Check yeoman generator works', () => {


### PR DESCRIPTION
Removes a lot of complexity from the yeoman generator by moving a lot of it's functionality inside of methods/out of the loops themselves.

Also adds an end option that allows to directly open the project in vscode if installed.