### PR TITLE
Add support for regex flags

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 *.js
+*.monarch.ts

--- a/examples/arithmetics/src/language-server/generated/grammar.ts
+++ b/examples/arithmetics/src/language-server/generated/grammar.ts
@@ -661,7 +661,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\s+"
+        "regex": "/\\\\s+/"
       },
       "fragment": false
     },
@@ -670,7 +670,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "[_a-zA-Z][\\\\w_]*"
+        "regex": "/[_a-zA-Z][\\\\w_]*/"
       },
       "fragment": false,
       "hidden": false
@@ -684,7 +684,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "[0-9]+(\\\\.[0-9]*)?"
+        "regex": "/[0-9]+(\\\\.[0-9]*)?/"
       },
       "fragment": false,
       "hidden": false
@@ -695,7 +695,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
       },
       "fragment": false
     },
@@ -705,7 +705,7 @@ export const ArithmeticsGrammar = (): Grammar => loadedArithmeticsGrammar ?? (lo
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\/[^\\\\n\\\\r]*"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
       },
       "fragment": false
     }

--- a/examples/arithmetics/syntaxes/arithmetics.monarch.ts
+++ b/examples/arithmetics/syntaxes/arithmetics.monarch.ts
@@ -6,7 +6,7 @@ export default {
     operators: [
         '%','*','+',',','-','/',':',';','^'
     ],
-    symbols:  /%|\(|\)|\*|\+|,|-|/|:|;|\^/,
+    symbols:  /%|\(|\)|\*|\+|,|-|\/|:|;|\^/,
 
     tokenizer: {
         initial: [

--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -18,13 +18,13 @@
       "patterns": [
         {
           "name": "comment.block.arithmetics",
-          "begin": "/\\*",
+          "begin": "\\/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.arithmetics"
             }
           },
-          "end": "\\*/",
+          "end": "\\*\\/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.arithmetics"
@@ -32,7 +32,7 @@
           }
         },
         {
-          "begin": "//",
+          "begin": "\\/\\/",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.arithmetics"

--- a/examples/domainmodel/src/language-server/generated/grammar.ts
+++ b/examples/domainmodel/src/language-server/generated/grammar.ts
@@ -363,7 +363,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\s+"
+        "regex": "/\\\\s+/"
       },
       "fragment": false
     },
@@ -372,7 +372,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "[_a-zA-Z][\\\\w_]*"
+        "regex": "/[_a-zA-Z][\\\\w_]*/"
       },
       "fragment": false,
       "hidden": false
@@ -383,7 +383,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
       },
       "fragment": false
     },
@@ -393,7 +393,7 @@ export const DomainModelGrammar = (): Grammar => loadedDomainModelGrammar ?? (lo
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\/[^\\\\n\\\\r]*"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
       },
       "fragment": false
     }

--- a/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
+++ b/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
@@ -18,13 +18,13 @@
       "patterns": [
         {
           "name": "comment.block.domain-model",
-          "begin": "/\\*",
+          "begin": "\\/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.domain-model"
             }
           },
-          "end": "\\*/",
+          "end": "\\*\\/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.domain-model"
@@ -32,7 +32,7 @@
           }
         },
         {
-          "begin": "//",
+          "begin": "\\/\\/",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.domain-model"

--- a/examples/requirements/src/language-server/generated/grammar.ts
+++ b/examples/requirements/src/language-server/generated/grammar.ts
@@ -246,7 +246,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\s+"
+        "regex": "/\\\\s+/"
       },
       "fragment": false
     },
@@ -255,7 +255,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "[_a-zA-Z][\\\\w_]*"
+        "regex": "/[_a-zA-Z][\\\\w_]*/"
       },
       "fragment": false,
       "hidden": false
@@ -269,7 +269,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "[0-9]+"
+        "regex": "/[0-9]+/"
       },
       "fragment": false,
       "hidden": false
@@ -279,7 +279,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'"
+        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/"
       },
       "fragment": false,
       "hidden": false
@@ -290,7 +290,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
       },
       "fragment": false
     },
@@ -300,7 +300,7 @@ export const RequirementsGrammar = (): Grammar => loadedRequirementsGrammar ?? (
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\/[^\\\\n\\\\r]*"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
       },
       "fragment": false
     }
@@ -558,7 +558,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\s+"
+        "regex": "/\\\\s+/"
       },
       "fragment": false
     },
