### PR TITLE
Added a validator to check for duplicate names

### DIFF
--- a/examples/statemachine/src/language-server/statemachine-validator.ts
+++ b/examples/statemachine/src/language-server/statemachine-validator.ts
@@ -5,20 +5,25 @@
  ******************************************************************************/
 
 import { ValidationAcceptor, ValidationChecks } from 'langium';
-import { State, StatemachineAstType } from './generated/ast';
+import { State, Statemachine, StatemachineAstType } from './generated/ast';
 import type { StatemachineServices } from './statemachine-module';
 
 export function registerValidationChecks(services: StatemachineServices) {
     const registry = services.validation.ValidationRegistry;
     const validator = services.validation.StatemachineValidator;
     const checks: ValidationChecks<StatemachineAstType> = {
-        State: validator.checkStateNameStartsWithCapital
+        State: validator.checkStateNameStartsWithCapital,
+        Statemachine: validator.checkUniqueStatesAndEvents
     };
     registry.register(checks, validator);
 }
 
 export class StatemachineValidator {
-
+    /**
+     * Checks if the state name starts with a capital letter.
+     * @param state the state to check
+     * @param accept the acceptor to report errors
+     */
     checkStateNameStartsWithCapital(state: State, accept: ValidationAcceptor): void {
         if (state.name) {
             const firstChar = state.name.substring(0, 1);
@@ -26,6 +31,30 @@ export class StatemachineValidator {
                 accept('warning', 'State name should start with a capital letter.', { node: state, property: 'name' });
             }
         }
+    }
+    /**
+     * Checks if there are duplicate state and event names.
+     * @param statemachine the statemachine to check
+     * @param accept the acceptor to report errors
+     */
+    checkUniqueStatesAndEvents(statemachine: Statemachine, accept: ValidationAcceptor): void {
+        const variables: string[] = [];
+
+        // let's check for duplicate state names
+        statemachine.states.forEach(state => {
+            if (variables.find(name => name === state.name)) {
+                accept('error',  `Name '${state.name}' does already exist.`, {node: state, property: 'name'});
+            }
+            variables.push(state.name);
+        });
+
+        // let's check for duplicate event names
+        statemachine.events.forEach(event => {
+            if (variables.find(name => name === event.name)) {
+                accept('error',  `Name '${event.name}' does already exist.`, {node: event, property: 'name'});
+            }
+            variables.push(event.name);
+        });
     }
 
 }


### PR DESCRIPTION
The current version of statemachine allows you to create duplicate events or states with the same name. 
This throws some problems when writing generators or previews for the statemachine. 
So I wrote a validator to check for duplicates: [link to the file](https://github.com/langium/langium/blob/emilkrebs/statemachineFixDuplicates/examples/statemachine/src/language-server/statemachine-validator.ts).

Here is a code example to replicate the bug:

```
statemachine TrafficLight

events 
    switchCapacity
    next

initialState PowerOff

state PowerOff
    switchCapacity => RedLight
end

state RedLight
    switchCapacity => PowerOff
    next => GreenLight
end

state YellowLight
    switchCapacity => PowerOff
    next => RedLight
end

state GreenLight
    switchCapacity => PowerOff
    next => YellowLight
end

// this would work
state GreenLight 
    switchCapacity => PowerOff
    next => YellowLight
end

// this would work either
state switchCapacity
    switchCapacity => PowerOff
    next => YellowLight
end
```


