### PR TITLE
Add publishing permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 name: Publish
 
+permissions:
+  contents: read
+  id-token: write
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
This should allow us to publish from GitHub Actions with `--provenance`.