@@ -567,7 +567,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "[_a-zA-Z][\\\\w_]*"
+        "regex": "/[_a-zA-Z][\\\\w_]*/"
       },
       "fragment": false,
       "hidden": false
@@ -581,7 +581,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "[0-9]+"
+        "regex": "/[0-9]+/"
       },
       "fragment": false,
       "hidden": false
@@ -591,7 +591,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'"
+        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/"
       },
       "fragment": false,
       "hidden": false
@@ -602,7 +602,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
       },
       "fragment": false
     },
@@ -612,7 +612,7 @@ export const TestsGrammar = (): Grammar => loadedTestsGrammar ?? (loadedTestsGra
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\/[^\\\\n\\\\r]*"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
       },
       "fragment": false
     },

--- a/examples/requirements/syntaxes/requirements.tmLanguage.json
+++ b/examples/requirements/syntaxes/requirements.tmLanguage.json
@@ -38,13 +38,13 @@
       "patterns": [
         {
           "name": "comment.block.requirements-lang",
-          "begin": "/\\*",
+          "begin": "\\/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.requirements-lang"
             }
           },
-          "end": "\\*/",
+          "end": "\\*\\/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.requirements-lang"
@@ -52,7 +52,7 @@
           }
         },
         {
-          "begin": "//",
+          "begin": "\\/\\/",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.requirements-lang"

--- a/examples/requirements/syntaxes/tests.tmLanguage.json
+++ b/examples/requirements/syntaxes/tests.tmLanguage.json
@@ -38,13 +38,13 @@
       "patterns": [
         {
           "name": "comment.block.tests-lang",
-          "begin": "/\\*",
+          "begin": "\\/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.tests-lang"
             }
           },
-          "end": "\\*/",
+          "end": "\\*\\/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.tests-lang"
@@ -52,7 +52,7 @@
           }
         },
         {
-          "begin": "//",
+          "begin": "\\/\\/",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.tests-lang"

--- a/examples/statemachine/src/language-server/generated/grammar.ts
+++ b/examples/statemachine/src/language-server/generated/grammar.ts
@@ -290,7 +290,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\s+"
+        "regex": "/\\\\s+/"
       },
       "fragment": false
     },
@@ -299,7 +299,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "[_a-zA-Z][\\\\w_]*"
+        "regex": "/[_a-zA-Z][\\\\w_]*/"
       },
       "fragment": false,
       "hidden": false
@@ -310,7 +310,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
       },
       "fragment": false
     },
@@ -320,7 +320,7 @@ export const StatemachineGrammar = (): Grammar => loadedStatemachineGrammar ?? (
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\/[^\\\\n\\\\r]*"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
       },
       "fragment": false
     }

--- a/examples/statemachine/syntaxes/statemachine.tmLanguage.json
+++ b/examples/statemachine/syntaxes/statemachine.tmLanguage.json
@@ -18,13 +18,13 @@
       "patterns": [
         {
           "name": "comment.block.statemachine",
-          "begin": "/\\*",
+          "begin": "\\/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.statemachine"
             }
           },
