### PR TITLE
Use `assert` for test utilities

### DIFF
--- a/examples/arithmetics/test/arithmetics-cli.test.ts
+++ b/examples/arithmetics/test/arithmetics-cli.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import path from 'path';
 import { exec, ExecException } from 'child_process';
 

--- a/examples/domainmodel/test/cross-refs.test.ts
+++ b/examples/domainmodel/test/cross-refs.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { AstNode, LangiumDocument, ReferenceDescription, EmptyFileSystem } from 'langium';
 import { parseDocument } from 'langium/test';
 import { createDomainModelServices } from '../src/language-server/domain-model-module';

--- a/examples/domainmodel/test/domainmodel-cli.test.ts
+++ b/examples/domainmodel/test/domainmodel-cli.test.ts
@@ -6,6 +6,7 @@
 
 import path from 'path';
 import fs from 'fs';
+import { afterEach, describe, expect, test } from 'vitest';
 import { exec, ExecException } from 'child_process';
 import { generateAction } from '../src/cli/generator';
 

--- a/examples/domainmodel/test/formatting.test.ts
+++ b/examples/domainmodel/test/formatting.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { EmptyFileSystem } from 'langium';
 import { expectFormatting } from 'langium/test';
 import { createDomainModelServices } from '../src/language-server/domain-model-module';

--- a/examples/domainmodel/test/nodelocator.test.ts
+++ b/examples/domainmodel/test/nodelocator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { AstNode, EmptyFileSystem } from 'langium';
 import { parseDocument } from 'langium/test';
 import { createDomainModelServices } from '../src/language-server/domain-model-module';

--- a/examples/domainmodel/test/refs-index.test.ts
+++ b/examples/domainmodel/test/refs-index.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { AstNode, EmptyFileSystem, getDocument, LangiumDocument, ReferenceDescription } from 'langium';
 import { parseDocument } from 'langium/lib/test';
 import { TextDocument } from 'vscode-languageserver-textdocument';

--- a/examples/requirements/test/generator.test.ts
+++ b/examples/requirements/test/generator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { extractRequirementModelWithTestModels } from '../src/cli/cli-util';
 import { generateSummaryFileHTMLContent } from '../src/cli/generator';
 import { createRequirementsAndTestsLangServices } from '../src/language-server/requirements-and-tests-lang-module';

--- a/examples/requirements/test/validator.test.ts
+++ b/examples/requirements/test/validator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { extractDocuments } from '../src/cli/cli-util';
 import { createRequirementsAndTestsLangServices } from '../src/language-server/requirements-and-tests-lang-module';
 import * as path from 'path';

--- a/examples/statemachine/test/generator.test.ts
+++ b/examples/statemachine/test/generator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { EmptyFileSystem, Generated, normalizeEOL, toString } from 'langium';
 import { parseHelper } from 'langium/test';
 import { generateCppContent } from '../src/cli/generator';

--- a/examples/statemachine/test/statemachine-cli.test.ts
+++ b/examples/statemachine/test/statemachine-cli.test.ts
@@ -6,6 +6,7 @@
 
 import path from 'path';
 import fs from 'fs';
