### PR TITLE
Fix container types calculation

### DIFF
--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -29,7 +29,7 @@ Multiplication infers Expression:
     Exponentiation ({infer BinaryExpression.left=current} operator=('*' | '/') right=Exponentiation)*;
 
 Exponentiation infers Expression:
-    PrimaryExpression ({infer BinaryExpression.left=current} operator='^' right=Modulo)*;
+    Modulo ({infer BinaryExpression.left=current} operator='^' right=Modulo)*;
 
 Modulo infers Expression:
     PrimaryExpression ({infer BinaryExpression.left=current} operator='%' right=PrimaryExpression)*;

--- a/examples/arithmetics/src/language-server/arithmetics.langium
+++ b/examples/arithmetics/src/language-server/arithmetics.langium
@@ -34,7 +34,6 @@ Exponentiation infers Expression:
 Modulo infers Expression:
     PrimaryExpression ({infer BinaryExpression.left=current} operator='%' right=PrimaryExpression)*;
 
-
 PrimaryExpression infers Expression:
     '(' Expression ')' |
     {infer NumberLiteral} value=NUMBER |

--- a/examples/arithmetics/src/language-server/generated/ast.ts
+++ b/examples/arithmetics/src/language-server/generated/ast.ts
@@ -46,7 +46,7 @@ export function isBinaryExpression(item: unknown): item is BinaryExpression {
 }
 
 export interface DeclaredParameter extends AstNode {
-    readonly $container: Definition | Module;
+    readonly $container: Definition;
     readonly $type: 'DeclaredParameter';
     name: string
 }
@@ -58,7 +58,7 @@ export function isDeclaredParameter(item: unknown): item is DeclaredParameter {
 }
 
 export interface Definition extends AstNode {
-    readonly $container: Definition | Module;
+    readonly $container: Module;
     readonly $type: 'Definition';
     args: Array<DeclaredParameter>
     expr: Expression
@@ -72,7 +72,7 @@ export function isDefinition(item: unknown): item is Definition {
 }
 
 export interface Evaluation extends AstNode {
-    readonly $container: Definition | Module;
+    readonly $container: Module;
     readonly $type: 'Evaluation';
     expression: Expression
 }

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -398,7 +398,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
     },
     {
       "$type": "ParserRule",
-      "name": "Potentiation",
+      "name": "Exponentiation",
       "inferredType": {
         "$type": "InferredType",
         "name": "Expression"
@@ -409,7 +409,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           },

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -409,7 +409,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@10"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
     },
     "examples/arithmetics": {
       "name": "langium-arithmetics-dsl",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "~4.1.2",

--- a/packages/langium/src/grammar/generated/ast.ts
+++ b/packages/langium/src/grammar/generated/ast.ts
@@ -52,7 +52,6 @@ export function isTypeDefinition(item: unknown): item is TypeDefinition {
 }
 
 export interface AbstractElement extends AstNode {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'AbstractElement' | 'Action' | 'Alternatives' | 'Assignment' | 'CharacterRange' | 'CrossReference' | 'Group' | 'Keyword' | 'NegatedToken' | 'RegexToken' | 'RuleCall' | 'TerminalAlternatives' | 'TerminalGroup' | 'TerminalRuleCall' | 'UnorderedGroup' | 'UntilToken' | 'Wildcard';
     cardinality?: '*' | '+' | '?'
     lookahead?: '?!' | '?='
@@ -146,7 +145,7 @@ export function isInferredType(item: unknown): item is InferredType {
 }
 
 export interface Interface extends AstNode {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Grammar;
     readonly $type: 'Interface';
     attributes: Array<TypeAttribute>
     name: string
@@ -222,7 +221,7 @@ export function isParameterReference(item: unknown): item is ParameterReference 
 }
 
 export interface ParserRule extends AstNode {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Grammar;
     readonly $type: 'ParserRule';
     dataType?: PrimitiveType
     definesHiddenTokens: boolean
@@ -282,7 +281,7 @@ export function isSimpleType(item: unknown): item is SimpleType {
 }
 
 export interface TerminalRule extends AstNode {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Grammar;
     readonly $type: 'TerminalRule';
     definition: AbstractElement
     fragment: boolean
@@ -298,7 +297,7 @@ export function isTerminalRule(item: unknown): item is TerminalRule {
 }
 
 export interface Type extends AstNode {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: Grammar;
     readonly $type: 'Type';
     name: string
     type: TypeDefinition
@@ -337,7 +336,6 @@ export function isUnionType(item: unknown): item is UnionType {
 }
 
 export interface Action extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Action';
     feature?: FeatureName
     inferredType?: InferredType
@@ -352,7 +350,6 @@ export function isAction(item: unknown): item is Action {
 }
 
 export interface Alternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Alternatives';
     elements: Array<AbstractElement>
 }
@@ -364,7 +361,6 @@ export function isAlternatives(item: unknown): item is Alternatives {
 }
 
 export interface Assignment extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Assignment';
     feature: FeatureName
     operator: '+=' | '=' | '?='
@@ -378,7 +374,6 @@ export function isAssignment(item: unknown): item is Assignment {
 }
 
 export interface CharacterRange extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'CharacterRange';
     left: Keyword
     right?: Keyword
@@ -391,7 +386,6 @@ export function isCharacterRange(item: unknown): item is CharacterRange {
 }
 
 export interface CrossReference extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'CrossReference';
     deprecatedSyntax: boolean
     terminal?: AbstractElement
@@ -405,7 +399,6 @@ export function isCrossReference(item: unknown): item is CrossReference {
 }
 
 export interface Group extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Group';
     elements: Array<AbstractElement>
     guardCondition?: Condition
@@ -418,7 +411,7 @@ export function isGroup(item: unknown): item is Group {
 }
 
 export interface Keyword extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
+    readonly $container: CharacterRange;
     readonly $type: 'Keyword';
     value: string
 }
@@ -430,7 +423,6 @@ export function isKeyword(item: unknown): item is Keyword {
 }
 
 export interface NegatedToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'NegatedToken';
     terminal: AbstractElement
 }
@@ -442,7 +434,6 @@ export function isNegatedToken(item: unknown): item is NegatedToken {
 }
 
 export interface RegexToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'RegexToken';
     regex: string
 }
@@ -454,7 +445,6 @@ export function isRegexToken(item: unknown): item is RegexToken {
 }
 
 export interface RuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'RuleCall';
     arguments: Array<NamedArgument>
     rule: Reference<AbstractRule>
@@ -467,7 +457,6 @@ export function isRuleCall(item: unknown): item is RuleCall {
 }
 
 export interface TerminalAlternatives extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalAlternatives';
     elements: Array<AbstractElement>
 }
