### PR TITLE
Fixed invalid grammar validation error

### DIFF
--- a/packages/langium/src/grammar/internal-grammar-util.ts
+++ b/packages/langium/src/grammar/internal-grammar-util.ts
@@ -354,8 +354,10 @@ function resolveTransitiveImportsInternal(documents: LangiumDocuments, grammar: 
 export function extractAssignments(element: ast.AbstractElement): ast.Assignment[] {
     if (ast.isAssignment(element)) {
         return [element];
-    } if (ast.isAlternatives(element) || ast.isGroup(element) || ast.isUnorderedGroup(element)) {
+    } else if (ast.isAlternatives(element) || ast.isGroup(element) || ast.isUnorderedGroup(element)) {
         return element.elements.flatMap(e => extractAssignments(e));
+    } else if (ast.isRuleCall(element) && element.rule.ref) {
+        return extractAssignments(element.rule.ref.definition);
     }
     return [];
 }

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -695,3 +695,18 @@ describe('Missing required properties are not arrays or booleans', () => {
     });
 
 });
+
+describe('Missing required properties', () => {
+    test('No missing properties', async () => {
+        const validation = await validate(`
+        interface A {
+            a: string;
+        }
+        interface C extends A {}
+        A returns A: B | C;
+        B returns A: a='foo';
+        C returns A: {C} a='bar';
+        `);
+        expectNoIssues(validation);
+    });
+});


### PR DESCRIPTION
Closes #940 

Updated how assignments are collected to get rid of the following validation errors: 
```
interface A {
	b: string
}

A  returns A: B | C;     // <-- error: Property 'b' is missing in a rule 'A', but is required in type 'A'.
AA returns A: B;         // <-- error: Property 'b' is missing in a rule 'AA', but is required in type 'A'. even if C is not referenced.

B returns A: b='foo';

interface C extends A {};
C returns A: { C } b='bar';
```