### PR TITLE
Add utilities for resolving cross-references

### DIFF
--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -119,7 +119,7 @@ export function isNumberLiteral(item: unknown): item is NumberLiteral {
     return reflection.isInstance(item, NumberLiteral);
 }
 
-export interface ArithmeticsAstType {
+export type ArithmeticsAstType = {
     AbstractDefinition: AbstractDefinition
     BinaryExpression: BinaryExpression
     DeclaredParameter: DeclaredParameter

--- a/examples/domainmodel/src/language-server/generated/ast.ts
+++ b/examples/domainmodel/src/language-server/generated/ast.ts
@@ -88,7 +88,7 @@ export function isPackageDeclaration(item: unknown): item is PackageDeclaration 
     return reflection.isInstance(item, PackageDeclaration);
 }
 
-export interface DomainModelAstType {
+export type DomainModelAstType = {
     AbstractElement: AbstractElement
     DataType: DataType
     Domainmodel: Domainmodel

--- a/examples/requirements/src/language-server/generated/ast.ts
+++ b/examples/requirements/src/language-server/generated/ast.ts
@@ -85,7 +85,7 @@ export function isTestModel(item: unknown): item is TestModel {
     return reflection.isInstance(item, TestModel);
 }
 
-export interface RequirementsAndTestsAstType {
+export type RequirementsAndTestsAstType = {
     Contact: Contact
     Environment: Environment
     Requirement: Requirement

--- a/examples/statemachine/src/language-server/generated/ast.ts
+++ b/examples/statemachine/src/language-server/generated/ast.ts
@@ -72,7 +72,7 @@ export function isTransition(item: unknown): item is Transition {
     return reflection.isInstance(item, Transition);
 }
 
-export interface StatemachineAstType {
+export type StatemachineAstType = {
     Command: Command
     Event: Event
     State: State

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -44,7 +44,7 @@ function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): Gener
     const crossReferenceTypes = buildCrossReferenceTypes(astTypes);
     const reflectionNode = new CompositeGeneratorNode();
 
-    reflectionNode.append(`export interface ${config.projectName}AstType {`, NL);
+    reflectionNode.append(`export type ${config.projectName}AstType {`, NL);
     reflectionNode.indent(astTypeBody => {
         for (const type of typeNames) {
             astTypeBody.append(type, ': ', type, NL);

--- a/packages/langium-cli/src/generator/ast-generator.ts
+++ b/packages/langium-cli/src/generator/ast-generator.ts
@@ -44,7 +44,7 @@ function generateAstReflection(config: LangiumConfig, astTypes: AstTypes): Gener
     const crossReferenceTypes = buildCrossReferenceTypes(astTypes);
     const reflectionNode = new CompositeGeneratorNode();
 
-    reflectionNode.append(`export type ${config.projectName}AstType {`, NL);
+    reflectionNode.append(`export type ${config.projectName}AstType = {`, NL);
     reflectionNode.indent(astTypeBody => {
         for (const type of typeNames) {
             astTypeBody.append(type, ': ', type, NL);

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -528,7 +528,7 @@ export function isWildcard(item: unknown): item is Wildcard {
     return reflection.isInstance(item, Wildcard);
 }
 
-export interface LangiumGrammarAstType {
+export type LangiumGrammarAstType = {
     AbstractElement: AbstractElement
     AbstractRule: AbstractRule
     AbstractType: AbstractType

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -263,6 +263,6 @@ export type AstTypeList<T> = Record<keyof T, AstNode>;
  * Returns all types that contain cross-references, A is meant to be the interface `XXXAstType` fromm your generated `ast.ts` file.
  * Meant to be used during cross-reference resolution in combination with `assertUnreachable(context.container)`.
  */
-export type AstNodeTypesWithCrossReferences<E, A extends AstTypeList<E>> = {
+export type AstNodeTypesWithCrossReferences<A extends AstTypeList<A>> = {
     [T in keyof A]: CrossReferencesOfAstNodeType<A[T]> extends never ? never : A[T]
 }[keyof A];

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -257,6 +257,6 @@ export type CrossReferencesOfAstNodeType<N extends AstNode> = (
  * Returns all types that contain cross-references, A is meant to be the interface `XXXAstType` fromm your generated `ast.ts` file.
  * Meant to be used during cross-reference resolution in combination with `assertUnreachable(context.container)`.
  */
-export type AstNodeTypesWithCrossReferences<A> = {
-    [T in keyof A]: A[T] extends AstNode ? (CrossReferencesOfAstNodeType<A[T]> extends never ? never : A[T]) : never
+export type AstNodeTypesWithCrossReferences<A extends Record<string, AstNode>> = {
+    [T in keyof A]: CrossReferencesOfAstNodeType<A[T]> extends never ? never : A[T]
 }[keyof A];

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -35,8 +35,6 @@ export interface GenericAstNode extends AstNode {
     [key: string]: unknown
 }
 
-export type AstTypeList<T> = Record<keyof T, AstNode>;
-
 type SpecificNodeProperties<N extends AstNode> = keyof Omit<N, keyof AstNode | number | symbol>;
 
 /**
@@ -241,7 +239,9 @@ export function isRootCstNode(node: unknown): node is RootCstNode {
     return isCompositeCstNode(node) && 'fullText' in node;
 }
 
-//Manipulates a type to have only properties whose value is of a certain type.
+/**
+ * Returns a type to have only properties names (!) of a type T whose property value is of a certain type K.
+ */
 type ExtractKeysOfValueType<T, K> = { [I in keyof T]: T[I] extends K ? I : never }[keyof T];
 
 /**
@@ -251,12 +251,18 @@ type ExtractKeysOfValueType<T, K> = { [I in keyof T]: T[I] extends K ? I : never
 export type CrossReferencesOfAstNodeType<N extends AstNode> = (
     ExtractKeysOfValueType<N, Reference|undefined>
     | ExtractKeysOfValueType<N, Array<Reference|undefined>|undefined>
-) & Record<string, never>;
+// eslint-disable-next-line @typescript-eslint/ban-types
+) & {};
+
+/**
+ * Represents the enumeration-like type, that lists all AstNode types of your grammar.
+ */
+export type AstTypeList<T> = Record<keyof T, AstNode>;
 
 /**
  * Returns all types that contain cross-references, A is meant to be the interface `XXXAstType` fromm your generated `ast.ts` file.
  * Meant to be used during cross-reference resolution in combination with `assertUnreachable(context.container)`.
  */
-export type AstNodeTypesWithCrossReferences<A extends Record<string, AstNode>> = {
+export type AstNodeTypesWithCrossReferences<E, A extends AstTypeList<E>> = {
     [T in keyof A]: CrossReferencesOfAstNodeType<A[T]> extends never ? never : A[T]
 }[keyof A];

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -241,11 +241,11 @@ export function isRootCstNode(node: unknown): node is RootCstNode {
     return isCompositeCstNode(node) && 'fullText' in node;
 }
 
-//Manipulates a type to show only properties of a certain type.
+//Manipulates a type to have only properties whose value is of a certain type.
 type ExtractKeysOfValueType<T, K> = { [I in keyof T]: T[I] extends K ? I : never }[keyof T];
 
 /**
- * Returns the property names of an AstNode that are cross-references.
+ * Returns the property names (!) of an AstNode that are cross-references.
  * Meant to be used during cross-reference resolution in combination with `assertUnreachable(context.property)`.
  */
 export type CrossReferencesOfAstNodeType<N extends AstNode> = (
@@ -254,9 +254,9 @@ export type CrossReferencesOfAstNodeType<N extends AstNode> = (
 ) & Record<string, never>;
 
 /**
- * Returns all types that contain cross-references.
+ * Returns all types that contain cross-references, A is meant to be the interface `XXXAstType` fromm your generated `ast.ts` file.
  * Meant to be used during cross-reference resolution in combination with `assertUnreachable(context.container)`.
  */
-export type AstNodeTypesWithCrossReferences<A extends Record<string, AstNode>> = {
-    [T in keyof A]: CrossReferencesOfAstNodeType<A[T]> extends never ? never : A[T]
+export type AstNodeTypesWithCrossReferences<A> = {
+    [T in keyof A]: A[T] extends AstNode ? (CrossReferencesOfAstNodeType<A[T]> extends never ? never : A[T]) : never
 }[keyof A];

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -240,3 +240,23 @@ export interface RootCstNode extends CompositeCstNode {
 export function isRootCstNode(node: unknown): node is RootCstNode {
     return isCompositeCstNode(node) && 'fullText' in node;
 }
+
+//Manipulates a type to show only properties of a certain type.
+type ExtractKeysOfValueType<T, K> = { [I in keyof T]: T[I] extends K ? I : never }[keyof T];
+
+/**
+ * Returns the property names of an AstNode that are cross-references.
+ * Meant to be used during cross-reference resolution in combination with `assertUnreachable(context.property)`.
+ */
+export type CrossReferencesOfAstNodeType<N extends AstNode> = (
+    ExtractKeysOfValueType<N, Reference|undefined>
+    | ExtractKeysOfValueType<N, Array<Reference|undefined>|undefined>
+) & Record<string, never>;
+
+/**
+ * Returns all types that contain cross-references.
+ * Meant to be used during cross-reference resolution in combination with `assertUnreachable(context.container)`.
+ */
+export type AstNodeTypesWithCrossReferences<A extends Record<string, AstNode>> = {
+    [T in keyof A]: CrossReferencesOfAstNodeType<A[T]> extends never ? never : A[T]
+}[keyof A];


### PR DESCRIPTION
I added two generic types that helped me a lot during the resolution of the cross-references. It assigns all possible types to the scope provider variables, so you can handle one by one until you reach NEVER, which is guarded by `assertUnreachable(....);`.

The big advantage is that you immediately get compile time feedback if you left out some case. Isn't this great?!

You can now add case by case and be sure that every scenario is handled :)...

# Example

```typescript
    override getScope(context: ReferenceInfo): Scope {
        const container = context.container as AstNodeTypesWithCrossReferences<SqlAstType>;
        if(isTableDefinition(container)) {
            const property = context.property as CrossReferencesOfAstNodeType<TableDefinition>;
            switch(property) {
                case 'schemaName': {
                    return this.getSchemasFromGlobalScope(context);
                }
                default:
                    assertUnreachable(property); //will complain only if you add a new crossers to TableDefinition without adding a case in this switch
            }
        } else if(isPrimaryKeyDefinition(container)) {
            const property = context.property as CrossReferencesOfAstNodeType<PrimaryKeyDefinition>;
            switch(property) {
                case 'primaryKeys':
                    const tableDef = getContainerOfType(container, isTableDefinition)!;
                    return this.streamColumnDefinitions(tableDef.columns.filter(isColumnDefinition));
                default:
                    assertUnreachable(property); //same...
            }
        } else {
            assertUnreachable(container); //will complain because there are more than 2 AST nodes with cross-references
        }

        return super.getScope(context);
    }            
```