### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Langium Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Build
+      shell: bash
+      run: |
+        npm ci
+        npm run build:clean
+    - name: Test
+      if: success() || failure()
+      shell: bash
+      run: |
+        npm run test
+    - name: Publish NPM Packages
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Update the following list when a new package is added
+      run: |
+        npm run publish:latest --workspace=langium
+        npm run publish:latest --workspace=langium-cli
+        npm run publish:latest --workspace=langium-sprotty
+        npm run publish:latest --workspace=generator-langium
+        npm run publish:latest --workspace=langium-arithmetics-dsl
+        npm run publish:latest --workspace=langium-domainmodel-dsl
+        npm run publish:latest --workspace=langium-statemachine-dsl
+    - name: Publish VSCode Extension
+      shell: bash
+      env:
+        VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+        OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+      run: |
+        npm install -g @vscode/vsce ovsx
+        cd packages/langium-vscode
+        PACKAGE_VERSION=`npm pkg get version --workspaces=false | tr -d \"`
+        vsce package
+        vsce publish -i langium-vscode-$PACKAGE_VERSION.vsix -p ${{ secrets.VSCE_TOKEN }}
+        ovsx publish langium-vscode-$PACKAGE_VERSION.vsix -p ${{ secrets.OVSX_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Build
       shell: bash
@@ -33,18 +33,15 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # Update the following list when a new package is added
       run: |
-        npm run publish:latest --workspace=langium
-        npm run publish:latest --workspace=langium-cli
-        npm run publish:latest --workspace=langium-sprotty
-        npm run publish:latest --workspace=generator-langium
-        npm run publish:latest --workspace=langium-arithmetics-dsl
-        npm run publish:latest --workspace=langium-domainmodel-dsl
-        npm run publish:latest --workspace=langium-statemachine-dsl
+        npm run publish:latest --provenance --workspace=langium
+        npm run publish:latest --provenance --workspace=langium-cli
+        npm run publish:latest --provenance --workspace=langium-sprotty
+        npm run publish:latest --provenance --workspace=generator-langium
+        npm run publish:latest --provenance --workspace=langium-arithmetics-dsl
+        npm run publish:latest --provenance --workspace=langium-domainmodel-dsl
+        npm run publish:latest --provenance --workspace=langium-statemachine-dsl
     - name: Publish VSCode Extension
       shell: bash
-      env:
-        VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
-        OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
       run: |
         npm install -g @vscode/vsce ovsx
         cd packages/langium-vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,43 +110,19 @@ const debugOptions = { execArgv: ['--nolazy', '--inspect-brk=6009'] };
 
 ## Release Process
 
-Currently the process of releasing a new version of Langium is done manually one package after another. It requires to carefully update versions and dependencies. Proposals for automation of parts of this process are welcome.
+The release process is mostly automated and requires running only a few commands.
+After commiting, pushing, tagging and releasing the changes, a GitHub Action will publish all artifacts (npm packages and vscode extensions).
 
- 1. Prepare the workspace
-    * Pull the latest changes
-    * `npm ci`
-    * `npm run build:clean`
-    * `npm run lint`
-    * `npm test`
- 2. `packages/langium`
-    * Update version in `package.json`
-    * `npm run publish:latest`
- 3. `packages/langium-cli`
-    * Update version in `package.json`
-    * Update dependency to `langium` with `~` as version prefix (include bugfix versions)
-    * `npm run publish:latest`
- 4. `packages/langium-sprotty`
-    * Update version in `package.json`
-    * Update dependency to `langium` with `~` as version prefix
-    * `npm run publish:latest`
- 5. `packages/generator-langium`
-    * Update version in `package.json`
-    * Update dependency to `langium` and dev-dependency to `langium-cli` in `langium-template/package.json` with `^` as version prefix (include minor and bugfix versions)
-    * `npm run publish:latest`
- 6. `packages/langium-vscode`
-    * Update version in `package.json`
-    * Update dependency to `langium`
-    * `npm install -g @vscode/vsce ovsx`
-    * `vsce package`
-    * `vsce publish -i langium-vscode-<version>.vsix -p <token>`
-    * `ovsx publish langium-vscode-<version>.vsix -p <token>`
- 7. `examples/*`
-    * Update dependency to `langium` and dev-dependency to `langium-cli`
-    * `npm run publish:latest`
- 8. `npm install` again in the repository root to update `package-lock.json`
- 9. Commit, tag and push your changes
- 10. Create a GitHub release from the new tag
- 11. Close the corresponding GitHub milestone
+1. Pull the latest changes
+2. Uplift the package versions
+    * Run `npm version major|minor|patch --no-git-tag-version --workspaces`
+3. Update the dependency versions
+    * Run `npm run version:dependencies`
+4. Update the generated files
+    * Run `npm run langium:generate`
+4. Commit, tag and push your changes
+5. Create a GitHub release from the new tag (this will automatically publish all artifacts)
+6. Close the corresponding GitHub milestone
 
 In order to publish `next` versions from the current state of the `main` branch, use `npm run publish:next`, and don't update the `version` numbers manually as this is done by the npm script.
 The changes must not be committed to the repository after publishing a `next` version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,10 @@ After commiting, pushing, tagging and releasing the changes, a GitHub Action wil
     * Run `npm run version:dependencies`
 4. Update the generated files
     * Run `npm run langium:generate`
-4. Commit, tag and push your changes
-5. Create a GitHub release from the new tag (this will automatically publish all artifacts)
-6. Close the corresponding GitHub milestone
+5. Create a PR with your updated changes, get a review and merge it
+6. Create a version tag on the latest commit on `main` and push it
+7. Create a GitHub release from the new tag (this will automatically publish all artifacts)
+8. Close the corresponding GitHub milestone
 
 In order to publish `next` versions from the current state of the `main` branch, use `npm run publish:next`, and don't update the `version` numbers manually as this is done by the npm script.
 The changes must not be committed to the repository after publishing a `next` version.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest",
     "test-ui": "vitest --ui",
     "coverage": "vitest run --coverage",
+    "version:dependencies": "node ./scripts/update-version.js && npm install",
     "langium:generate": "npm run langium:generate --workspace=langium --workspace=examples/domainmodel --workspace=examples/arithmetics --workspace=examples/statemachine --workspace=examples/requirements",
     "dev-build": "npm run dev-clean && npm install && npm link ./packages/langium && npm link ./packages/langium-cli && npm link ./packages/generator-langium",
     "dev-clean": "shx rm -rf packages/**/node_modules && npm uninstall -g langium-workspaces langium-cli generator-langium langium && npm unlink langium-workspaces langium-cli generator-langium langium"

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,33 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+async function runUpdate() {
+    const langiumPath = getPath('langium', true);
+    const langiumPackage = await fs.readJson(langiumPath);
+    const version = langiumPackage.version;
+    await Promise.all([
+        replaceAll('langium-cli', true, version),
+        replaceAll('langium-sprotty', true, version),
+        replaceAll('langium-vscode', true, version),
+        replaceAll('generator-langium/langium-template-core', true, version, true),
+        replaceAll('arithmetics', false, version),
+        replaceAll('domainmodel', false, version),
+        replaceAll('requirements', false, version),
+        replaceAll('statemachine', false, version),
+    ]);
+}
+
+async function replaceAll(project, package, version, dot) {
+    const path = getPath(project, package, dot);
+    let content = await fs.readFile(path, 'utf-8');
+    content = content
+        .replace(/(?<="langium": "~)\d+\.\d+\.\d+/g, version)
+        .replace(/(?<="langium-cli": "~)\d+\.\d+\.\d+/g, version);
+    await fs.writeFile(path, content);
+}
+
+function getPath(project, package, dot) {
+    return path.join(package ? 'packages' : 'examples', project, (dot ? '.' : '') + 'package.json');
+}
+
+runUpdate();

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -6,6 +6,7 @@ async function runUpdate() {
     const langiumPackage = await fs.readJson(langiumPath);
     const version = langiumPackage.version;
     await Promise.all([
+        replaceAll('langium', true, version),
         replaceAll('langium-cli', true, version),
         replaceAll('langium-sprotty', true, version),
         replaceAll('langium-vscode', true, version),
@@ -21,8 +22,8 @@ async function replaceAll(project, package, version, dot) {
     const path = getPath(project, package, dot);
     let content = await fs.readFile(path, 'utf-8');
     content = content
-        .replace(/(?<="langium": "~)\d+\.\d+\.\d+/g, version)
-        .replace(/(?<="langium-cli": "~)\d+\.\d+\.\d+/g, version);
+        .replace(/(?<="langium": "[~\^]?)\d+\.\d+\.\d+/g, version)
+        .replace(/(?<="langium-cli": "[~\^]?)\d+\.\d+\.\d+/g, version);
     await fs.writeFile(path, content);
 }
 


### PR DESCRIPTION
Simplifies and mostly automates the release process:

1. Updating tags only requires two commands to run now.
2. Publishing will be performed from within GitHub actions whenever a new release is created.

Since the `npm version` script does not automatically update dependency versions between the packages, we need to update them via a script. This is what `version:dependencies` does.