### PR TITLE
Support terminal lookahead

### DIFF
--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -46,6 +46,7 @@ export interface AbstractElement extends AstNode {
     readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?'
+    lookahead?: '?!' | '?='
 }
 
 export const AbstractElement = 'AbstractElement';
@@ -472,7 +473,6 @@ export interface TerminalGroup extends AbstractElement {
     readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalGroup';
     elements: Array<AbstractElement>
-    lookahead?: '?!' | '?='
 }
 
 export const TerminalGroup = 'TerminalGroup';

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -472,6 +472,7 @@ export interface TerminalGroup extends AbstractElement {
     readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalGroup';
     elements: Array<AbstractElement>
+    lookahead?: '?!' | '?='
 }
 
 export const TerminalGroup = 'TerminalGroup';

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3230,13 +3230,6 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "$type": "Group",
         "elements": [
           {
-            "$type": "Action",
-            "inferredType": {
-              "$type": "InferredType",
-              "name": "TerminalGroup"
-            }
-          },
-          {
             "$type": "Keyword",
             "value": "("
           },
@@ -3260,16 +3253,11 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "cardinality": "?"
           },
           {
-            "$type": "Assignment",
-            "feature": "elements",
-            "operator": "+=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@47"
-              },
-              "arguments": []
-            }
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@47"
+            },
+            "arguments": []
           },
           {
             "$type": "Keyword",

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3266,7 +3266,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@44"
+                "$ref": "#/rules@47"
               },
               "arguments": []
             }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3230,15 +3230,46 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
         "$type": "Group",
         "elements": [
           {
+            "$type": "Action",
+            "inferredType": {
+              "$type": "InferredType",
+              "name": "TerminalGroup"
+            }
+          },
+          {
             "$type": "Keyword",
             "value": "("
           },
           {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@47"
+            "$type": "Assignment",
+            "feature": "lookahead",
+            "operator": "=",
+            "terminal": {
+              "$type": "Alternatives",
+              "elements": [
+                {
+                  "$type": "Keyword",
+                  "value": "?="
+                },
+                {
+                  "$type": "Keyword",
+                  "value": "?!"
+                }
+              ]
             },
-            "arguments": []
+            "cardinality": "?"
+          },
+          {
+            "$type": "Assignment",
+            "feature": "elements",
+            "operator": "+=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@44"
+              },
+              "arguments": []
+            }
           },
           {
             "$type": "Keyword",

--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -164,7 +164,8 @@ function abstractElementToRegex(element: ast.AbstractElement): string {
             throw new Error('Missing rule reference.');
         }
         return withCardinality(terminalRegex(rule), {
-            cardinality: element.cardinality
+            cardinality: element.cardinality,
+            lookahead: element.lookahead
         });
     } else if (ast.isNegatedToken(element)) {
         return negateTokenToRegex(element);
@@ -173,11 +174,13 @@ function abstractElementToRegex(element: ast.AbstractElement): string {
     } else if (ast.isRegexToken(element)) {
         return withCardinality(element.regex, {
             cardinality: element.cardinality,
+            lookahead: element.lookahead,
             wrap: false
         });
     } else if (ast.isWildcard(element)) {
         return withCardinality(WILDCARD, {
-            cardinality: element.cardinality
+            cardinality: element.cardinality,
+            lookahead: element.lookahead
         });
     } else {
         throw new Error(`Invalid terminal element: ${element?.$type}`);
@@ -186,7 +189,8 @@ function abstractElementToRegex(element: ast.AbstractElement): string {
 
 function terminalAlternativesToRegex(alternatives: ast.TerminalAlternatives): string {
     return withCardinality(alternatives.elements.map(abstractElementToRegex).join('|'), {
-        cardinality: alternatives.cardinality
+        cardinality: alternatives.cardinality,
+        lookahead: alternatives.lookahead
     });
 }
 
@@ -199,13 +203,15 @@ function terminalGroupToRegex(group: ast.TerminalGroup): string {
 
 function untilTokenToRegex(until: ast.UntilToken): string {
     return withCardinality(`${WILDCARD}*?${abstractElementToRegex(until.terminal)}`, {
-        cardinality: until.cardinality
+        cardinality: until.cardinality,
+        lookahead: until.lookahead
     });
 }
 
 function negateTokenToRegex(negate: ast.NegatedToken): string {
     return withCardinality(`(?!${abstractElementToRegex(negate.terminal)})${WILDCARD}*?`, {
-        cardinality: negate.cardinality
+        cardinality: negate.cardinality,
+        lookahead: negate.lookahead
     });
 }
 
@@ -213,11 +219,13 @@ function characterRangeToRegex(range: ast.CharacterRange): string {
     if (range.right) {
         return withCardinality(`[${keywordToRegex(range.left)}-${keywordToRegex(range.right)}]`, {
             cardinality: range.cardinality,
+            lookahead: range.lookahead,
             wrap: false
         });
     }
     return withCardinality(keywordToRegex(range.left), {
         cardinality: range.cardinality,
+        lookahead: range.lookahead,
         wrap: false
     });
 }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -183,7 +183,7 @@ TerminalTokenElement infers AbstractElement:
     CharacterRange | TerminalRuleCall | ParenthesizedTerminalElement | NegatedToken | UntilToken | RegexToken | Wildcard;
 
 ParenthesizedTerminalElement infers AbstractElement:
-    {infer TerminalGroup} '(' (lookahead=('?='|'?!'))? elements+=TerminalAlternatives ')';
+    '(' (lookahead=('?='|'?!'))? TerminalAlternatives ')';
 
 TerminalRuleCall infers AbstractElement:
     {infer TerminalRuleCall} rule=[TerminalRule:ID];

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -183,7 +183,7 @@ TerminalTokenElement infers AbstractElement:
     CharacterRange | TerminalRuleCall | ParenthesizedTerminalElement | NegatedToken | UntilToken | RegexToken | Wildcard;
 
 ParenthesizedTerminalElement infers AbstractElement:
-    '(' TerminalAlternatives ')';
+    {infer TerminalGroup} '(' (lookahead=('?='|'?!'))? elements+=TerminalAlternatives ')';
 
 TerminalRuleCall infers AbstractElement:
     {infer TerminalRuleCall} rule=[TerminalRule:ID];

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -154,13 +154,19 @@ describe('TerminalRule to regex', () => {
     test('Should create optional alternatives with keywords', async () => {
         const terminal = await getTerminal("terminal X: ('a' | 'b')?;");
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('((a|b))?');
+        expect(regex).toBe('(a|b)?');
     });
 
-    test('Should create positive lookahead group', async () => {
+    test('Should create positive lookahead group with single element', async () => {
         const terminal = await getTerminal("terminal X: 'a' (?='b');");
         const regex = terminalRegex(terminal);
         expect(regex).toBe('(a(?=b))');
+    });
+
+    test('Should create positive lookahead group with multiple elements', async () => {
+        const terminal = await getTerminal("terminal X: 'a' (?='b' 'c' 'd');");
+        const regex = terminalRegex(terminal);
+        expect(regex).toBe('(a(?=bcd))');
     });
 
     test('Should create negative lookahead group', async () => {

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -154,7 +154,19 @@ describe('TerminalRule to regex', () => {
     test('Should create optional alternatives with keywords', async () => {
         const terminal = await getTerminal("terminal X: ('a' | 'b')?;");
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('(a|b)?');
+        expect(regex).toBe('((a|b))?');
+    });
+
+    test('Should create positive lookahead group', async () => {
+        const terminal = await getTerminal("terminal X: 'a' (?='b');");
+        const regex = terminalRegex(terminal);
+        expect(regex).toBe('(a(?=b))');
+    });
+
+    test('Should create negative lookahead group', async () => {
+        const terminal = await getTerminal("terminal X: 'a' (?!'b');");
+        const regex = terminalRegex(terminal);
+        expect(regex).toBe('(a(?!b))');
     });
 
     test('Should create terminal reference in terminal definition', async () => {


### PR DESCRIPTION
In some cases (mostly for complex terminal definitions) it might make sense to create regexes with positive/negative lookahead support. While users could always use the direct regex syntax to do this, they lose the option to then use the normal terminal syntax. This change adds a `?=` (positive) and `?!` (negative) lookahead syntax to our grammar to improve on this.