+import { afterAll, describe, expect, test } from 'vitest';
 import { exec, ExecException } from 'child_process';
 
 describe('Test the statemachine CLI', () => {

--- a/packages/generator-langium/test/yeoman-generator.test.ts
+++ b/packages/generator-langium/test/yeoman-generator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { normalizeEOL } from 'langium';
 import path from 'path';
 import { createHelpers } from 'yeoman-test';

--- a/packages/langium-cli/test/generator/module-generator.test.ts
+++ b/packages/langium-cli/test/generator/module-generator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { generateModule } from '../../src/generator/module-generator';
 import { LangiumConfig, LangiumLanguageConfig, RelativePath } from '../../src/package';
 import { Grammar } from 'langium';

--- a/packages/langium-cli/test/generator/types-generator.test.ts
+++ b/packages/langium-cli/test/generator/types-generator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem, Grammar, normalizeEOL } from 'langium';
 import { parseHelper } from 'langium/test';
 import { generateTypesFile } from '../../src/generator/types-generator';

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -17,6 +17,7 @@ import { findNodeForProperty } from '../utils/grammar-util';
 import { SemanticTokensDecoder } from '../lsp/semantic-token-provider';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { BuildOptions } from '../workspace/document-builder';
+import assert from 'assert';
 
 export function parseHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string, buildOptions?: BuildOptions) => Promise<LangiumDocument<T>> {
     const metaData = services.LanguageMetaData;
@@ -34,20 +35,13 @@ export function parseHelper<T extends AstNode = AstNode>(services: LangiumServic
 export type ExpectFunction = (actual: unknown, expected: unknown, message?: string) => void;
 
 let expectedFunction: ExpectFunction = (actual, expected, message) => {
-    if (typeof expect === 'function') {
-        if (message && expect.length === 2) {
-            // With `jest-expect-message` or `vitest`
-            expect(actual, message).toEqual(expected);
-        } else {
-            expect(actual).toEqual(expected);
-        }
-    } else {
-        throw new Error('No expect function provided. Use the `expectFunction` function to supply a custom expect function or install `vitest` or `jest`.');
-    }
+    assert.deepStrictEqual(actual, expected, message);
 };
 
 /**
- * Overrides the assertion function used by tests. Tries to use Jest by default.
+ * Overrides the assertion function used by tests. Uses `assert.deepStrictEqual` by default
+ *
+ * @deprecated Since 1.2.0. Do not override the assertion functionality.
  */
 export function expectFunction(functions: ExpectFunction): void {
     expectedFunction = functions;

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -36,7 +36,7 @@ export type ExpectFunction = (actual: unknown, expected: unknown, message?: stri
 let expectedFunction: ExpectFunction = (actual, expected, message) => {
     if (typeof expect === 'function') {
         if (message && expect.length === 2) {
-            // With `jest-expect-message`
+            // With `jest-expect-message` or `vitest`
             expect(actual, message).toEqual(expected);
         } else {
             expect(actual).toEqual(expected);

--- a/packages/langium/test/dependency-injection.test.ts
+++ b/packages/langium/test/dependency-injection.test.ts
@@ -8,6 +8,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
+import { describe, expect, test } from 'vitest';
 import { inject, Module } from '../src/dependency-injection';
 
 describe('A dependency type', () => {

--- a/packages/langium/test/documentation/jsdoc.test.ts
+++ b/packages/langium/test/documentation/jsdoc.test.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import { Range } from 'vscode-languageserver';
+import { describe, expect, test } from 'vitest';
 import { JSDocLine, JSDocParagraph, JSDocTag, parseJSDoc } from '../../src';
 
 describe('JSDoc parsing', () => {

--- a/packages/langium/test/generator/generation-tracing.test.ts
+++ b/packages/langium/test/generator/generation-tracing.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { beforeAll, describe, expect, test } from 'vitest';
 import { toStringAndTrace, traceToNode } from '../../src/generator/generator-node';
 import type { SourceRegion, TraceRegion } from '../../src/generator/generator-tracing';
 import { joinTracedToNode, joinTracedToNodeIf } from '../../src/generator/node-joiner';

--- a/packages/langium/test/generator/node.test.ts
+++ b/packages/langium/test/generator/node.test.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import { EOL } from 'os';
+import { describe, expect, test } from 'vitest';
 import { CompositeGeneratorNode, IndentNode, NewLineNode, NL, NLEmpty, toString as process } from '../../src';
 
 describe('new lines', () => {

--- a/packages/langium/test/generator/template-node.test.ts
+++ b/packages/langium/test/generator/template-node.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { EOL, toString } from '../../src/generator/generator-node';
 import { joinToNode } from '../../src/generator/node-joiner';
 import { expandToNode as n } from '../../src/generator/template-node';

--- a/packages/langium/test/generator/template-string.test.ts
+++ b/packages/langium/test/generator/template-string.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { expect, test } from 'vitest';
 import { expandToString as s, normalizeEOL } from '../../src/generator/template-string';
 
 test('Should not throw when substituting null', () => {

--- a/packages/langium/test/grammar/ast-reflection-interpreter.test.ts
+++ b/packages/langium/test/grammar/ast-reflection-interpreter.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { interpretAstReflection } from '../../src';
 import { InterfaceType } from '../../src/grammar/type-system/type-collector/types';
 

--- a/packages/langium/test/grammar/formatting.test.ts
+++ b/packages/langium/test/grammar/formatting.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { expectFormatting } from '../../src/test';
 

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { beforeAll, describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem, findNameAssignment, getEntryRule, Grammar, stream } from '../../src';
 import { InferredType, isParserRule, isTerminalRule, ParserRule, TerminalRule } from '../../src/grammar/generated/ast';
 import { LangiumGrammarGrammar } from '../../src/grammar/generated/grammar';

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { AstNode, createLangiumGrammarServices, EmptyFileSystem, GrammarAST, Properties, streamAllContents, streamContents } from '../../src';
 import { Assignment, isAssignment, ParserRule, UnionType } from '../../src/grammar/generated/ast';

--- a/packages/langium/test/grammar/lsp/langium-grammar-semantic-token-provider.test.ts
+++ b/packages/langium/test/grammar/lsp/langium-grammar-semantic-token-provider.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { highlightHelper, expectSemanticToken } from '../../../src/test';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../../src';
 import { SemanticTokenTypes } from 'vscode-languageserver';

--- a/packages/langium/test/grammar/references/grammar-scope.test.ts
+++ b/packages/langium/test/grammar/references/grammar-scope.test.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import { Utils } from 'vscode-uri';
+import { beforeAll, describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem, Grammar } from '../../../src';
 import { CrossReference, InferredType, Interface } from '../../../src/grammar/generated/ast';
 import { clearDocuments, parseHelper } from '../../../src/test';

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, Grammar, EmptyFileSystem, expandToString, EOL } from '../../../src';
 import { mergeTypesAndInterfaces } from '../../../src/grammar/type-system';
 import { collectAst } from '../../../src/grammar/type-system/ast-collector';

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { createLangiumGrammarServices, EmptyFileSystem, GrammarAST, streamAllContents, streamContents } from '../../../src';
 import { Assignment, isAssignment } from '../../../src/grammar/generated/ast';

--- a/packages/langium/test/grammar/type-system/types-util.test.ts
+++ b/packages/langium/test/grammar/type-system/types-util.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { InterfaceType, isAstType } from '../../../src/grammar/type-system';
 
 describe('isAstType', () => {

--- a/packages/langium/test/lsp/completion-provider.test.ts
+++ b/packages/langium/test/lsp/completion-provider.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { createLangiumGrammarServices, createServicesForGrammar, EmptyFileSystem } from '../../src';
 import { expectCompletion } from '../../src/test';
 
@@ -77,7 +78,7 @@ describe('Langium completion provider', () => {
 
 describe('Completion within alternatives', () => {
 
-    it('Should show correct keywords in completion of entry rule', async () => {
+    test('Should show correct keywords in completion of entry rule', async () => {
 
         const grammar = `
         grammar g
@@ -106,7 +107,7 @@ describe('Completion within alternatives', () => {
         });
     });
 
-    it('Should show correct cross reference and keyword in completion', async () => {
+    test('Should show correct cross reference and keyword in completion', async () => {
 
         const grammar = `
         grammar g

--- a/packages/langium/test/lsp/document-symbol.test.ts
+++ b/packages/langium/test/lsp/document-symbol.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { Position, Range, SymbolKind } from 'vscode-languageserver';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { expectSymbols } from '../../src/test';

--- a/packages/langium/test/lsp/execute-command-handler.test.ts
+++ b/packages/langium/test/lsp/execute-command-handler.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createServicesForGrammar, AbstractExecuteCommandHandler, ExecuteCommandAcceptor } from '../../src';
 
 describe('AbstractExecuteCommandHandler', () => {

--- a/packages/langium/test/lsp/find-references.test.ts
+++ b/packages/langium/test/lsp/find-references.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { expectFindReferences } from '../../src/test';
 

--- a/packages/langium/test/lsp/folding-range.test.ts
+++ b/packages/langium/test/lsp/folding-range.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { expectFoldings } from '../../src/test';
 

--- a/packages/langium/test/lsp/goto-definition.test.ts
+++ b/packages/langium/test/lsp/goto-definition.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { expectGoToDefinition } from '../../src/test';
 

--- a/packages/langium/test/lsp/hover.test.ts
+++ b/packages/langium/test/lsp/hover.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { expectHover } from '../../src/test';
 

--- a/packages/langium/test/lsp/signatureHelpProvider.test.ts
+++ b/packages/langium/test/lsp/signatureHelpProvider.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { SignatureHelpOptions } from 'vscode-languageserver';
 import { mergeSignatureHelpOptions } from '../../src/lsp/signature-help-provider';
 

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { onTestFailed } from 'vitest';
+import { describe, expect, test, onTestFailed, beforeEach } from 'vitest';
 import { TokenType, TokenVocabulary } from 'chevrotain';
 import { AstNode, createServicesForGrammar, DefaultTokenBuilder, Grammar, GrammarAST, LangiumParser, TokenBuilderOptions } from '../../src';
 

--- a/packages/langium/test/parser/lexer.test.ts
+++ b/packages/langium/test/parser/lexer.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createServicesForGrammar, Lexer } from '../../src';
 
 describe('DefaultLexer', () => {

--- a/packages/langium/test/parser/token-builder.test.ts
+++ b/packages/langium/test/parser/token-builder.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { beforeAll, describe, expect, test } from 'vitest';
 import { TokenPattern, TokenType } from '@chevrotain/types';
 import { createLangiumGrammarServices, Grammar, EmptyFileSystem } from '../../src';
 import { parseHelper } from '../../src/test';

--- a/packages/langium/test/parser/value-converter.test.ts
+++ b/packages/langium/test/parser/value-converter.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, Grammar, EmptyFileSystem } from '../../src';
 import { CharacterRange, TerminalRule } from '../../src/grammar/generated/ast';
 import { parseHelper } from '../../src/test';

--- a/packages/langium/test/references/naming.test.ts
+++ b/packages/langium/test/references/naming.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { isNamed } from '../../src';
 
 describe('Naming Tests', () => {

--- a/packages/langium/test/service-registry.test.ts
+++ b/packages/langium/test/service-registry.test.ts
@@ -6,6 +6,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { describe, expect, test } from 'vitest';
 import { URI } from 'vscode-uri';
 import { DefaultServiceRegistry } from '../src/service-registry';
 import { LangiumServices } from '../src/services';

--- a/packages/langium/test/utils/ast-util.test.ts
+++ b/packages/langium/test/utils/ast-util.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem, streamAst } from '../../src';
 import { isParserRule } from '../../src/grammar/generated/ast';
 

--- a/packages/langium/test/utils/collections.test.ts
+++ b/packages/langium/test/utils/collections.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { MultiMap } from '../../src/utils/collections';
 
 describe('MultiMap', () => {

--- a/packages/langium/test/utils/cst-utils.test.ts
+++ b/packages/langium/test/utils/cst-utils.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem, Grammar } from '../../src';
 import { parseHelper } from '../../src/test';
 import * as cstUtil from '../../src/utils/cst-util';

--- a/packages/langium/test/utils/grammar-util.test.ts
+++ b/packages/langium/test/utils/grammar-util.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem, getAllReachableRules, Grammar } from '../../src';
 import { parseHelper } from '../../src/test';
 

--- a/packages/langium/test/utils/promise-util.test.ts
+++ b/packages/langium/test/utils/promise-util.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { Deferred, delayNextTick, MutexLock } from '../../src';
 
 describe('Mutex locking', () => {

--- a/packages/langium/test/utils/regex-util.test.ts
+++ b/packages/langium/test/utils/regex-util.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { getTerminalParts, isMultilineComment, partialMatches } from '../../src';
 
 describe('partial regex', () => {

--- a/packages/langium/test/utils/stream.test.ts
+++ b/packages/langium/test/utils/stream.test.ts
@@ -4,7 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { onTestFailed } from 'vitest';
+import { describe, expect, onTestFailed, test } from 'vitest';
 import * as s from '../../src/utils/stream';
 
 describe('stream', () => {

--- a/packages/langium/test/utils/uri-utils.test.ts
+++ b/packages/langium/test/utils/uri-utils.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { URI } from 'vscode-uri';
 import { relativeURI, equalURI } from '../../src/utils/uri-util';
 

--- a/packages/langium/test/validation/document-validator.test.ts
+++ b/packages/langium/test/validation/document-validator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { beforeAll, describe, expect, test } from 'vitest';
 import { Position, Range } from 'vscode-languageserver';
 import { AstNode, createServicesForGrammar, ValidationChecks } from '../../src';
 import { validationHelper, ValidationResult } from '../../src/test';

--- a/packages/langium/test/workspace/ast-node-locator.test.ts
+++ b/packages/langium/test/workspace/ast-node-locator.test.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { describe, expect, test } from 'vitest';
 import { Alternatives, Grammar, ParserRule } from '../../src/grammar/generated/ast';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 import { parseHelper } from '../../src/test';

--- a/packages/langium/test/workspace/configuration.test.ts
+++ b/packages/langium/test/workspace/configuration.test.ts
@@ -6,6 +6,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { beforeEach, describe, expect, test } from 'vitest';
 import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
 
 describe('ConfigurationProvider', () => {

--- a/packages/langium/tsconfig.json
+++ b/packages/langium/tsconfig.json
@@ -2,11 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
-    "types": [
-        "node",
-        "vitest/globals"
-    ]
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/langium/tsconfig.json
+++ b/packages/langium/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": [
+        "node",
+        "vitest/globals"
+    ]
   },
   "include": [
     "src/**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,8 +49,7 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     "types": [
-      "node",
-      "vitest/globals"
+      "node"
     ],                                        /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,6 @@ export default defineConfig({
         },
         deps: {
             interopDefault: true
-        },
-        globals: true
+        }
     }
 });

--- a/vitest.globals.ts
+++ b/vitest.globals.ts
@@ -1,9 +1,0 @@
-/******************************************************************************
- * Copyright 2023 TypeFox GmbH
- * This program and the accompanying materials are made available under the
- * terms of the MIT License, which is available in the project root.
- ******************************************************************************/
-
-// Static import statement of vitest globals
-// Ensures that TypeScript understands where globals such as `describe` and `test` come from
-import 'vitest/globals';


### PR DESCRIPTION
Effectively reverts the changes from https://github.com/langium/langium/pull/1001 by utilizing `assert` from the node.js runtime instead of trying to use `jest` or `vitest` `expect` functions.