-          "end": "\\*/",
+          "end": "\\*\\/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.statemachine"
@@ -32,7 +32,7 @@
           }
         },
         {
-          "begin": "//",
+          "begin": "\\/\\/",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.statemachine"

--- a/packages/langium-cli/src/generator/highlighting/prism-generator.ts
+++ b/packages/langium-cli/src/generator/highlighting/prism-generator.ts
@@ -27,19 +27,19 @@ export function generatePrismHighlighting(grammar: Grammar, config: LangiumLangu
     const commentTerminals = terminals.filter(isCommentTerminal);
     if (commentTerminals.length === 1) {
         highlighter.comment = {
-            pattern: `/${terminalRegex(commentTerminals[0])}/`,
+            pattern: terminalRegex(commentTerminals[0]).toString(),
             greedy: true
         };
     } else if (commentTerminals.length > 0) {
         highlighter.comment = commentTerminals.map(e => ({
-            pattern: `/${terminalRegex(e)}/`,
+            pattern: terminalRegex(e).toString(),
             greedy: true
         }));
     }
     const stringTerminal = terminals.find(e => e.name.toLowerCase() === 'string');
     if (stringTerminal) {
         highlighter.string = {
-            pattern: `/${terminalRegex(stringTerminal)}/`,
+            pattern: terminalRegex(stringTerminal).toString(),
             greedy: true
         };
     }

--- a/packages/langium-vscode/data/langium.tmLanguage.json
+++ b/packages/langium-vscode/data/langium.tmLanguage.json
@@ -79,173 +79,212 @@
             "match": "\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\\{[0-9A-Fa-f]+\\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
         },
         "regex": {
-            "patterns": [
-                {
-                    "name": "string.regex.langium",
-                    "begin": "/(?![/*])(?=(?:[^/\\\\\\[]|\\\\.|\\[([^\\]\\\\]|\\\\.)+\\])+/(?![/*]))",
-                    "beginCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.string.begin.langium"
-                        }
-                    },
-                    "end": "/",
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.string.end.langium"
-                        },
-                        "2": {
-                            "name": "keyword.other.langium"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "#regexp"
-                        }
-                    ]
-                }
-            ]
-        },
-        "regexp": {
-            "patterns": [
-                {
-                    "name": "keyword.control.anchor.regexp",
-                    "match": "\\\\[bB]|\\^|\\$"
-                },
-                {
-                    "name": "keyword.other.back-reference.regexp",
-                    "match": "\\\\[1-9]\\d*"
-                },
-                {
-                    "name": "keyword.operator.quantifier.regexp",
-                    "match": "[?+*]|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??"
-                },
-                {
-                    "name": "keyword.operator.or.regexp",
-                    "match": "\\|"
-                },
-                {
-                    "name": "meta.group.assertion.regexp",
-                    "begin": "(\\()((\\?=)|(\\?!))",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.group.regexp"
-                        },
-                        "2": {
-                            "name": "punctuation.definition.group.assertion.regexp"
-                        },
-                        "3": {
-                            "name": "meta.assertion.look-ahead.regexp"
-                        },
-                        "4": {
-                            "name": "meta.assertion.negative-look-ahead.regexp"
-                        }
-                    },
-                    "end": "(\\))",
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.group.regexp"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "#regexp"
-                        }
-                    ]
-                },
-                {
-                    "name": "meta.group.regexp",
-                    "begin": "\\((\\?:)?",
-                    "beginCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.group.regexp"
-                        },
-                        "1": {
-                            "name": "punctuation.definition.group.capture.regexp"
-                        }
-                    },
-                    "end": "\\)",
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.group.regexp"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "#regexp"
-                        }
-                    ]
-                },
-                {
-                    "name": "constant.other.character-class.set.regexp",
-                    "begin": "(\\[)(\\^)?",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.character-class.regexp"
-                        },
-                        "2": {
-                            "name": "keyword.operator.negation.regexp"
-                        }
-                    },
-                    "end": "(\\])",
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.character-class.regexp"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "name": "constant.other.character-class.range.regexp",
-                            "match": "(?:.|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))",
-                            "captures": {
-                                "1": {
-                                    "name": "constant.character.numeric.regexp"
-                                },
-                                "2": {
-                                    "name": "constant.character.control.regexp"
-                                },
-                                "3": {
-                                    "name": "constant.character.escape.backslash.regexp"
-                                },
-                                "4": {
-                                    "name": "constant.character.numeric.regexp"
-                                },
-                                "5": {
-                                    "name": "constant.character.control.regexp"
-                                },
-                                "6": {
-                                    "name": "constant.character.escape.backslash.regexp"
-                                }
-                            }
-                        },
-                        {
-                            "include": "#regex-character-class"
-                        }
-                    ]
-                },
-                {
-                    "include": "#regex-character-class"
-                }
-            ]
-        },
-        "regex-character-class": {
-            "patterns": [
-                {
-                    "name": "constant.other.character-class.regexp",
-                    "match": "\\\\[wWsSdDtrnvf]|\\."
-                },
-                {
-                    "name": "constant.character.numeric.regexp",
-                    "match": "\\\\([0-7]{3}|x\\h\\h|u\\h\\h\\h\\h)"
-                },
-                {
-                    "name": "constant.character.control.regexp",
-                    "match": "\\\\c[A-Z]"
-                },
-                {
-                    "name": "constant.character.escape.backslash.regexp",
-                    "match": "\\\\."
-                }
-            ]
-        }
+			"patterns": [
+				{
+					"name": "string.regexp.ts",
+					"begin": "(?<!\\+\\+|--|})(?<=[=(:,\\[?+!]|^return|[^\\._$[:alnum:]]return|^case|[^\\._$[:alnum:]]case|=>|&&|\\|\\||\\*\\/)\\s*(\\/)(?![\\/*])(?=(?:[^\\/\\\\\\[\\()]|\\\\.|\\[([^\\]\\\\]|\\\\.)+\\]|\\(([^\\)\\\\]|\\\\.)+\\))+\\/([a-z]+|(?![\\/\\*])|(?=\\/\\*))(?!\\s*[a-zA-Z0-9_$]))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.ts"
+						}
+					},
+					"end": "(/)([a-z]*)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.ts"
+						},
+						"2": {
+							"name": "keyword.other.ts"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				},
+				{
+					"name": "string.regexp.ts",
+					"begin": "((?<![_$[:alnum:])\\]]|\\+\\+|--|}|\\*\\/)|((?<=^return|[^\\._$[:alnum:]]return|^case|[^\\._$[:alnum:]]case))\\s*)\\/(?![\\/*])(?=(?:[^\\/\\\\\\[]|\\\\.|\\[([^\\]\\\\]|\\\\.)*\\])+\\/([a-z]+|(?![\\/\\*])|(?=\\/\\*))(?!\\s*[a-zA-Z0-9_$]))",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.ts"
+						}
+					},
+					"end": "(/)([a-z]*)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.ts"
+						},
+						"2": {
+							"name": "keyword.other.ts"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				}
+			]
+		},
+		"regexp": {
+			"patterns": [
+				{
+					"name": "keyword.control.anchor.regexp",
+					"match": "\\\\[bB]|\\^|\\$"
+				},
+				{
+					"match": "\\\\[1-9]\\d*|\\\\k<([a-zA-Z_$][\\w$]*)>",
+					"captures": {
+						"0": {
+							"name": "keyword.other.back-reference.regexp"
+						},
+						"1": {
+							"name": "variable.other.regexp"
+						}
+					}
+				},
+				{
+					"name": "keyword.operator.quantifier.regexp",
+					"match": "[?+*]|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??"
+				},
+				{
+					"name": "keyword.operator.or.regexp",
+					"match": "\\|"
+				},
+				{
+					"name": "meta.group.assertion.regexp",
+					"begin": "(\\()((\\?=)|(\\?!)|(\\?<=)|(\\?<!))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.group.regexp"
+						},
+						"2": {
+							"name": "punctuation.definition.group.assertion.regexp"
+						},
+						"3": {
+							"name": "meta.assertion.look-ahead.regexp"
+						},
+						"4": {
+							"name": "meta.assertion.negative-look-ahead.regexp"
+						},
+						"5": {
+							"name": "meta.assertion.look-behind.regexp"
+						},
+						"6": {
+							"name": "meta.assertion.negative-look-behind.regexp"
+						}
+					},
+					"end": "(\\))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.group.regexp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				},
+				{
+					"name": "meta.group.regexp",
+					"begin": "\\((?:(\\?:)|(?:\\?<([a-zA-Z_$][\\w$]*)>))?",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.group.regexp"
+						},
+						"1": {
+							"name": "punctuation.definition.group.no-capture.regexp"
+						},
+						"2": {
+							"name": "variable.other.regexp"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.group.regexp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				},
+				{
+					"name": "constant.other.character-class.set.regexp",
+					"begin": "(\\[)(\\^)?",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.character-class.regexp"
+						},
+						"2": {
+							"name": "keyword.operator.negation.regexp"
+						}
+					},
+					"end": "(\\])",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.character-class.regexp"
+						}
+					},
+					"patterns": [
+						{
+							"name": "constant.other.character-class.range.regexp",
+							"match": "(?:.|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))",
+							"captures": {
+								"1": {
+									"name": "constant.character.numeric.regexp"
+								},
+								"2": {
+									"name": "constant.character.control.regexp"
+								},
+								"3": {
+									"name": "constant.character.escape.backslash.regexp"
+								},
+								"4": {
+									"name": "constant.character.numeric.regexp"
+								},
+								"5": {
+									"name": "constant.character.control.regexp"
+								},
+								"6": {
+									"name": "constant.character.escape.backslash.regexp"
+								}
+							}
+						},
+						{
+							"include": "#regex-character-class"
+						}
+					]
+				},
+				{
+					"include": "#regex-character-class"
+				}
+			]
+		},
+		"regex-character-class": {
+			"patterns": [
+				{
+					"name": "constant.other.character-class.regexp",
+					"match": "\\\\[wWsSdDtrnvf]|\\."
+				},
+				{
+					"name": "constant.character.numeric.regexp",
+					"match": "\\\\([0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4})"
+				},
+				{
+					"name": "constant.character.control.regexp",
+					"match": "\\\\c[A-Z]"
+				},
+				{
+					"name": "constant.character.escape.backslash.regexp",
+					"match": "\\\\."
+				}
+			]
+		}
     }
 }

