### PR TITLE
feat: Add `jsExtension` to `LangiumConfig`

### DIFF
--- a/packages/langium-cli/src/generator/module-generator.ts
+++ b/packages/langium-cli/src/generator/module-generator.ts
@@ -13,6 +13,7 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
     const parserConfig = config.chevrotainParserConfig;
     const hasIParserConfigImport = Boolean(parserConfig) || grammars.some(grammar => grammarConfigMap.get(grammar)?.chevrotainParserConfig !== undefined);
     const node = new CompositeGeneratorNode();
+    const importExtension = config.jsExtension ? '.js' : '';
 
     node.append(generatedHeader);
     if (config.langiumInternal) {
@@ -25,9 +26,11 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
     } else {
         node.append(`import type { LangiumGeneratedServices, LangiumGeneratedSharedServices, LangiumSharedServices, LangiumServices, LanguageMetaData, Module${hasIParserConfigImport ? ', IParserConfig' : ''} } from 'langium';`, NL);
     }
-
     node.append(
-        'import { ', config.projectName, "AstReflection } from './ast';", NL,
+        'import { ',
+        config.projectName,
+        `AstReflection } from './ast${importExtension}';`,
+        NL,
         'import { '
     );
     for (let i = 0; i < grammars.length; i++) {
@@ -39,7 +42,7 @@ export function generateModule(grammars: Grammar[], config: LangiumConfig, gramm
             }
         }
     }
-    node.append(" } from './grammar';", NL, NL);
+    node.append(` } from './grammar${importExtension}';`, NL, NL);
 
     for (const grammar of grammars) {
         if (grammar.name) {

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -29,6 +29,8 @@ export interface LangiumConfig {
     languages: LangiumLanguageConfig[]
     /** Main output directory for TypeScript code */
     out?: string
+    /** Should add `.js` extension in import statements of generated files */
+    jsExtension?: boolean
     /** Configure the chevrotain parser for all languages */
     chevrotainParserConfig?: IParserConfig,
     /** The following option is meant to be used only by Langium itself */


### PR DESCRIPTION
When downstream projects are using `nodenext` module resolution, file extensions are mandatory.
So if `jsExtension` is true, a `.js` extension will be added to the ast and grammar imports.

Context: https://github.com/mermaid-js/mermaid/pull/4450#issuecomment-1575549546