### PR TITLE
Allow to use `AstNode` in validation

### DIFF
--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -132,6 +132,7 @@ export function isLinkingError(obj: unknown): obj is LinkingError {
  */
 export interface AstReflection {
     getAllTypes(): string[]
+    getAllSubTypes(type: string): string[]
     getReferenceType(refInfo: ReferenceInfo): string
     getTypeMetaData(type: string): TypeMetaData
     isInstance(node: unknown, type: string): boolean
@@ -145,6 +146,7 @@ export interface AstReflection {
 export abstract class AbstractAstReflection implements AstReflection {
 
     protected subtypes: Record<string, Record<string, boolean | undefined>> = {};
+    protected allSubtypes: Record<string, string[] | undefined> = {};
 
     abstract getAllTypes(): string[];
     abstract getReferenceType(refInfo: ReferenceInfo): string;
@@ -170,6 +172,23 @@ export abstract class AbstractAstReflection implements AstReflection {
             const result = this.computeIsSubtype(subtype, supertype);
             nested[supertype] = result;
             return result;
+        }
+    }
+
+    getAllSubTypes(type: string): string[] {
+        const existing = this.allSubtypes[type];
+        if (existing) {
+            return existing;
+        } else {
+            const allTypes = this.getAllTypes();
+            const types: string[] = [];
+            for (const possibleSubType of allTypes) {
+                if (this.isSubtype(possibleSubType, type)) {
+                    types.push(possibleSubType);
+                }
+            }
+            this.allSubtypes[type] = types;
+            return types;
         }
     }
 }

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -54,6 +54,8 @@ export type ValidationChecks<T> = {
     [K in keyof T]?: T[K] extends AstNode
         ? ValidationCheck<T[K]> | Array<ValidationCheck<T[K]>>
         : never
+} & {
+    AstNode?: ValidationCheck<AstNode>;
 }
 
 /**
@@ -99,15 +101,17 @@ export class ValidationRegistry {
     }
 
     protected doRegister(type: string, check: ValidationCheck): void {
-        for (const subtype of this.reflection.getAllTypes()) {
-            if (this.reflection.isSubtype(subtype, type)) {
-                this.validationChecks.add(subtype, check);
-            }
+        if (type === 'AstNode') {
+            this.validationChecks.add('AstNode', check);
+            return;
+        }
+        for (const subtype of this.reflection.getAllSubTypes(type)) {
+            this.validationChecks.add(subtype, check);
         }
     }
 
     getChecks(type: string): readonly ValidationCheck[] {
-        return this.validationChecks.get(type);
+        return this.validationChecks.get(type).concat(this.validationChecks.get('AstNode'));
     }
 
 }

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -4,9 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeAll, describe, expect, test } from 'vitest';
 import { Position, Range } from 'vscode-languageserver';
-import { AstNode, createServicesForGrammar } from '../../src';
+import { AstNode, createServicesForGrammar, ValidationChecks } from '../../src';
 import { validationHelper, ValidationResult } from '../../src/test';
 
 // Related to https://github.com/langium/langium/issues/571
@@ -31,7 +31,7 @@ describe('Parser error is thrown on resynced token with NaN position', () => {
 
     let validate: (input: string) => Promise<ValidationResult<AstNode>>;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const services = await createServicesForGrammar({
             grammar
         });
@@ -58,4 +58,43 @@ describe('Parser error is thrown on resynced token with NaN position', () => {
         expect(diagnostics).toHaveLength(1);
         expect(diagnostics[0].range).toStrictEqual(Range.create(0, 0, 0, 0));
     });
+});
+
+describe('Generic `AstNode` validation applies to all nodes', () => {
+
+    const grammar = `grammar GenericAstNode
+
+    entry Model:
+        (elements+=(A | B))*;
+
+    A: a=ID;
+    B: b=INT;
+
+    hidden terminal WS: /\\s+/;
+    terminal ID: /[_a-zA-Z][\\w_]*/;
+    terminal INT returns number: /[0-9]+/;
+    `;
+
+    let validate: (input: string) => Promise<ValidationResult<AstNode>>;
+
+    beforeAll(async () => {
+        const services = await createServicesForGrammar({
+            grammar
+        });
+        const validationChecks: ValidationChecks<object> = {
+            AstNode: (node, accept) => {
+                accept('error', 'TEST', { node });
+            }
+        };
+        services.validation.ValidationRegistry.register(validationChecks);
+        validate = validationHelper(services);
+    });
+
+    test('Diagnostics are shown on all elements', async () => {
+        const validationResult = await validate('a 42');
+        const diagnostics = validationResult.diagnostics;
+        // One for each `element`, once on the root model
+        expect(diagnostics).toHaveLength(3);
+    });
+
 });


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/983

Also improves a few minor other things in the validation system.