### PR TITLE
yeoman - Create tasks.json to generate grammar files

### DIFF
--- a/packages/generator-langium/langium-template/.vscode/tasks.json
+++ b/packages/generator-langium/langium-template/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build <%= language-id %>",
+            "command": "npm run langium:generate && npm run build",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "Langium: Generate grammar and build the <%= language-id %> language",
+            "icon": {
+                "color": "terminal.ansiGreen",
+                "id": "server-process"
+            }
+        }
+    ]
+}

--- a/packages/generator-langium/test/yeoman-generator.test.ts
+++ b/packages/generator-langium/test/yeoman-generator.test.ts
@@ -27,6 +27,8 @@ describe('Check yeoman generator works', () => {
             .then((result) => {
                 result.assertFile(['hello-world/package.json']);
                 result.assertFileContent('hello-world/package.json', PACKAGE_JSON_EXPECTATION);
+                result.assertFile(['hello-world/.vscode/tasks.json']);
+                result.assertFileContent('hello-world/.vscode/tasks.json', TASKS_JSON_EXPECTATION);
             });
         context.cleanup(); // clean-up
     }, 120_000);
@@ -97,3 +99,27 @@ normalizeEOL(`{
         "typescript": "~4.9.5"
     }
 }`);
+
+const TASKS_JSON_EXPECTATION =
+normalizeEOL(`{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build hello-world",
+            "command": "npm run langium:generate && npm run build",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "Langium: Generate grammar and build the hello-world language",
+            "icon": {
+                "color": "terminal.ansiGreen",
+                "id": "server-process"
+            }
+        }
+    ]
+}
+`);


### PR DESCRIPTION
Yeoman now generates a `tasks.json` file that contains a task to run `langium:generate` script. This task is defined as a `preLaunchTask`  in `Run extension` launch config.

See #926