--- a/packages/langium/src/grammar/generated/grammar.ts
+++ b/packages/langium/src/grammar/generated/grammar.ts
@@ -3628,7 +3628,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "ID",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\^?[_a-zA-Z][\\\\w_]*"
+        "regex": "/\\\\^?[_a-zA-Z][\\\\w_]*/"
       },
       "fragment": false,
       "hidden": false
@@ -3638,7 +3638,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "STRING",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'"
+        "regex": "/\\"(\\\\\\\\.|[^\\"\\\\\\\\])*\\"|'(\\\\\\\\.|[^'\\\\\\\\])*'/"
       },
       "fragment": false,
       "hidden": false
@@ -3652,7 +3652,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       },
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/(?![*+?])(?:[^\\\\r\\\\n\\\\[/\\\\\\\\]|\\\\\\\\.|\\\\[(?:[^\\\\r\\\\n\\\\]\\\\\\\\]|\\\\\\\\.)*\\\\])+\\\\/"
+        "regex": "/\\\\/(?![*+?])(?:[^\\\\r\\\\n\\\\[/\\\\\\\\]|\\\\\\\\.|\\\\[(?:[^\\\\r\\\\n\\\\]\\\\\\\\]|\\\\\\\\.)*\\\\])+\\\\/[a-z]*/"
       },
       "fragment": false,
       "hidden": false
