### PR TITLE
Add validation for cross-reference to union type

### DIFF
--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -743,9 +743,7 @@ export class LangiumGrammarValidator {
         if (ast.isType(reference.type.ref) && ast.isUnionType(reference.type.ref.type)) {
             const errors = checkTypeUnionContainsOnlyParseRules(reference.type.ref.type);
             if (errors.length > 0) {
-                errors.forEach(e => {
-                    accept('error', `Cross-reference on type union is only valid if all alternatives are AST nodes. \`${e}\` is not an AST node.`, {node: reference, property: 'type'});
-                });
+                accept('error', `Cross-reference on type union is only valid if all alternatives are AST nodes. ${errors.join(', ')} ${errors.length > 1 ? 'are' : 'is'} not ${errors.length > 1 ? '' : 'an '}AST node${errors.length > 1 ? 's':''}.`, { node: reference, property: 'type' });
             }
         }
     }

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -877,6 +877,6 @@ function checkTypeUnionContainsOnlyParseRules(type: ast.UnionType): string[] {
             }
         }
     });
-    return errors;
+    return Array.from(new Set(errors));
 }
 

--- a/packages/langium/src/grammar/validation/validator.ts
+++ b/packages/langium/src/grammar/validation/validator.ts
@@ -871,7 +871,7 @@ function checkTypeUnionContainsOnlyParseRules(type: ast.UnionType): string[] {
                     }
                 }
             } else if (type.stringType) {
-                errors.push(type.stringType);
+                errors.push(`"${type.stringType}"`);
             } else if (type.primitiveType) {
                 errors.push(type.primitiveType);
             }

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -726,7 +726,7 @@ describe('Cross-reference to type union is only valid if all alternatives are AS
         const reference = ((rule.definition as Assignment).terminal as Assignment).terminal as CrossReference;
         expectError(
             validationResult,
-            /Cross-reference on type union is only valid if all alternatives are AST nodes. `B` is not an AST node./,
+            /Cross-reference on type union is only valid if all alternatives are AST nodes. B is not an AST node./,
             {
                 node: reference,
                 property: 'type'
@@ -749,7 +749,27 @@ describe('Cross-reference to type union is only valid if all alternatives are AS
         const reference = ((rule.definition as Assignment).terminal as Assignment).terminal as CrossReference;
         expectError(
             validationResult,
-            /Cross-reference on type union is only valid if all alternatives are AST nodes. `C` is not an AST node./,
+            /Cross-reference on type union is only valid if all alternatives are AST nodes. C is not an AST node./,
+            {
+                node: reference,
+                property: 'type'
+            }
+        );
+    });
+
+    test('Should return validation error on union type containing several non-AST nodes', async () => {
+        const validationResult = await validate(`
+        type A = 'A';
+        type T = A | "foo"";
+        R: a=[T];
+
+        terminal ID returns string: /[a-z]+/;
+        `);
+        const rule = validationResult.document.parseResult.value.rules[0] as ParserRule;
+        const reference = ((rule.definition as Assignment).terminal as Assignment).terminal as CrossReference;
+        expectError(
+            validationResult,
+            /Cross-reference on type union is only valid if all alternatives are AST nodes. A, "foo" are not AST nodes./,
             {
                 node: reference,
                 property: 'type'

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { AstNode, createLangiumGrammarServices, EmptyFileSystem, GrammarAST, Properties, streamAllContents, streamContents } from '../../src';
-import { Assignment, isAssignment, ParserRule, UnionType } from '../../src/grammar/generated/ast';
+import { Assignment, CrossReference, isAssignment, ParserRule, UnionType } from '../../src/grammar/generated/ast';
 import { IssueCodes } from '../../src/grammar/validation/validator';
 import { clearDocuments, expectError, expectIssue, expectNoIssues, expectWarning, parseHelper, validationHelper, ValidationResult } from '../../src/test';
 
@@ -694,4 +694,66 @@ describe('Missing required properties are not arrays or booleans', () => {
         });
     });
 
+});
+
+describe('Cross-reference to type union is only valid if all alternatives are AST nodes.', () => {
+    afterEach(() => {
+        clearDocuments(services.grammar);
+    });
+
+    test('Should not return error on union type composed only of AST nodes', async () => {
+        const validationResult = await validate(`
+        A: 'A' name=ID;
+        B: 'B' name=ID;
+        type T = A | B;
+        R: a=[T];
+
+        terminal ID returns string: /[a-z]+/;
+        `);
+        expectNoIssues(validationResult);
+    });
+
+    test('Should return validation error on union type containing a primitive', async () => {
+        const validationResult = await validate(`
+        A: 'A' name=ID;
+        type B = 'B';
+        type T = A | B;
+        R: a=[T];
+
+        terminal ID returns string: /[a-z]+/;
+        `);
+        const rule = validationResult.document.parseResult.value.rules[1] as ParserRule;
+        const reference = ((rule.definition as Assignment).terminal as Assignment).terminal as CrossReference;
+        expectError(
+            validationResult,
+            /Cross-reference on type union is only valid if all alternatives are AST nodes. `B` is not an AST node./,
+            {
+                node: reference,
+                property: 'type'
+            }
+        );
+    });
+
+    test('Should return validation error on union type containing nested primitives', async () => {
+        const validationResult = await validate(`
+        A: 'A' name=ID;
+        B: 'B' name=ID;
+        type C = 'C';
+        type D = B | C;
+        type T = A | D;
+        R: a=[T];
+
+        terminal ID returns string: /[a-z]+/;
+        `);
+        const rule = validationResult.document.parseResult.value.rules[2] as ParserRule;
+        const reference = ((rule.definition as Assignment).terminal as Assignment).terminal as CrossReference;
+        expectError(
+            validationResult,
+            /Cross-reference on type union is only valid if all alternatives are AST nodes. `C` is not an AST node./,
+            {
+                node: reference,
+                property: 'type'
+            }
+        );
+    });
 });


### PR DESCRIPTION
Closes #966 

Adds validation for cross-reference to union type that are not composed only of AST nodes.

I'm pretty sure I am missing some test cases but couldn't think of other ways this validation would be triggered. If you think of some other cases please let me know and I will add tests for them.