### PR TITLE
Update document url in 'Cycle detected' error message

### DIFF
--- a/packages/langium/src/dependency-injection.ts
+++ b/packages/langium/src/dependency-injection.ts
@@ -92,7 +92,7 @@ function _resolve<I, T>(obj: any, prop: string | symbol | number, module: Module
             throw new Error('Construction failure. Please make sure that your dependencies are constructable.', {cause: obj[prop]});
         }
         if (obj[prop] === __requested__) {
-            throw new Error('Cycle detected. Please make "' + String(prop) + '" lazy. See https://langium.org/docs/di/cyclic-dependencies');
+            throw new Error('Cycle detected. Please make "' + String(prop) + '" lazy. See https://langium.org/docs/configuration-services/#resolving-cyclic-dependencies');
         }
         return obj[prop];
     } else if (prop in module) {

--- a/packages/langium/test/dependency-injection.test.ts
+++ b/packages/langium/test/dependency-injection.test.ts
@@ -234,7 +234,7 @@ describe('The inject function', () => {
         }
         expect(() =>
             inject({ a: (api: API) => new A(api), b: (api: API) => new B(api) }).a
-        ).toThrowError('Cycle detected. Please make "a" lazy. See https://langium.org/docs/di/cyclic-dependencies');
+        ).toThrowError('Cycle detected. Please make "a" lazy. See https://langium.org/docs/configuration-services/#resolving-cyclic-dependencies');
     });
 
     test('should throw when cyclic dependency is accessed during factory function call', () => {
@@ -243,7 +243,7 @@ describe('The inject function', () => {
         const createB = ({ a }: API) => ({ b: a.a });
         expect(() =>
             inject({ a: createA, b: createB }).a
-        ).toThrowError('Cycle detected. Please make "a" lazy. See https://langium.org/docs/di/cyclic-dependencies');
+        ).toThrowError('Cycle detected. Please make "a" lazy. See https://langium.org/docs/configuration-services/#resolving-cyclic-dependencies');
     });
 
     test('should merge groups', () => {


### PR DESCRIPTION
This updates the cyclic dependency detected URL to the recently created (see https://github.com/langium/langium-website/pull/149) section on the Langium documentation page.

See original issue: https://github.com/langium/langium-website/issues/39