@@ -3663,7 +3663,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "WS",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\s+"
+        "regex": "/\\\\s+/"
       },
       "fragment": false
     },
@@ -3673,7 +3673,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "ML_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/"
+        "regex": "/\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\//"
       },
       "fragment": false
     },
@@ -3683,7 +3683,7 @@ export const LangiumGrammarGrammar = (): Grammar => loadedLangiumGrammarGrammar 
       "name": "SL_COMMENT",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\/\\\\/[^\\\\n\\\\r]*"
+        "regex": "/\\\\/\\\\/[^\\\\n\\\\r]*/"
       },
       "fragment": false
     }

--- a/packages/langium/src/grammar/langium-grammar.langium
+++ b/packages/langium/src/grammar/langium-grammar.langium
@@ -208,7 +208,7 @@ FeatureName returns string:
 
 terminal ID: /\^?[_a-zA-Z][\w_]*/;
 terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
-terminal RegexLiteral returns string: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\//;
+terminal RegexLiteral returns string: /\/(?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+\/[a-z]*/;
 
 hidden terminal WS: /\s+/;
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;

--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -284,7 +284,7 @@ function buildDataRuleType(element: AbstractElement, cancel: () => PlainProperty
             if (isTerminalRule(ref)) {
                 return {
                     primitive: ref.type?.name ?? 'string',
-                    regex: terminalRegex(ref)
+                    regex: terminalRegex(ref).toString()
                 };
             } else {
                 return {

--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -458,7 +458,7 @@ function createDataTypeCheckerFunctionReturnString(subTypes: string[], strings: 
     ];
 
     if (regexes.length > 0) {
-        const joinedRegexes = regexes.map(e => `/${e}/.test(item)`).join(' || ');
+        const joinedRegexes = regexes.map(e => `${e}.test(item)`).join(' || ');
         allArray.push(`(typeof item === 'string' && (${joinedRegexes}))`);
     }
 

--- a/packages/langium/src/lsp/completion/follow-element-computation.ts
+++ b/packages/langium/src/lsp/completion/follow-element-computation.ts
@@ -294,7 +294,7 @@ function ruleMatches(rule: ast.AbstractRule | undefined, token: IToken): boolean
         // We have to take keywords into account
         // e.g. most keywords are valid IDs as well
         // Only return 'true' if this terminal does not match a keyword. TODO
-        return new RegExp(terminalRegex(rule)).test(token.image);
+        return terminalRegex(rule).test(token.image);
     } else {
         return false;
     }

--- a/packages/langium/src/parser/lexer.ts
+++ b/packages/langium/src/parser/lexer.ts
@@ -39,7 +39,9 @@ export class DefaultLexer implements Lexer {
         });
         this.tokenTypes = this.toTokenTypeDictionary(tokens);
         const lexerTokens = isTokenTypeDictionary(tokens) ? Object.values(tokens) : tokens;
-        this.chevrotainLexer = new ChevrotainLexer(lexerTokens);
+        this.chevrotainLexer = new ChevrotainLexer(lexerTokens, {
+            positionTracking: 'full'
+        });
     }
 
     get definition(): TokenTypeDictionary {

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -45,7 +45,6 @@ export class DefaultValueConverter implements ValueConverter {
             case 'INT': return convertInt(input);
             case 'STRING': return convertString(input);
             case 'ID': return convertID(input);
-            case 'REGEXLITERAL': return convertRegexLiteral(input);
         }
         switch (getRuleType(rule)?.toLowerCase()) {
             case 'number': return convertNumber(input);
@@ -82,10 +81,6 @@ function convertEscapeCharacter(char: string): string {
         case '0': return '\0';
         default: return char;
     }
-}
-
-export function convertRegexLiteral(input: string): string {
-    return input.substring(1, input.length - 1);
 }
 
 export function convertID(input: string): string {

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -103,7 +103,7 @@ export function getCrossReferenceTerminal(crossRef: ast.CrossReference): ast.Abs
  * that contains visible characters is considered a comment.
  */
 export function isCommentTerminal(terminalRule: ast.TerminalRule): boolean {
-    return terminalRule.hidden && !' '.match(terminalRegex(terminalRule));
+    return terminalRule.hidden && !terminalRegex(terminalRule).test(' ');
 }
 
 /**

--- a/packages/langium/src/utils/regex-util.ts
+++ b/packages/langium/src/utils/regex-util.ts
@@ -142,7 +142,7 @@ export function isWhitespaceRegExp(value: RegExp | string): boolean {
 }
 
 export function escapeRegExp(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return value.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
 }
 
 export function getCaseInsensitivePattern(keyword: string): string {

--- a/packages/langium/test/grammar/grammar-util.test.ts
+++ b/packages/langium/test/grammar/grammar-util.test.ts
@@ -135,46 +135,40 @@ describe('Get Name from Type', () => {
 
 describe('TerminalRule to regex', () => {
 
-    test('Should create empty keyword', async () => {
-        const terminal = await getTerminal("terminal X: '';");
-        const regex = terminalRegex(terminal);
-        expect(regex).toBe('');
-    });
-
     test('Should create keyword with escaped characters', async () => {
         const terminal = await getTerminal("terminal X: '(';");
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('\\(');
+        expect(regex).toEqual(/\(/);
     });
 
     test('Should create combined regexes', async () => {
         const terminal = await getTerminal('terminal X: /x/ /y/;');
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('(xy)');
+        expect(regex).toEqual(/(xy)/);
     });
 
     test('Should create optional alternatives with keywords', async () => {
         const terminal = await getTerminal("terminal X: ('a' | 'b')?;");
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('(a|b)?');
+        expect(regex).toEqual(/(a|b)?/);
     });
 
     test('Should create positive lookahead group with single element', async () => {
         const terminal = await getTerminal("terminal X: 'a' (?='b');");
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('(a(?=b))');
+        expect(regex).toEqual(/(a(?=b))/);
     });
 
     test('Should create positive lookahead group with multiple elements', async () => {
         const terminal = await getTerminal("terminal X: 'a' (?='b' 'c' 'd');");
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('(a(?=bcd))');
+        expect(regex).toEqual(/(a(?=bcd))/);
     });
 
     test('Should create negative lookahead group', async () => {
         const terminal = await getTerminal("terminal X: 'a' (?!'b');");
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('(a(?!b))');
+        expect(regex).toEqual(/(a(?!b))/);
     });
 
     test('Should create terminal reference in terminal definition', async () => {
@@ -183,12 +177,12 @@ describe('TerminalRule to regex', () => {
         terminal Y: 'a';
         `, 'X');
         const regex = terminalRegex(terminal);
-        expect(regex).toBe('((a)(a))');
+        expect(regex).toEqual(/((a)(a))/);
     });
 
     test('Should create negated token', async () => {
         const terminal = await getTerminal("terminal X: !'a';");
-        const regex = new RegExp(`^${terminalRegex(terminal)}$`);
+        const regex = new RegExp(`^${terminalRegex(terminal).source}$`);
         expect('a').not.toMatch(regex);
         expect('b').toMatch(regex);
         expect('c').toMatch(regex);
@@ -196,7 +190,7 @@ describe('TerminalRule to regex', () => {
 
     test('Should create character ranges', async () => {
         const terminal = await getTerminal("terminal X: 'a'..'b';");
-        const regex = new RegExp(`^${terminalRegex(terminal)}$`);
+        const regex = new RegExp(`^${terminalRegex(terminal).source}$`);
         expect('a').toMatch(regex);
         expect('b').toMatch(regex);
         expect('c').not.toMatch(regex);
@@ -204,7 +198,7 @@ describe('TerminalRule to regex', () => {
 
     test('Should create wildcards', async () => {
         const terminal = await getTerminal('terminal X: .;');
-        const regex = new RegExp(`^${terminalRegex(terminal)}$`);
+        const regex = new RegExp(`^${terminalRegex(terminal).source}$`);
         expect('a').toMatch(regex);
         expect(':').toMatch(regex);
         expect('ab').not.toMatch(regex);
@@ -212,7 +206,7 @@ describe('TerminalRule to regex', () => {
 
     test('Should create until tokens', async () => {
         const terminal = await getTerminal("terminal X: 'a'->'b';");
-        const regex = new RegExp(`^${terminalRegex(terminal)}$`);
+        const regex = new RegExp(`^${terminalRegex(terminal).source}$`);
         expect('ab').toMatch(regex);
         expect('a some value b').toMatch(regex);
     });

--- a/packages/langium/test/parser/langium-parser-builder.test.ts
+++ b/packages/langium/test/parser/langium-parser-builder.test.ts
@@ -622,6 +622,29 @@ describe('Fragment rules', () => {
 
 });
 
+describe('Unicode terminal rules', () => {
+
+    const grammar = `
+    grammar test
+    entry Model: value=UnicodeID;
+    terminal UnicodeID returns string: /\\p{L}(\\p{L}|\\p{N})*/u;
+    hidden terminal WS: /\\s+/;
+    `;
+    const parser = parserFromGrammar(grammar);
+
+    for (const value of ['John', 'Jörg', 'José', '佐藤', '李']) {
+        test(`Parses ${value} using unicode terminal`, () => {
+            return expectParse(value);
+        });
+    }
+
+    async function expectParse(value: string): Promise<void> {
+        const result = (await parser).parse(value);
+        expect(result.value).toHaveProperty('value', value);
+    }
+
+});
+
 describe('ALL(*) parser', () => {
 
     const grammar = `

--- a/packages/langium/test/utils/regex-util.test.ts
+++ b/packages/langium/test/utils/regex-util.test.ts
@@ -99,24 +99,24 @@ describe('comment start/end parts', () => {
 
     test('JS style singleline comment should start with //', () => {
         expect(getTerminalParts(/\/\/[^\n\r]*/)).toEqual([{
-            start: '//',
+            start: '\\/\\/',
             end: ''
         }]);
     });
 
     test('JS style multiline comment should start with /* and end with */', () => {
         expect(getTerminalParts(/\/\*[\s\S]*?\*\//)).toEqual([{
-            start: '/\\*',
-            end: '\\*/'
+            start: '\\/\\*',
+            end: '\\*\\/'
         }]);
     });
 
     test('JS style combined comment should contain both /* */ and // parts', () => {
         expect(getTerminalParts(/\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/)).toEqual([{
-            start: '/\\*',
-            end: '\\*/'
+            start: '\\/\\*',
+            end: '\\*\\/'
         }, {
-            start: '//',
+            start: '\\/\\/',
             end: ''
         }]);
     });


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/127

This change adds support for the following regex flags:

* `i` - case insensitivity
* `s` - allow to match newline characters with `.`
* `u` - enable unicode support

Other flags (`g`, `y`, `m`) are not applicable in the context of Langium/Chevrotain and return a warning if used.

Right now, only regex flags defined on regular expressions themselves are valid for this feature. We cannot specify regex flags on composite terminals themselves. That would require some dedicated syntax, but we can add that in a separate PR.