### PR TITLE
Don't Format Documents with Lexer/Parser Errors

### DIFF
--- a/examples/domainmodel/test/formatting.test.ts
+++ b/examples/domainmodel/test/formatting.test.ts
@@ -4,9 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { describe, test } from 'vitest';
+import { describe, test, beforeAll, expect } from 'vitest';
 import { EmptyFileSystem } from 'langium';
-import { expectFormatting } from 'langium/test';
+import { expectFormatting, expectFunction } from 'langium/test';
 import { createDomainModelServices } from '../src/language-server/domain-model-module';
 
 const services = createDomainModelServices({ ...EmptyFileSystem }).domainmodel;
@@ -14,9 +14,14 @@ const formatting = expectFormatting(services);
 
 describe('Domain model formatting', () => {
 
+    beforeAll(() => {
+        // override expect function to use the one from Vitest
+        expectFunction((a,e) => {
+            expect(a).toBe(e);
+        });
+    });
+
     test('Should create newline formatting', async () => {
-        // force true until version problems are solved
-        return true;
         await formatting({
             before: 'package foo.bar { datatype Complex entity E2 extends E1 { next: E2 other: Complex nested: Complex time: Complex }}',
             after: `package foo.bar {
@@ -32,8 +37,6 @@ describe('Domain model formatting', () => {
     });
 
     test('Should indent comments correctly', async () => {
-        // force true until version problems are solved
-        return true;
         await formatting({
             before: `package foo.bar {
         /**

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -81,7 +81,7 @@ export abstract class AbstractFormatter implements Formatter {
      * @param range Formatting range to check for safety
      * @returns Whether the given formatting range does not overlap with or follow any regions with an error
      */
-    private isFormatRangeErrorFree(document: LangiumDocument, range: Range): boolean {
+    protected isFormatRangeErrorFree(document: LangiumDocument, range: Range): boolean {
         const pr = document.parseResult;
         if (pr.lexerErrors.length || pr.parserErrors.length) {
             // collect the earliest error line from either

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -78,18 +78,13 @@ export abstract class AbstractFormatter implements Formatter {
         const pr = document.parseResult;
 
         if (pr.lexerErrors.length || pr.parserErrors.length) {
-            let earliestErrLine = Number.MAX_VALUE;
-
             // collect the earliest error line from either
-            for (const lexerError of pr.lexerErrors) {
-                earliestErrLine = Math.min(lexerError.line ?? Number.MAX_VALUE, earliestErrLine);
-            }
-            for (const parserError of pr.parserErrors) {
-                earliestErrLine = Math.min(parserError.token.startLine ?? Number.MAX_VALUE, earliestErrLine);
-            }
-
+            const earliestErrLine = Math.min(
+                ...pr.lexerErrors.map(e => e.line ?? Number.MAX_VALUE),
+                ...pr.parserErrors.map(e => e.token.startLine ?? Number.MAX_VALUE)
+            );
             // if the earliest error line occurs before or at the end line of the range, then don't format
-            if (Math.min(earliestErrLine, params.range.end.line) === earliestErrLine) {
+            if (earliestErrLine <= params.range.end.line) {
                 return [];
             }
         }

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -64,7 +64,14 @@ export abstract class AbstractFormatter implements Formatter {
     }
 
     formatDocument(document: LangiumDocument, params: DocumentFormattingParams): MaybePromise<TextEdit[]> {
-        return this.doDocumentFormat(document, params.options);
+        const pr = document.parseResult;
+        if (pr.lexerErrors.length === 0 && pr.parserErrors.length === 0) {
+            // safe to format
+            return this.doDocumentFormat(document, params.options);
+        } else {
+            // don't format a potentially broken document, return no edits
+            return [];
+        }
     }
 
     formatDocumentRange(document: LangiumDocument, params: DocumentRangeFormattingParams): MaybePromise<TextEdit[]> {

--- a/packages/langium/test/grammar/formatting.test.ts
+++ b/packages/langium/test/grammar/formatting.test.ts
@@ -5,8 +5,8 @@
  ******************************************************************************/
 
 import { beforeAll, describe, test, expect } from 'vitest';
-import { createLangiumGrammarServices, EmptyFileSystem } from 'langium';
-import { expectFormatting, expectFunction } from 'langium/test';
+import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
+import { expectFormatting } from '../../src/test';
 
 const services = createLangiumGrammarServices({ ...EmptyFileSystem }).grammar;
 const formatting = expectFormatting(services);

--- a/packages/langium/test/grammar/formatting.test.ts
+++ b/packages/langium/test/grammar/formatting.test.ts
@@ -45,12 +45,76 @@ terminal ID: /[a-zA-Z_]\\w*/;`
         await formatting({
             before: `grammar Code
 Param: name=ID
-hidden terminal WS: /\s+/;
-terminal ID: /[_a-zA-Z][\w_]*/;`,
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;`,
             after: `grammar Code
 Param: name=ID
-hidden terminal WS: /\s+/;
-terminal ID: /[_a-zA-Z][\w_]*/;`
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;`
+        });
+    });
+
+    test('Should allow formatting range before a parser/lexer error', async () => {
+        await formatting({
+            before: `grammar Code
+P1: 'p1' a=ID;
+P2: 'p2' b=ID
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;
+P3: 'p3' c=ID;`,
+            after: `grammar Code
+P1:
+    'p1' a=ID;
+P2: 'p2' b=ID
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;
+P3: 'p3' c=ID;`,
+
+            range: {
+                start: { line: 0, character: 0},
+                end: { line: 1, character: 14}
+            }
+        });
+    });
+
+    test('Disallow formatting range on or after a parser/lexer error', async () => {
+        const before = `grammar Code
+P1: 'p1' a=ID;
+P2: 'p2' b=ID
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;
+P3: 'p3' c=ID;`;
+
+        // expect that formatting doesn't occur after the error line
+        await formatting({
+            before,
+            after: `grammar Code
+P1: 'p1' a=ID;
+P2: 'p2' b=ID
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;
+P3: 'p3' c=ID;`,
+
+            range: {
+                start: { line: 5, character: 0},
+                end: { line: 6, character: 0}
+            }
+        });
+
+        // expect that formatting doesn't occur on the error line
+        await formatting({
+            before,
+            after: `grammar Code
+P1: 'p1' a=ID;
+P2: 'p2' b=ID
+hidden terminal WS: /\\s+/;
+terminal ID: /[_a-zA-Z][\\w_]*/;
+P3: 'p3' c=ID;`,
+
+            range: {
+                start: { line: 0, character: 0},
+                end: { line: 4, character: 0}
+            }
         });
     });
 

--- a/packages/langium/test/grammar/formatting.test.ts
+++ b/packages/langium/test/grammar/formatting.test.ts
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { beforeAll, describe, test, expect } from 'vitest';
+import { createLangiumGrammarServices, EmptyFileSystem } from 'langium';
+import { expectFormatting, expectFunction } from 'langium/test';
+
+const services = createLangiumGrammarServices({ ...EmptyFileSystem }).grammar;
+const formatting = expectFormatting(services);
+
+describe('Langium grammar formatting tests', () => {
+
+    beforeAll(() => {
+        // override expect function to use the one from Vitest
+        expectFunction((a,e) => {
+            expect(a).toBe(e);
+        });
+    });
+
+    test('Should format simple grammar correctly', async () => {
+        await formatting({
+            before: 'grammar T\nA:val=ID;',
+            after: 'grammar T\nA:\n    val=ID;'
+        });
+    });
+
+    test('Should format more complex grammar correctly', async () => {
+        await formatting({
+            before: `grammar T
+A:'a' aval=ID;B:'b' bval=ID;terminal ID: /[a-zA-Z_]\\w*/;`,
+            after: `grammar T
+A:
+    'a' aval=ID;
+B:
+    'b' bval=ID;
+terminal ID: /[a-zA-Z_]\\w*/;`
+        });
+    });
+
+    // Added to guard against #912 (Grammar formatter deletes code)
+    test('Should not format syntactically incorrect grammar', async () => {
+        await formatting({
+            before: `grammar Code
+Param: name=ID
+hidden terminal WS: /\s+/;
+terminal ID: /[_a-zA-Z][\w_]*/;`,
+            after: `grammar Code
+Param: name=ID
+hidden terminal WS: /\s+/;
+terminal ID: /[_a-zA-Z][\w_]*/;`
+        });
+    });
+
+});

--- a/packages/langium/test/grammar/formatting.test.ts
+++ b/packages/langium/test/grammar/formatting.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { beforeAll, describe, test, expect } from 'vitest';
+import { describe, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { expectFormatting } from '../../src/test';
 
@@ -12,13 +12,6 @@ const services = createLangiumGrammarServices({ ...EmptyFileSystem }).grammar;
 const formatting = expectFormatting(services);
 
 describe('Langium grammar formatting tests', () => {
-
-    beforeAll(() => {
-        // override expect function to use the one from Vitest
-        expectFunction((a,e) => {
-            expect(a).toBe(e);
-        });
-    });
 
     test('Should format simple grammar correctly', async () => {
         await formatting({


### PR DESCRIPTION
Closes #912 by producing no formatting when a given document has either lexer or parser errors. Just to add there's no checking of error diagnostics, since these can still be produced for a syntactically valid document.

The result is that trying to format the previously given example produces no changes, at least not until the document has been corrected. Gif below for reference.

We should also make sure to publish a patched version onto the playground as well.

![Feb-24-2023 10-11-08](https://user-images.githubusercontent.com/5070304/221139252-d1cf7de3-8e76-44a8-abac-fefc54569e2d.gif)
