### PR TITLE
Fix incorrect yeoman vscode-engines version

### DIFF
--- a/examples/arithmetics/package.json
+++ b/examples/arithmetics/package.json
@@ -5,7 +5,7 @@
     "description": "Example language built with Langium",
     "homepage": "https://langium.org",
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
     },
     "license": "MIT",
     "categories": [

--- a/examples/domainmodel/package.json
+++ b/examples/domainmodel/package.json
@@ -5,7 +5,7 @@
     "description": "Example language built with Langium",
     "homepage": "https://langium.org",
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
     },
     "license": "MIT",
     "categories": [

--- a/examples/requirements/package.json
+++ b/examples/requirements/package.json
@@ -4,7 +4,7 @@
     "description": "A demo showing how to combine two DSLs",
     "version": "1.0.0",
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
     },
     "categories": [
         "Programming Languages"

--- a/examples/statemachine/package.json
+++ b/examples/statemachine/package.json
@@ -5,7 +5,7 @@
     "description": "Example language built with Langium",
     "homepage": "https://langium.org",
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
     },
     "license": "MIT",
     "categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "langium-cli": "~1.0.0"
       },
       "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
       }
     },
     "examples/domainmodel": {
@@ -68,7 +68,7 @@
         "langium-cli": "~1.0.0"
       },
       "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
       }
     },
     "examples/requirements": {
@@ -89,7 +89,7 @@
         "langium-cli": "~1.0.0"
       },
       "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
       }
     },
     "examples/statemachine": {
@@ -111,7 +111,7 @@
         "langium-cli": "~1.0.0"
       },
       "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.67.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8038,7 +8038,7 @@
         "yeoman-test": "~7.3.0"
       },
       "engines": {
-        "node": ">=12.10.0"
+        "node": ">=14.0.0"
       }
     },
     "packages/langium": {
@@ -8076,7 +8076,7 @@
         "@types/fs-extra": "~11.0.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "packages/langium-sprotty": {
@@ -8096,7 +8096,7 @@
         "vscode-languageserver": "~8.0.2"
       },
       "engines": {
-        "vscode": "1.67.0"
+        "vscode": "^1.67.0"
       }
     }
   },

--- a/packages/generator-langium/langium-template/package.json
+++ b/packages/generator-langium/langium-template/package.json
@@ -4,7 +4,7 @@
     "description": "Please enter a brief description here",
     "version": "0.0.1",
     "engines": {
-        "vscode": "~1.67.0"
+        "vscode": "^1.67.0"
     },
     "categories": [
         "Programming Languages"

--- a/packages/generator-langium/package.json
+++ b/packages/generator-langium/package.json
@@ -4,7 +4,7 @@
   "description": "Yeoman generator for Langium - the language engineering tool",
   "homepage": "https://langium.org",
   "engines": {
-    "node": ">=12.10.0"
+    "node": ">=14.0.0"
   },
   "keywords": [
     "yeoman-generator",

--- a/packages/generator-langium/test/yeoman-generator.test.ts
+++ b/packages/generator-langium/test/yeoman-generator.test.ts
@@ -40,7 +40,7 @@ normalizeEOL(`{
     "description": "Please enter a brief description here",
     "version": "0.0.1",
     "engines": {
-        "vscode": "~1.67.0"
+        "vscode": "^1.67.0"
     },
     "categories": [
         "Programming Languages"

--- a/packages/langium-cli/package.json
+++ b/packages/langium-cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for Langium - the language engineering tool",
   "homepage": "https://langium.org",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "keywords": [
     "cli",

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -16,7 +16,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "1.67.0"
+    "vscode": "^1.67.0"
   },
   "contributes": {
     "languages": [


### PR DESCRIPTION
Using `~` prevents vscode from picking up the extension compared to `^`.