### PR TITLE
Fixes for deep and declared hierarchies

### DIFF
--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -64,7 +64,7 @@ function mergeAndRemoveDuplicates<T extends { name: string }>(...elements: T[]):
 export function specifyAstNodeProperties(astTypes: AstTypes) {
     const nameToType = filterInterfaceLikeTypes(astTypes);
     const array = Array.from(nameToType.values());
-    flattenHierarchy(array);
+    addSubTypes(array);
     buildContainerTypes(array);
     buildTypeNames(nameToType);
 }
@@ -125,23 +125,11 @@ function isDataType(property: PropertyType, visited: Set<PropertyType>): boolean
     }
 }
 
-function flattenHierarchy(types: TypeOption[]) {
-    // Recursively collect all supertypes
-    const visited = new Set<TypeOption>();
-    const collect = (type: TypeOption): void => {
-        if (visited.has(type)) return;
-        visited.add(type);
-        for (const superType of type.superTypes) {
-            collect(superType);
-            superType.superTypes.forEach(t => type.superTypes.add(t));
-            type.superTypes.add(superType);
+function addSubTypes(types: TypeOption[]) {
+    for (const interfaceType of types) {
+        for (const superTypeName of interfaceType.superTypes) {
+            superTypeName.subTypes.add(interfaceType);
         }
-    };
-    types.forEach(collect);
-
-    // Invert all supertypes
-    for (const type of types) {
-        type.superTypes.forEach(t => t.subTypes.add(type));
     }
 }
 

--- a/packages/langium/src/grammar/type-system/ast-collector.ts
+++ b/packages/langium/src/grammar/type-system/ast-collector.ts
@@ -66,23 +66,22 @@ export function specifyAstNodeProperties(astTypes: AstTypes) {
     const array = Array.from(nameToType.values());
     addSubTypes(array);
     buildContainerTypes(array);
-    buildTypeNames(nameToType);
+    buildTypeNames(array);
 }
 
-function buildTypeNames(nameToType: Map<string, TypeOption>) {
-    const queue = Array.from(nameToType.values()).filter(e => e.subTypes.size === 0);
+function buildTypeNames(types: TypeOption[]) {
+    // Recursively collect all subtype names
     const visited = new Set<TypeOption>();
-    for (const type of queue) {
+    const collect = (type: TypeOption): void => {
+        if (visited.has(type)) return;
         visited.add(type);
         type.typeNames.add(type.name);
-        const superTypes = Array.from(type.superTypes)
-            .map(superType => nameToType.get(superType.name))
-            .filter(e => e !== undefined) as TypeOption[];
-        for (const superType of superTypes) {
-            type.typeNames.forEach(e => superType.typeNames.add(e));
+        for (const subtype of type.subTypes) {
+            collect(subtype);
+            subtype.typeNames.forEach(n => type.typeNames.add(n));
         }
-        queue.push(...superTypes.filter(e => !visited.has(e)));
-    }
+    };
+    types.forEach(collect);
 }
 
 /**

--- a/packages/langium/src/grammar/validation/types-validator.ts
+++ b/packages/langium/src/grammar/validation/types-validator.ts
@@ -9,8 +9,8 @@ import { MultiMap } from '../../utils/collections';
 import { DiagnosticInfo, ValidationAcceptor, ValidationChecks } from '../../validation/validation-registry';
 import { extractAssignments } from '../internal-grammar-util';
 import { LangiumGrammarServices } from '../langium-grammar-module';
-import { flattenPropertyUnion, InterfaceType, isInterfaceType, isMandatoryPropertyType, isReferenceType, isTypeAssignable, isUnionType, Property, PropertyType, propertyTypeToString } from '../type-system/type-collector/types';
-import { DeclaredInfo, InferredInfo, isDeclared, isInferred, isInferredAndDeclared, LangiumGrammarDocument } from '../workspace/documents';
+import { flattenPropertyUnion, InterfaceType, isArrayType, isInterfaceType, isMandatoryPropertyType, isPropertyUnion, isReferenceType, isTypeAssignable, isUnionType, isValueType, Property, PropertyType, propertyTypeToString } from '../type-system/type-collector/types';
+import { DeclaredInfo, InferredInfo, isDeclared, isInferred, isInferredAndDeclared, LangiumGrammarDocument, ValidationResources } from '../workspace/documents';
 
 export function registerTypeValidationChecks(services: LangiumGrammarServices): void {
     const registry = services.validation.ValidationRegistry;
@@ -50,7 +50,7 @@ export class LangiumGrammarTypesValidator {
                     validateInferredInterface(typeInfo.inferred as InterfaceType, accept);
                 }
                 if (isInferredAndDeclared(typeInfo)) {
-                    validateDeclaredAndInferredConsistency(typeInfo, accept);
+                    validateDeclaredAndInferredConsistency(typeInfo, validationResources, accept);
                 }
             }
         }
@@ -170,7 +170,7 @@ function arePropTypesIdentical(a: Property, b: Property): boolean {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & DeclaredInfo, accept: ValidationAcceptor) {
+function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & DeclaredInfo, resources: ValidationResources, accept: ValidationAcceptor) {
     const { inferred, declared, declaredNode, inferredNodes } = typeInfo;
     const typeName = declared.name;
 
@@ -211,7 +211,7 @@ function validateDeclaredAndInferredConsistency(typeInfo: InferredInfo & Declare
             applyErrorToRulesAndActions(`in a rule that returns type '${typeName}'`),
         );
     } else if (isInterfaceType(inferred) && isInterfaceType(declared)) {
-        validatePropertiesConsistency(inferred, declared,
+        validatePropertiesConsistency(inferred, declared, resources,
             applyErrorToRulesAndActions(`in a rule that returns type '${typeName}'`),
             applyErrorToProperties,
             applyMissingPropErrorToRules
@@ -241,6 +241,7 @@ function isOptionalProperty(prop: Property): boolean {
 function validatePropertiesConsistency(
     inferred: InterfaceType,
     declared: InterfaceType,
+    resources: ValidationResources,
     applyErrorToType: (errorMessage: string) => void,
     applyErrorToProperties: (nodes: Set<ast.Assignment | ast.Action | ast.TypeAttribute>, errorMessage: string) => void,
     applyMissingPropErrorToRules: (missingProp: string) => void
@@ -251,13 +252,27 @@ function validatePropertiesConsistency(
     // This field only contains properties of itself or super types
     const declaredProps = new Map(declared.superProperties.map(e => [e.name, e]));
 
+    // The inferred props may not have full hierarchy information so try finding
+    // the a corresponding declared type
+    const matchingProp = (type: PropertyType): PropertyType => {
+        if (isPropertyUnion(type)) return { types: type.types.map(t => matchingProp(t)) };
+        if (isReferenceType(type)) return { referenceType: matchingProp(type.referenceType) };
+        if (isArrayType(type)) return { elementType: matchingProp(type.elementType) };
+        if (isValueType(type)) {
+            const resource = resources.typeToValidationInfo.get(type.value.name);
+            if (!resource) return type;
+            return { value: 'declared' in resource ? resource.declared : resource.inferred };
+        }
+        return type;
+    };
+
     // detects extra properties & validates matched ones on consistency by the 'optional' property
     for (const [name, foundProp] of allInferredProps.entries()) {
         const expectedProp = declaredProps.get(name);
         if (expectedProp) {
             const foundTypeAsStr = propertyTypeToString(foundProp.type, 'DeclaredType');
             const expectedTypeAsStr = propertyTypeToString(expectedProp.type, 'DeclaredType');
-            const typeAlternativesErrors = isTypeAssignable(foundProp.type, expectedProp.type);
+            const typeAlternativesErrors = isTypeAssignable(matchingProp(foundProp.type), expectedProp.type);
             if (!typeAlternativesErrors) {
                 const errorMsgPrefix = `The assigned type '${foundTypeAsStr}' is not compatible with the declared property '${name}' of type '${expectedTypeAsStr}'.`;
                 applyErrorToProperties(foundProp.astNodes, errorMsgPrefix);

--- a/packages/langium/src/grammar/validation/types-validator.ts
+++ b/packages/langium/src/grammar/validation/types-validator.ts
@@ -253,7 +253,7 @@ function validatePropertiesConsistency(
     const declaredProps = new Map(declared.superProperties.map(e => [e.name, e]));
 
     // The inferred props may not have full hierarchy information so try finding
-    // the a corresponding declared type
+    // a corresponding declared type
     const matchingProp = (type: PropertyType): PropertyType => {
         if (isPropertyUnion(type)) return { types: type.types.map(t => matchingProp(t)) };
         if (isReferenceType(type)) return { referenceType: matchingProp(type.referenceType) };

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -543,6 +543,44 @@ describe('types of `$container` and `$type` are correct', () => {
             }
         `);
     });
+
+    test('types of `$type` for declared deep hierarchies', async () => {
+        await expectTypes(`
+            interface A {}
+            interface B extends A {}
+            interface C extends B {}
+            interface D extends C {}
+            interface E extends C {}
+            interface F extends D {}
+            interface G extends D {}
+            interface H extends A {}
+        `, expandToString`
+            export interface A extends AstNode {
+                readonly $type: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H';
+            }
+            export interface B extends A {
+                readonly $type: 'B' | 'C' | 'D' | 'E' | 'F' | 'G';
+            }
+            export interface H extends A {
+                readonly $type: 'H';
+            }
+            export interface C extends B {
+                readonly $type: 'C' | 'D' | 'E' | 'F' | 'G';
+            }
+            export interface D extends C {
+                readonly $type: 'D' | 'F' | 'G';
+            }
+            export interface E extends C {
+                readonly $type: 'E';
+            }
+            export interface F extends D {
+                readonly $type: 'F';
+            }
+            export interface G extends D {
+                readonly $type: 'G';
+            }
+        `);
+    });
 });
 
 // https://github.com/langium/langium/issues/744

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -497,4 +497,28 @@ describe('Property types validation takes in account types hierarchy', () => {
         });
     });
 
+    test('No false positive on declared type assignment', async () => {
+        const validation = await validate(`
+        interface A {}
+        interface B extends A {}
+        interface C extends B {}
+        interface D extends C {}
+        interface E extends C {}
+        interface F extends D {}
+        interface G extends D {}
+        interface H extends A {}
+
+        interface Test {
+            value: A;
+        }
+
+        F returns F: {F};
+
+        Test returns Test:
+            value=F
+        ;`);
+
+        console.log(validation.diagnostics);
+        expectNoIssues(validation);
+    });
 });


### PR DESCRIPTION
Fixes #949:

- `$type` missing some subtype names occasionally - names are collected recursively
- assignment validation using inferred hierarchy which is very likely to be incomplete with declared types - replaced the inferred property type with a matching declared type for assignment checks only

This does not fix `$container` being non-optional on grammar entry types and its supertypes.