### PR TITLE
Make parser rule reachable when used in crossref

### DIFF
--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -70,11 +70,14 @@ export function getAllReachableRules(grammar: ast.Grammar, allTerminals: boolean
 function ruleDfs(rule: ast.AbstractRule, visitedSet: Set<string>, allTerminals: boolean): void {
     visitedSet.add(rule.name);
     streamAllContents(rule).forEach(node => {
+        let refRule: ast.AbstractRule | undefined;
         if (ast.isRuleCall(node) || (allTerminals && ast.isTerminalRuleCall(node))) {
-            const refRule = node.rule.ref;
-            if (refRule && !visitedSet.has(refRule.name)) {
-                ruleDfs(refRule, visitedSet, allTerminals);
-            }
+            refRule = node.rule.ref;
+        } else if (ast.isCrossReference(node) && ast.isParserRule(node.type.ref)) {
+            refRule = node.type.ref;
+        }
+        if (refRule && !visitedSet.has(refRule.name)) {
+            ruleDfs(refRule, visitedSet, allTerminals);
         }
     });
 }

--- a/packages/langium/test/grammar/langium-grammar-validator.test.ts
+++ b/packages/langium/test/grammar/langium-grammar-validator.test.ts
@@ -369,8 +369,11 @@ describe('Unused rules validation', () => {
         const text = `
         grammar TestUnusedParserRule
 
-        entry Used: name=ID;
+        entry Entry: rule=Used ref=[Referenced:ID];
+        Used: name=ID;
         Unused: name=ID;
+        Referenced: name=ID;
+
         hidden terminal WS: /\\s+/;
         terminal ID: /[_a-zA-Z][\\w_]*/;
         `;

--- a/packages/langium/test/utils/grammar-util.test.ts
+++ b/packages/langium/test/utils/grammar-util.test.ts
@@ -36,4 +36,26 @@ describe('Grammar Utils', () => {
         expect(reachableRules).toContain('Ws');
     });
 
+    test('Parser rule should be reachable when only used in cross reference', async () => {
+        // the actual bug was that the 'Hello' rule marked as unused - so
+        // a 'Hint: This rule is declared but never referenced.' was thrown
+        // arrange
+        const input = `
+            grammar HelloWorld
+
+            entry Model: foreignHello=[Hello:NAME];
+
+            Hello: greeting='Hello' name=NAME '!';
+
+            terminal NAME: /[A-Z][a-z]*/;
+        `;
+        const output = await parse(input);
+
+        // act
+        const reachableRules = [...getAllReachableRules(output.parseResult.value, false)].map(r => r.name);
+
+        // assert
+        expect(reachableRules).toContain('Hello');
+    });
+
 });


### PR DESCRIPTION
This removes redundant hint "This rule is declared but never referenced" during Langium validation for Parser Rules that are only referenced from cross reference in the grammar.

An example of cases when this hint is shown incorrectly: [ImportableElement presents a type union, and is only referenced by crossref](https://github.com/Crystal-VPL/crystal-core-lang/blob/f9f93963e20f4834c002ad015dc5fedd3b548071/src/language-server/behavior/behavior.langium).

Please, let me know, if I should raise a corresponding bug ticket.