### PR TITLE
Improve type validation for type unions

### DIFF
--- a/packages/langium-cli/test/generator/types-generator.test.ts
+++ b/packages/langium-cli/test/generator/types-generator.test.ts
@@ -18,7 +18,7 @@ describe('Types generator', () => {
         // on Windows system the line ending of result is "\r\n"
         // Therefore typesFileContent is normalized to prevent false negatives
         const typesFileContent = generateTypesFile(grammar, [result.value]);
-        expect(typesFileContent).toMatch(EXPECTED_TYPES);
+        expect(typesFileContent).toBe(EXPECTED_TYPES);
     });
 
 });
@@ -32,7 +32,7 @@ type Statement = Definition | Evaluation;
 
 interface BinaryExpression {
     left: Expression
-    operator: '*' | '+' | '-' | '/'
+    operator: "*" | "+" | "-" | "/"
     right: Expression
 }
 

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -250,15 +250,17 @@ export function isTypeAssignable(from: PropertyType, to: PropertyType): boolean 
         return from.types.every(fromType => isTypeAssignable(fromType, to));
     } else if (isPropertyUnion(to)) {
         return to.types.some(toType => isTypeAssignable(from, toType));
+    } else if (isValueType(to) && isUnionType(to.value)) {
+        if (isValueType(from) && isUnionType(from.value) && to.value.name === from.value.name) {
+            return true;
+        }
+        return isTypeAssignable(from, to.value.type);
     } else if (isReferenceType(from)) {
         return isReferenceType(to) && isTypeAssignable(from.referenceType, to.referenceType);
     } else if (isArrayType(from)) {
         return isArrayType(to) && isTypeAssignable(from.elementType, to.elementType);
     } else if (isValueType(from)) {
         if (isUnionType(from.value)) {
-            if (isValueType(to) && to.value.name === from.value.name) {
-                return true;
-            }
             return isTypeAssignable(from.value.type, to);
         }
         if (!isValueType(to)) {
@@ -309,7 +311,8 @@ export function propertyTypeToString(type: PropertyType, mode: 'AstType' | 'Decl
     } else if (isPrimitiveType(type)) {
         return type.primitive;
     } else if (isStringType(type)) {
-        return `'${type.string}'`;
+        const delimiter = mode === 'AstType' ? "'" : '"';
+        return `${delimiter}${type.string}${delimiter}`;
     }
     throw new Error('Invalid type');
 }

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -17,7 +17,7 @@ import { ValidationAcceptor, ValidationChecks } from '../../validation/validatio
 import { LangiumDocuments } from '../../workspace/documents';
 import * as ast from '../generated/ast';
 import { isParserRule, isRuleCall } from '../generated/ast';
-import { getTypeNameWithoutError, isDataTypeRule, isOptionalCardinality, isPrimitiveType, resolveImport, resolveTransitiveImports, terminalRegex } from '../internal-grammar-util';
+import { getTypeNameWithoutError, hasDataTypeReturn, isDataTypeRule, isOptionalCardinality, isPrimitiveType, resolveImport, resolveTransitiveImports, terminalRegex } from '../internal-grammar-util';
 import type { LangiumGrammarServices } from '../langium-grammar-module';
 import { typeDefinitionToPropertyType } from '../type-system/type-collector/declared-types';
 import { flattenPlainType, isPlainReferenceType } from '../type-system/type-collector/plain-types';
@@ -624,12 +624,12 @@ export class LangiumGrammarValidator {
         if (isEmptyRule(rule)) {
             return;
         }
-        const hasDatatypeReturnType = rule.dataType;
-        const isDataType = isDataTypeRule(rule);
-        if (!hasDatatypeReturnType && isDataType) {
+        const hasDatatypeReturnType = hasDataTypeReturn(rule);
+        const dataTypeRule = isDataTypeRule(rule);
+        if (!hasDatatypeReturnType && dataTypeRule) {
             accept('error', 'This parser rule does not create an object. Add a primitive return type or an action to the start of the rule to force object instantiation.', { node: rule, property: 'name' });
-        } else if (hasDatatypeReturnType && !isDataType) {
-            accept('error', 'Normal parser rules are not allowed to return a primitive value. Use a datatype rule for that.', { node: rule, property: 'dataType' });
+        } else if (hasDatatypeReturnType && !dataTypeRule) {
+            accept('error', 'Normal parser rules are not allowed to return a primitive value. Use a datatype rule for that.', { node: rule, property: rule.dataType ? 'dataType' : 'returnType' });
         }
     }
 

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -328,7 +328,7 @@ export interface ExpectDiagnosticCode {
 }
 
 export interface ExpectDiagnosticAstOptions<T extends AstNode> {
-    node: T;
+    node?: T;
     property?: Properties<T> | { name: Properties<T>, index?: number };
 }
 
@@ -356,7 +356,7 @@ function rangeToString(range: Range): string {
 
 function filterByOptions<T extends AstNode = AstNode, N extends AstNode = AstNode>(validationResult: ValidationResult<T>, options: ExpectDiagnosticOptions<N>) {
     const filters: Array<Predicate<Diagnostic>> = [];
-    if ('node' in options) {
+    if ('node' in options && options.node) {
         let cstNode: CstNode | undefined = options.node.$cstNode;
         if (options.property) {
             const name = typeof options.property === 'string' ? options.property : options.property.name;

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { AstNode, createLangiumGrammarServices, EmptyFileSystem, GrammarAST, Properties, streamAllContents, streamContents } from '../../src';
-import { Assignment, isAssignment, UnionType } from '../../src/grammar/generated/ast';
+import { Assignment, isAssignment, ParserRule, UnionType } from '../../src/grammar/generated/ast';
 import { IssueCodes } from '../../src/grammar/validation/validator';
 import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper, ValidationResult } from '../../src/test';
 
@@ -139,6 +139,46 @@ describe('Langium grammar validation', () => {
         expect(validationResult.diagnostics).toHaveLength(1);
         expect(validationResult.diagnostics[0].code).toBe(IssueCodes.InvalidInfers);
     });
+});
+
+describe('Data type rule return type', () => {
+
+    test('normal rule + data type return type = error', async () => {
+        const validationResult = await validate(`
+            ParserRule returns string: name='ParserRule';
+        `);
+        expectError(validationResult, 'Normal parser rules are not allowed to return a primitive value. Use a datatype rule for that.', {
+            node: validationResult.document.parseResult.value.rules[0] as ParserRule,
+            property: 'dataType'
+        });
+    });
+
+    test('data type rule + primitive data type = valid', async () => {
+        const validationResult = await validate(`
+            ParserRule returns string: 'ParserRule';
+        `);
+        expectNoIssues(validationResult);
+    });
+
+    test('data type rule + complex data type = valid', async () => {
+        const validationResult = await validate(`
+            ParserRule returns ParserRuleType: 'ParserRule';
+            type ParserRuleType = 'ParserRule';
+        `);
+        expectNoIssues(validationResult);
+    });
+
+    test('normal rule + complex data type = error', async () => {
+        const validationResult = await validate(`
+            ParserRule returns ParserRuleType: name='ParserRule';
+            type ParserRuleType = 'ParserRule';
+        `);
+        expectError(validationResult, 'Normal parser rules are not allowed to return a primitive value. Use a datatype rule for that.', {
+            node: validationResult.document.parseResult.value.rules[0] as ParserRule,
+            property: 'returnType'
+        });
+    });
+
 });
 
 describe('checkReferenceToRuleButNotType', () => {

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -26,20 +26,15 @@ describe('validate params in types', () => {
         terminal ID: /[a-zA-Z_][\\w_]*/;
         `.trim();
         // verify we only have 1 error, associated with a missing 'name' prop
-        const validation = await validate(prog);
+        const document = await parseDocument(grammarServices, prog);
+        let diagnostics: Diagnostic[] = await grammarServices.validation.DocumentValidator.validateDocument(document);
+        diagnostics = diagnostics.filter(d => d.severity === DiagnosticSeverity.Error);
+        expect(diagnostics).toHaveLength(1);
 
-        expectError(validation, "A property 'name' is expected. in a rule that returns type 'B'.", {
-            range: {
-                start: {
-                    line: 4,
-                    character: 8
-                },
-                end: {
-                    line: 4,
-                    character: 10
-                }
-            }
-        });
+        // verify the location of the single diagnostic error, should be only for the 2nd rule
+        const d = diagnostics[0];
+        expect(d.range.start).toEqual({ character: 8, line: 5 });
+        expect(d.range.end).toEqual({ character: 34, line: 5 });
     });
 
     // verifies that missing required params use the right msg & position
@@ -56,20 +51,15 @@ describe('validate params in types', () => {
         `.trim();
 
         // expect exactly 1 error, associated with a missing 'name' prop for type 'A'
-        const validation = await validate(prog);
+        const document = await parseDocument(grammarServices, prog);
+        let diagnostics: Diagnostic[] = await grammarServices.validation.DocumentValidator.validateDocument(document);
+        diagnostics = diagnostics.filter(d => d.severity === DiagnosticSeverity.Error);
+        expect(diagnostics).toHaveLength(1);
 
-        expectError(validation, "Property 'name' is missing in a rule 'Y', but is required in type 'A'.", {
-            range: {
-                start: {
-                    line: 5,
-                    character: 8
-                },
-                end: {
-                    line: 5,
-                    character: 34
-                }
-            }
-        });
+        // verify location of diagnostic
+        const d = diagnostics[0];
+        expect(d.range.start).toEqual({ character: 8, line: 4 });
+        expect(d.range.end).toEqual({ character: 10, line: 4 });
     });
 
     // tests that an optional param in a declared type can be optionally present in a rule

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -31,10 +31,10 @@ describe('validate params in types', () => {
         diagnostics = diagnostics.filter(d => d.severity === DiagnosticSeverity.Error);
         expect(diagnostics).toHaveLength(1);
 
-        // verify the location of the single diagnostic error, should be only for the 2nd rule
+        // verify location of diagnostic
         const d = diagnostics[0];
-        expect(d.range.start).toEqual({ character: 8, line: 5 });
-        expect(d.range.end).toEqual({ character: 34, line: 5 });
+        expect(d.range.start).toEqual({ character: 8, line: 4 });
+        expect(d.range.end).toEqual({ character: 10, line: 4 });
     });
 
     // verifies that missing required params use the right msg & position
@@ -56,10 +56,10 @@ describe('validate params in types', () => {
         diagnostics = diagnostics.filter(d => d.severity === DiagnosticSeverity.Error);
         expect(diagnostics).toHaveLength(1);
 
-        // verify location of diagnostic
+        // verify the location of the single diagnostic error, should be only for the 2nd rule
         const d = diagnostics[0];
-        expect(d.range.start).toEqual({ character: 8, line: 4 });
-        expect(d.range.end).toEqual({ character: 10, line: 4 });
+        expect(d.range.start).toEqual({ character: 8, line: 5 });
+        expect(d.range.end).toEqual({ character: 34, line: 5 });
     });
 
     // tests that an optional param in a declared type can be optionally present in a rule


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/943

Fixes two main issues:

1. Allow to use type unions as return types of data type rules (if they are also a return type)
2. Resolve union types as early as possible during assignability checking. This allows to use type unions as property types of declared interfaces.