### PR TITLE
Fix CST nodes pointing to stale AST nodes when parsed from actions

### DIFF
--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -166,7 +166,7 @@ export class LangiumParser extends AbstractLangiumParser {
             if (!this.isRecording()) {
                 const node: any = { $type };
                 this.stack.push(node);
-                if ($type === DatatypeSymbol)  {
+                if ($type === DatatypeSymbol) {
                     node.value = '';
                 }
             }
@@ -334,6 +334,11 @@ export class LangiumParser extends AbstractLangiumParser {
                 target[name] = existingValue;
             }
         }
+
+        if (source.$cstNode) {
+            source.$cstNode.element = target;
+        }
+
         return target;
     }
 


### PR DESCRIPTION
This fixes CST node `element` pointing to stale AST nodes when parsed from an action. This is important for CST based services such as a formatter which can fail because keywords or properties are incorrectly assumed to be owned by another AST node. Removing the `element` assignment fails the test.