@@ -479,7 +468,6 @@ export function isTerminalAlternatives(item: unknown): item is TerminalAlternati
 }
 
 export interface TerminalGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalGroup';
     elements: Array<AbstractElement>
 }
@@ -491,7 +479,6 @@ export function isTerminalGroup(item: unknown): item is TerminalGroup {
 }
 
 export interface TerminalRuleCall extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'TerminalRuleCall';
     rule: Reference<TerminalRule>
 }
@@ -503,7 +490,6 @@ export function isTerminalRuleCall(item: unknown): item is TerminalRuleCall {
 }
 
 export interface UnorderedGroup extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'UnorderedGroup';
     elements: Array<AbstractElement>
 }
@@ -515,7 +501,6 @@ export function isUnorderedGroup(item: unknown): item is UnorderedGroup {
 }
 
 export interface UntilToken extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'UntilToken';
     terminal: AbstractElement
 }
@@ -527,7 +512,6 @@ export function isUntilToken(item: unknown): item is UntilToken {
 }
 
 export interface Wildcard extends AbstractElement {
-    readonly $container: Alternatives | Assignment | CharacterRange | CrossReference | Grammar | Group | NegatedToken | ParserRule | TerminalAlternatives | TerminalGroup | TerminalRule | UnorderedGroup | UntilToken;
     readonly $type: 'Wildcard';
 }
 

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -105,7 +105,6 @@ export class UnionType {
     type: PropertyType;
     superTypes = new Set<TypeOption>();
     subTypes = new Set<TypeOption>();
-    containerTypes = new Set<TypeOption>();
     typeNames = new Set<string>();
     declared: boolean;
     dataType?: string;

--- a/packages/langium/src/grammar/type-system/types-util.ts
+++ b/packages/langium/src/grammar/type-system/types-util.ts
@@ -202,6 +202,22 @@ export function findReferenceTypes(type: PropertyType): string[] {
     return [];
 }
 
+export function findAstTypes(type: PropertyType): string[] {
+    if (isPropertyUnion(type)) {
+        return type.types.flatMap(e => findAstTypes(e));
+    } else if (isValueType(type)) {
+        const value = type.value;
+        if ('type' in value) {
+            return findAstTypes(value.type);
+        } else {
+            return [value.name];
+        }
+    } else if (isArrayType(type)) {
+        return findAstTypes(type.elementType);
+    }
+    return [];
+}
+
 export function isAstType(type: PropertyType): boolean {
     if (isPropertyUnion(type)) {
         return type.types.every(isAstType);


### PR DESCRIPTION
Closes #150.
* drops union types from the calculation of container types
* drops sharing of container types over connected components: now the container types are lifted only lifted to the parents
* if one of the children has no container types, the parent also loses container types

Examples:
```
interface A extends AstNode { $container: E | F | G; strA: string }
interface B extends AstNode { $container: E | F | H; strB: string }
interface C extends A, B { $container: E; strC: string }
interface D extends A, B { $container: F; strC: string }
interface E extends AstNode{ c: C }
interface F extends AstNode{ d: D }
interface G extends AstNode{ a: A }
interface H extends AstNode{ b: B }
```

`X` has no container types -- `A` and `B`, too
```
interface A extends AstNode { strA: string }
interface B extends AstNode { strB: string }
interface C extends A, B { $container: E; strC: string }
interface D extends A, B { $container: F; strC: string }
interface X extends A, B { strC: string }
interface E extends AstNode{ c: C }
interface F extends AstNode{ d: D }
interface G extends AstNode{ a: A }
interface H extends AstNode{ b: B }
```