### PR TITLE
Improve completion behavior for cross references

### DIFF
--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -138,7 +138,7 @@ export class DefaultCompletionProvider implements CompletionProvider {
         if (!astNode) {
             const parserRule = getEntryRule(this.grammar)!;
             await this.completionForRule(context, parserRule, acceptor);
-            return CompletionList.create(items, true);
+            return CompletionList.create(this.deduplicateItems(items), true);
         }
 
         const contexts: CompletionContext[] = [context];

--- a/packages/langium/test/lsp/completion-provider.test.ts
+++ b/packages/langium/test/lsp/completion-provider.test.ts
@@ -77,7 +77,7 @@ describe('Langium completion provider', () => {
 
 describe('Completion within alternatives', () => {
 
-    it('Should show correct keywords in completion of entry rule', async () => {
+    test('Should show correct keywords in completion of entry rule', async () => {
 
         const grammar = `
         grammar g
@@ -106,7 +106,7 @@ describe('Completion within alternatives', () => {
         });
     });
 
-    it('Should show correct cross reference and keyword in completion', async () => {
+    test('Should show correct cross reference and keyword in completion', async () => {
 
         const grammar = `
         grammar g
@@ -125,6 +125,32 @@ describe('Completion within alternatives', () => {
             text,
             index: 0,
             expectedItems: ['A', 'self']
+        });
+    });
+
+    test('Should remove duplicated entries', async () => {
+        const grammar = `
+        grammar g
+        entry Model: (elements+=(Person | Greeting))*;
+        Person: 'person' name=ID;
+        // The following double 'person' assignment could lead to duplicated completion items
+        Greeting: 'hello' (person1=[Person:ID] 'x' | person2=[Person:ID] 'y');
+
+        terminal ID: /\\^?[_a-zA-Z][\\w_]*/;
+        hidden terminal WS: /\\s+/;
+        `;
+
+        const services = await createServicesForGrammar({ grammar });
+        const completion = expectCompletion(services);
+        const text = `
+        person A
+        hello <|>
+        `;
+
+        await completion({
+            text,
+            index: 0,
+            expectedItems: ['A']
         });
     });
 });


### PR DESCRIPTION
Fixes two minor issues:

* In some grammars, the completion might be slightly different if we use the following AST node (i.e. the AST node right at the cursor position). In most languages, this is the correct behavior. We now create two separate contexts if the node after the cursor and the one before are different and create completion for both.
* Sometimes, we evaluate the same keyword/cross reference multiple times over the course of the completion provider. Users would see the same proposals multiple times in their list. This change implements a deduplication algorithm, which removes duplicated entries.