### PR TITLE
Generate syntax railroad diagrams

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,10 @@ jobs:
       shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # Update the following list when a new package is added
+      # Update the following list when a new npm package is added
       run: |
         npm run publish:latest --provenance --workspace=langium
+        npm run publish:latest --provenance --workspace=langium-railroad
         npm run publish:latest --provenance --workspace=langium-cli
         npm run publish:latest --provenance --workspace=langium-sprotty
         npm run publish:latest --provenance --workspace=generator-langium

--- a/examples/arithmetics/package.json
+++ b/examples/arithmetics/package.json
@@ -66,7 +66,7 @@
         "langium:generate": "langium generate",
         "langium:watch": "langium generate --watch",
         "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-        "publish:latest": "npm publish --tag latest"
+        "publish:latest": "npm publish --tag latest --access public"
     },
     "dependencies": {
         "chalk": "~4.1.2",

--- a/examples/domainmodel/package.json
+++ b/examples/domainmodel/package.json
@@ -55,7 +55,7 @@
         "langium:generate": "langium generate",
         "langium:watch": "langium generate --watch",
         "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-        "publish:latest": "npm publish --tag latest"
+        "publish:latest": "npm publish --tag latest --access public"
     },
     "dependencies": {
         "chalk": "~4.1.2",

--- a/examples/statemachine/package.json
+++ b/examples/statemachine/package.json
@@ -56,7 +56,7 @@
         "langium:generate": "langium generate",
         "langium:watch": "langium generate --watch",
         "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-        "publish:latest": "npm publish --tag latest"
+        "publish:latest": "npm publish --tag latest --access public"
     },
     "dependencies": {
         "chalk": "~4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4599,6 +4599,10 @@
       "resolved": "examples/domainmodel",
       "link": true
     },
+    "node_modules/langium-railroad": {
+      "resolved": "packages/langium-railroad",
+      "link": true
+    },
     "node_modules/langium-requirements-dsl": {
       "resolved": "examples/requirements",
       "link": true
@@ -6380,6 +6384,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -8518,6 +8527,7 @@
         "fs-extra": "~11.1.0",
         "jsonschema": "~1.4.1",
         "langium": "~1.2.0",
+        "langium-railroad": "~1.2.0",
         "lodash": "~4.17.21"
       },
       "bin": {
@@ -8528,6 +8538,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "packages/langium-railroad": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "~1.2.0",
+        "railroad-diagrams": "^1.0.0"
       }
     },
     "packages/langium-sprotty": {
@@ -8544,6 +8562,7 @@
       "dependencies": {
         "ignore": "~5.2.4",
         "langium": "1.2.0",
+        "langium-railroad": "1.2.0",
         "vscode-languageserver": "~8.0.2"
       },
       "engines": {
@@ -11967,6 +11986,7 @@
         "fs-extra": "~11.1.0",
         "jsonschema": "~1.4.1",
         "langium": "~1.2.0",
+        "langium-railroad": "~1.2.0",
         "lodash": "~4.17.21"
       }
     },
@@ -11980,6 +12000,13 @@
         "lodash": "~4.17.21",
         "vscode-languageclient": "~8.0.2",
         "vscode-languageserver": "~8.0.2"
+      }
+    },
+    "langium-railroad": {
+      "version": "file:packages/langium-railroad",
+      "requires": {
+        "langium": "~1.2.0",
+        "railroad-diagrams": "^1.0.0"
       }
     },
     "langium-requirements-dsl": {
@@ -12018,6 +12045,7 @@
       "requires": {
         "ignore": "~5.2.4",
         "langium": "1.2.0",
+        "langium-railroad": "1.2.0",
         "vscode-languageserver": "~8.0.2"
       }
     },
@@ -13376,6 +13404,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "devOptional": true
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
     },
     "react-is": {
       "version": "17.0.2",

--- a/packages/generator-langium/package.json
+++ b/packages/generator-langium/package.json
@@ -30,7 +30,7 @@
     "test": "vitest run",
     "debug": "npx --node-arg=--inspect yo langium",
     "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "chalk": "~4.1.2",

--- a/packages/langium-cli/README.md
+++ b/packages/langium-cli/README.md
@@ -44,17 +44,22 @@ Schema:
         caseInsensitive: boolean
         // Enable generating a TextMate syntax highlighting file
         textMate: {
-            // Output path to syntax highlighting file
+            // Output path to syntax highlighting file (json)
             out: string
         }
         // Enable generating a monarch syntax highlighting file
         monarch: {
-            // Output path to syntax highlighting file
+            // Output path to syntax highlighting file (js)
             out: string
         }
         // Enable generating a prism syntax highlighting file
         prism: {
-            // Output path to syntax highlighting file
+            // Output path to syntax highlighting file (js)
+            out: string
+        }
+        // Enable generating railroad syntax diagram
+        railroad: {
+            // Output path to syntax diagram file (html)
             out: string
         }
         // Configure the chevrotain parser for a single language
@@ -79,6 +84,9 @@ Example:
         "fileExtensions": [".dmodel"],
         "textMate": {
             "out": "syntaxes/domain-model.tmLanguage.json"
+        },
+        "railroad": {
+            "out": "docs/syntax-diagram.html"
         }
     }],
     "out": "src/language-server/generated",

--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -99,6 +99,19 @@
                         "out"
                     ]
                 },
+                "railroad": {
+                    "description": "An object to describe railroad syntax diagram properties",
+                    "type": "object",
+                    "properties": {
+                        "out": {
+                            "description": "The output file path to the generated railroad html file",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "out"
+                    ]
+                },
                 "chevrotainParserConfig": {
                     "$ref": "#/$defs/chevrotainParserConfig"
                 }

--- a/packages/langium-cli/package.json
+++ b/packages/langium-cli/package.json
@@ -30,7 +30,7 @@
     "watch": "tsc --watch",
     "lint": "eslint src test --ext .ts",
     "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "chalk": "~4.1.2",

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -258,12 +258,7 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
 
     for (const grammar of grammars) {
         const languageConfig = configMap.get(grammar);
-        const diagram = createGrammarDiagramHtml(grammar);
-        const diagramPath = path.resolve(relPath, 'diagram.html');
-        const cssPath = path.join(require.resolve('railroad-diagrams'), '..', 'railroad-diagrams.css');
-        const css = await fs.readFile(cssPath);
-        const fullHtml = '<style>' + css + '</style>' + diagram;
-        await writeWithFail(diagramPath, fullHtml, options);
+
         if (languageConfig?.textMate) {
             const genTmGrammar = generateTextMate(grammar, languageConfig);
             const textMatePath = path.resolve(relPath, languageConfig.textMate.out);
@@ -283,6 +278,13 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
             const prismPath = path.resolve(relPath, languageConfig.prism.out);
             log('log', options, `Writing prism grammar to ${chalk.white.bold(prismPath)}`);
             await writeHighlightGrammar(genPrismGrammar, prismPath, options);
+        }
+
+        if (languageConfig?.railroad) {
+            const diagram = createGrammarDiagramHtml(grammar);
+            const diagramPath = path.resolve(relPath, languageConfig.railroad.out);
+            log('log', options, `Writing railroad syntax diagram to ${chalk.white.bold(diagramPath)}`);
+            await writeWithFail(diagramPath, diagram, options);
         }
     }
 

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -19,6 +19,7 @@ import { getUserChoice, log } from './generator/util';
 import { getFilePath, RelativePath } from './package';
 import { validateParser } from './parser-validation';
 import { generateTypesFile } from './generator/types-generator';
+import { createGrammarDiagramHtml } from 'langium-railroad';
 import chalk from 'chalk';
 import path from 'path';
 import fs from 'fs-extra';
@@ -257,6 +258,12 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
 
     for (const grammar of grammars) {
         const languageConfig = configMap.get(grammar);
+        const diagram = createGrammarDiagramHtml(grammar);
+        const diagramPath = path.resolve(relPath, 'diagram.html');
+        const cssPath = path.join(require.resolve('railroad-diagrams'), '..', 'railroad-diagrams.css');
+        const css = await fs.readFile(cssPath);
+        const fullHtml = '<style>' + css + '</style>' + diagram;
+        await writeWithFail(diagramPath, fullHtml, options);
         if (languageConfig?.textMate) {
             const genTmGrammar = generateTextMate(grammar, languageConfig);
             const textMatePath = path.resolve(relPath, languageConfig.textMate.out);

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -63,6 +63,11 @@ export interface LangiumLanguageConfig {
         /** Output path to syntax highlighting file */
         out: string
     }
+    /** Enable generating a railroad syntax diagram */
+    railroad?: {
+        /** Output path to the railroad diagram file */
+        out: string
+    }
     /** Configure the chevrotain parser for a single language */
     chevrotainParserConfig?: IParserConfig
 }

--- a/packages/langium-railroad/LICENSE
+++ b/packages/langium-railroad/LICENSE
@@ -1,0 +1,16 @@
+Copyright 2023 TypeFox GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/langium-railroad/README.md
+++ b/packages/langium-railroad/README.md
@@ -1,0 +1,16 @@
+# Integration of Langium and Sprotty
+
+This package provides glue code for [Langium](https://langium.org) and [Sprotty](https://www.npmjs.com/package/sprotty). It includes the following features:
+
+ * Generate diagram models from a Langium AST
+ * Listen to document changes and update existing diagram models automatically
+ * Hook into the JSON-RPC channel used by the language server
+
+The counterpart of this integration is the [sprotty-vscode](https://www.npmjs.com/package/sprotty-vscode) package, which provides Sprotty diagrams embedded in VS Code webviews and is able to connect with the JSON-RPC stream of a chosen language.
+
+## How to Use This
+
+ 1. Implement a diagram model generator by extending `LangiumDiagramGenerator`
+ 2. Add `SprottyDiagramServices` to the dependency injection module of your language and bind the `diagram.DiagramGenerator` service
+ 3. Add `DefaultSprottyModule` to the `inject` function that sets up your dependency injection container
+ 4. Call the `addDiagramHandler` function in your main code to hook into the JSON-RPC stream

--- a/packages/langium-railroad/README.md
+++ b/packages/langium-railroad/README.md
@@ -1,16 +1,5 @@
-# Integration of Langium and Sprotty
+# Langium Railroad Diagrams
 
-This package provides glue code for [Langium](https://langium.org) and [Sprotty](https://www.npmjs.com/package/sprotty). It includes the following features:
+This package provides the ability to build railroad syntax diagrams for [Langium](https://langium.org) grammars.
 
- * Generate diagram models from a Langium AST
- * Listen to document changes and update existing diagram models automatically
- * Hook into the JSON-RPC channel used by the language server
-
-The counterpart of this integration is the [sprotty-vscode](https://www.npmjs.com/package/sprotty-vscode) package, which provides Sprotty diagrams embedded in VS Code webviews and is able to connect with the JSON-RPC stream of a chosen language.
-
-## How to Use This
-
- 1. Implement a diagram model generator by extending `LangiumDiagramGenerator`
- 2. Add `SprottyDiagramServices` to the dependency injection module of your language and bind the `diagram.DiagramGenerator` service
- 3. Add `DefaultSprottyModule` to the `inject` function that sets up your dependency injection container
- 4. Call the `addDiagramHandler` function in your main code to hook into the JSON-RPC stream
+It is reused by the [langium-cli](https://www.npmjs.com/package/langium-cli) package and the [Langium VSCode extension](https://marketplace.visualstudio.com/items?itemName=langium.langium-vscode).

--- a/packages/langium-railroad/package.json
+++ b/packages/langium-railroad/package.json
@@ -26,7 +26,7 @@
     "watch": "tsc --watch",
     "lint": "eslint src --ext .ts",
     "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "langium": "~1.2.0",

--- a/packages/langium-railroad/package.json
+++ b/packages/langium-railroad/package.json
@@ -1,7 +1,7 @@
 {
   "name": "langium-railroad",
   "version": "1.2.0",
-  "description": "Use Langium as source railroad diagrams",
+  "description": "Use Langium as source for railroad syntax diagrams",
   "homepage": "https://langium.org",
   "keywords": [
     "language",
@@ -29,12 +29,8 @@
     "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {
-    "jsdom": "^22.1.0",
     "langium": "~1.2.0",
     "railroad-diagrams": "^1.0.0"
-  },
-  "devDependencies": {
-    "@types/jsdom": "^21.1.1"
   },
   "volta": {
     "node": "16.19.0",
@@ -43,7 +39,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/langium/langium",
-    "directory": "packages/langium-sprotty"
+    "directory": "packages/langium-railroad"
   },
   "bugs": "https://github.com/langium/langium/issues",
   "author": {

--- a/packages/langium-railroad/package.json
+++ b/packages/langium-railroad/package.json
@@ -1,48 +1,40 @@
 {
-  "name": "langium-cli",
-  "version": "1.2.1",
-  "description": "CLI for Langium - the language engineering tool",
+  "name": "langium-railroad",
+  "version": "1.2.0",
+  "description": "Use Langium as source railroad diagrams",
   "homepage": "https://langium.org",
-  "engines": {
-    "node": ">=14.0.0"
-  },
   "keywords": [
-    "cli",
+    "language",
     "dsl",
+    "diagram",
     "lsp",
+    "language-server",
     "vscode",
-    "typescript"
+    "visualization",
+    "modeling"
   ],
   "license": "MIT",
   "files": [
-    "bin",
     "lib",
-    "src",
-    "langium-config-schema.json"
+    "src"
   ],
-  "bin": {
-    "langium": "./bin/langium.js"
-  },
-  "main": "./lib/langium.js",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "clean": "shx rm -rf lib coverage",
     "build": "tsc",
     "watch": "tsc --watch",
-    "lint": "eslint src test --ext .ts",
+    "lint": "eslint src --ext .ts",
     "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
     "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {
-    "chalk": "~4.1.2",
-    "commander": "~10.0.0",
-    "fs-extra": "~11.1.0",
-    "jsonschema": "~1.4.1",
+    "jsdom": "^22.1.0",
     "langium": "~1.2.0",
-    "langium-railroad": "~1.2.0",
-    "lodash": "~4.17.21"
+    "railroad-diagrams": "^1.0.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "~11.0.1"
+    "@types/jsdom": "^21.1.1"
   },
   "volta": {
     "node": "16.19.0",
@@ -51,7 +43,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/langium/langium",
-    "directory": "packages/langium-cli"
+    "directory": "packages/langium-sprotty"
   },
   "bugs": "https://github.com/langium/langium/issues",
   "author": {

--- a/packages/langium-railroad/src/grammar-railroad.ts
+++ b/packages/langium-railroad/src/grammar-railroad.ts
@@ -5,53 +5,93 @@
  ******************************************************************************/
 
 import { GrammarAST, findNameAssignment } from 'langium';
-import * as railroad from 'railroad-diagrams';
+import type { FakeSVG } from 'railroad-diagrams';
+import * as rr from 'railroad-diagrams';
+
+export const defaultCss = `
+svg.railroad-diagram {
+    background-color: hsl(30,20%,95%);
+}
+svg.railroad-diagram path {
+    stroke-width: 3;
+    stroke: black;
+    fill: rgba(0,0,0,0);
+}
+svg.railroad-diagram text {
+    font: bold 14px monospace;
+    text-anchor: middle;
+}
+svg.railroad-diagram text.label {
+    text-anchor: start;
+}
+svg.railroad-diagram text.comment {
+    font: italic 12px monospace;
+}
+svg.railroad-diagram rect {
+    stroke-width: 3;
+    stroke: black;
+    fill: hsl(120,100%,90%);
+}
+`.trim();
 
 export function createGrammarDiagramHtml(grammar: GrammarAST.Grammar): string {
-    return createGrammarDiagram(grammar);
+    let text = `<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+${defaultCss}
+</style>
+</head>
+<body>
+`;
+    text += createGrammarDiagram(grammar);
+    text += `</body>
+</html>`;
+
+    return text;
 }
 
 export function createGrammarDiagram(grammar: GrammarAST.Grammar): string {
     const nonTerminals = grammar.rules.filter(GrammarAST.isParserRule);
     let text = '';
     for (const nonTerminal of nonTerminals) {
-        text += '<h2>' + nonTerminal.name + '</h2>';
+        text += '<h2>' + nonTerminal.name + '</h2>\n';
         text += createRuleDiagram(nonTerminal);
     }
     return text;
 }
 
 function createRuleDiagram(rule: GrammarAST.ParserRule): string {
-    const diagram = new railroad.Diagram(toRailroad(rule.definition));
+    const diagram = new rr.Diagram(toRailroad(rule.definition));
     return diagram.toString();
 }
 
-function toRailroad(element: GrammarAST.AbstractElement): railroad.FakeSVG[] {
+function toRailroad(element: GrammarAST.AbstractElement): FakeSVG[] {
     if (GrammarAST.isAssignment(element)) {
         return wrapCardinality(element.cardinality, toRailroad(element.terminal));
     } else if (GrammarAST.isAlternatives(element)) {
-        return wrapCardinality(element.cardinality, [new railroad.Choice(0, element.elements.flatMap(e => toRailroad(e)))]);
+        return wrapCardinality(element.cardinality, [new rr.Choice(0, element.elements.flatMap(e => toRailroad(e)))]);
     } else if (GrammarAST.isUnorderedGroup(element)) {
-        const choice = new railroad.Choice(0, element.elements.flatMap(e => toRailroad(e)));
-        const repetition = new railroad.ZeroOrMore(choice);
+        const choice = new rr.Choice(0, element.elements.flatMap(e => toRailroad(e)));
+        const repetition = new rr.ZeroOrMore(choice);
         return wrapCardinality(element.cardinality, [repetition]);
     } else if (GrammarAST.isGroup(element)) {
-        return wrapCardinality(element.cardinality, [new railroad.Sequence(element.elements.flatMap(e => toRailroad(e)))]);
+        return wrapCardinality(element.cardinality, [new rr.Sequence(element.elements.flatMap(e => toRailroad(e)))]);
     } else if (GrammarAST.isKeyword(element)) {
-        return wrapCardinality(element.cardinality, [new railroad.Terminal(element.value)]);
+        return wrapCardinality(element.cardinality, [new rr.Terminal(element.value)]);
     } else if (GrammarAST.isRuleCall(element)) {
-        return wrapCardinality(element.cardinality, [new railroad.NonTerminal(element.rule.$refText)]);
+        return wrapCardinality(element.cardinality, [new rr.NonTerminal(element.rule.$refText)]);
     } else if (GrammarAST.isCrossReference(element)) {
         if (GrammarAST.isKeyword(element.terminal)) {
-            return wrapCardinality(element.cardinality, [new railroad.Terminal(element.terminal.value)]);
+            return wrapCardinality(element.cardinality, [new rr.Terminal(element.terminal.value)]);
         } else if (GrammarAST.isRuleCall(element.terminal)) {
-            return wrapCardinality(element.cardinality, [new railroad.NonTerminal(element.terminal.rule.$refText)]);
+            return wrapCardinality(element.cardinality, [new rr.NonTerminal(element.terminal.rule.$refText)]);
         } else {
             const nameAssignment = element.type.ref && findNameAssignment(element.type.ref);
             if (nameAssignment) {
                 return wrapCardinality(element.cardinality, toRailroad(nameAssignment));
             } else {
-                return wrapCardinality(element.cardinality, [new railroad.NonTerminal('UNKNOWN')]);
+                return wrapCardinality(element.cardinality, [new rr.NonTerminal('UNKNOWN')]);
             }
         }
     } else {
@@ -59,14 +99,14 @@ function toRailroad(element: GrammarAST.AbstractElement): railroad.FakeSVG[] {
     }
 }
 
-function wrapCardinality(cardinality: '?' | '*' | '+' | undefined, items: railroad.FakeSVG[]): railroad.FakeSVG[] {
+function wrapCardinality(cardinality: '?' | '*' | '+' | undefined, items: FakeSVG[]): FakeSVG[] {
     if (cardinality) {
         if (cardinality === '*') {
-            return [new railroad.ZeroOrMore(new railroad.Sequence(items))];
+            return [new rr.ZeroOrMore(new rr.Sequence(items))];
         } else if (cardinality === '+') {
-            return [new railroad.OneOrMore(new railroad.Sequence(items))];
+            return [new rr.OneOrMore(new rr.Sequence(items))];
         } else if (cardinality === '?') {
-            return [new railroad.Optional(new railroad.Sequence(items))];
+            return [new rr.Optional(new rr.Sequence(items))];
         }
     }
     return items;

--- a/packages/langium-railroad/src/grammar-railroad.ts
+++ b/packages/langium-railroad/src/grammar-railroad.ts
@@ -1,0 +1,73 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { GrammarAST, findNameAssignment } from 'langium';
+import * as railroad from 'railroad-diagrams';
+
+export function createGrammarDiagramHtml(grammar: GrammarAST.Grammar): string {
+    return createGrammarDiagram(grammar);
+}
+
+export function createGrammarDiagram(grammar: GrammarAST.Grammar): string {
+    const nonTerminals = grammar.rules.filter(GrammarAST.isParserRule);
+    let text = '';
+    for (const nonTerminal of nonTerminals) {
+        text += '<h2>' + nonTerminal.name + '</h2>';
+        text += createRuleDiagram(nonTerminal);
+    }
+    return text;
+}
+
+function createRuleDiagram(rule: GrammarAST.ParserRule): string {
+    const diagram = new railroad.Diagram(toRailroad(rule.definition));
+    return diagram.toString();
+}
+
+function toRailroad(element: GrammarAST.AbstractElement): railroad.FakeSVG[] {
+    if (GrammarAST.isAssignment(element)) {
+        return wrapCardinality(element.cardinality, toRailroad(element.terminal));
+    } else if (GrammarAST.isAlternatives(element)) {
+        return wrapCardinality(element.cardinality, [new railroad.Choice(0, element.elements.flatMap(e => toRailroad(e)))]);
+    } else if (GrammarAST.isUnorderedGroup(element)) {
+        const choice = new railroad.Choice(0, element.elements.flatMap(e => toRailroad(e)));
+        const repetition = new railroad.ZeroOrMore(choice);
+        return wrapCardinality(element.cardinality, [repetition]);
+    } else if (GrammarAST.isGroup(element)) {
+        return wrapCardinality(element.cardinality, [new railroad.Sequence(element.elements.flatMap(e => toRailroad(e)))]);
+    } else if (GrammarAST.isKeyword(element)) {
+        return wrapCardinality(element.cardinality, [new railroad.Terminal(element.value)]);
+    } else if (GrammarAST.isRuleCall(element)) {
+        return wrapCardinality(element.cardinality, [new railroad.NonTerminal(element.rule.$refText)]);
+    } else if (GrammarAST.isCrossReference(element)) {
+        if (GrammarAST.isKeyword(element.terminal)) {
+            return wrapCardinality(element.cardinality, [new railroad.Terminal(element.terminal.value)]);
+        } else if (GrammarAST.isRuleCall(element.terminal)) {
+            return wrapCardinality(element.cardinality, [new railroad.NonTerminal(element.terminal.rule.$refText)]);
+        } else {
+            const nameAssignment = element.type.ref && findNameAssignment(element.type.ref);
+            if (nameAssignment) {
+                return wrapCardinality(element.cardinality, toRailroad(nameAssignment));
+            } else {
+                return wrapCardinality(element.cardinality, [new railroad.NonTerminal('UNKNOWN')]);
+            }
+        }
+    } else {
+        return [];
+    }
+}
+
+function wrapCardinality(cardinality: '?' | '*' | '+' | undefined, items: railroad.FakeSVG[]): railroad.FakeSVG[] {
+    if (cardinality) {
+        if (cardinality === '*') {
+            return [new railroad.ZeroOrMore(new railroad.Sequence(items))];
+        } else if (cardinality === '+') {
+            return [new railroad.OneOrMore(new railroad.Sequence(items))];
+        } else if (cardinality === '?') {
+            return [new railroad.Optional(new railroad.Sequence(items))];
+        }
+    }
+    return items;
+}

--- a/packages/langium-railroad/src/grammar-railroad.ts
+++ b/packages/langium-railroad/src/grammar-railroad.ts
@@ -34,13 +34,25 @@ svg.railroad-diagram rect {
 }
 `.trim();
 
-export function createGrammarDiagramHtml(grammar: GrammarAST.Grammar): string {
+export interface GrammarDiagramOptions {
+    css?: string;
+    javascript?: string;
+}
+
+export function createGrammarDiagramHtml(grammar: GrammarAST.Grammar, options?: GrammarDiagramOptions): string {
     let text = `<!DOCTYPE HTML>
 <html>
 <head>
 <style>
 ${defaultCss}
-</style>
+</style>${options?.css ? `
+<style>
+${options.css}
+</style>` : ''}
+${options?.javascript ? `
+<script>
+${options.javascript}
+</script>` : ''}
 </head>
 <body>
 `;

--- a/packages/langium-railroad/src/index.ts
+++ b/packages/langium-railroad/src/index.ts
@@ -1,0 +1,7 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+export * from './grammar-railroad';

--- a/packages/langium-railroad/src/railroad-types.d.ts
+++ b/packages/langium-railroad/src/railroad-types.d.ts
@@ -4,8 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 declare module 'railroad-diagrams' {
 
     export type Direction = 'cw' | 'ccw';
@@ -182,27 +180,5 @@ declare module 'railroad-diagrams' {
     export class Block extends FakeSVG {
         constructor(options?: BlockOptions);
     }
-
-    export default {
-        Diagram: (args: DiagramItem[]) => new Diagram(),
-        ComplexDiagram: (args: DiagramItem[]) => new ComplexDiagram(),
-        Sequence: (args: DiagramItem[]) => new Sequence(),
-        Stack: (args: DiagramItem[]) => new Stack(),
-        OptionalSequence: (args: DiagramItem[]) => new OptionalSequence(),
-        AlternatingSequence: (args: DiagramItem[]) => new AlternatingSequence(),
-        Choice: (normal: number, args: DiagramItem[]) => new Choice(),
-        HorizontalChoice: (args: DiagramItem[]) => new HorizontalChoice(),
-        MultipleChoice: (args: DiagramItem[]) => new MultipleChoice(),
-        Optional: (item: DiagramItem, skip?: 'skip') => new Choice(),
-        OneOrMore: (item: DiagramItem, rep?: DiagramItem) => new OneOrMore(),
-        ZeroOrMore: (item: DiagramItem, rep?: DiagramItem, skip?: 'skip') => new ZeroOrMore(),
-        Start: (options?: StartOptions) => new Start(),
-        End: (options?: EndOptions) => new End(),
-        Terminal: (text: string, options?: TerminalOptions) => new Terminal(),
-        NonTerminal: (text: string, options?: NonTerminalOptions) => new NonTerminal(),
-        Comment: (text: string, options?: CommentOptions) => new Comment(),
-        Skip: () => new Skip(),
-        Block: (options?: BlockOptions) => new Block()
-    };
 
 }

--- a/packages/langium-railroad/src/railroad-types.d.ts
+++ b/packages/langium-railroad/src/railroad-types.d.ts
@@ -1,0 +1,208 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+declare module 'railroad-diagrams' {
+
+    export type Direction = 'cw' | 'ccw';
+    export type CardinalDirection = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw';
+    export type DiagramItem = FakeSVG | string;
+
+    export class FakeSVG {
+        needsSpace: boolean;
+        up: number;
+        down: number;
+        height: number;
+        width: number;
+        tagName: string;
+        attrs: Record<string, string>;
+        children: DiagramItem[] | string;
+        constructor(tagName: string, attrs?: Record<string, string>, text?: DiagramItem[]);
+        format(x: number, y: number, width: number): this;
+        addTo(parent: unknown): this;
+        toString(): string;
+        walk(cb: (item: this) => void): void;
+    }
+
+    export class Path extends FakeSVG {
+        constructor(x: number, y: number);
+        m(x: number, y: number): this;
+        h(val: number): this;
+        right(val: number): this;
+        left(val: number): this;
+        v(val: number): this;
+        down(val: number): this;
+        up(val: number): this;
+        arc(sweep: number): this;
+        arc_8(start: CardinalDirection, dir: Direction): this;
+        l(x: number, y: number): this;
+        format(): this;
+    }
+
+    export class DiagramMultiContainer extends FakeSVG {
+        items: DiagramItem[];
+        constructor(tagName: string, items: DiagramItem[], attrs?: Record<string, string>, text?: string);
+    }
+
+    export class Diagram extends DiagramMultiContainer {
+        formatted: boolean;
+        constructor(items: DiagramItem[]);
+        format(paddingt?: number, paddingr?: number, paddingb?: number, paddingl?: number): this;
+        toStandalone(style?: string): string;
+    }
+
+    export class ComplexDiagram extends FakeSVG {
+        constructor(items: DiagramItem[]): Diagram;
+    }
+
+    export class Sequence extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class Stack extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class OptionalSequence extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class AlternatingSequence extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class Choice extends DiagramMultiContainer {
+        constructor(normal: number, items: DiagramItem[]);
+    }
+
+    export class HorizontalChoice extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class MultipleChoice extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class HorizontalChoice extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class HorizontalChoice extends DiagramMultiContainer {
+        constructor(items: DiagramItem[]);
+    }
+
+    export class Optional extends FakeSVG {
+        constructor(item: DiagramItem, skip?: 'skip'): Choice;
+    }
+
+    export class OneOrMore extends FakeSVG {
+        constructor(item: DiagramItem, rep?: DiagramItem);
+    }
+
+    export class ZeroOrMore extends FakeSVG {
+        constructor(item: DiagramItem, rep?: DiagramItem, skip?: 'skip'): Choice;
+    }
+
+    export class Group extends FakeSVG {
+        item: FakeSVG;
+        label?: FakeSVG;
+        constructor(item: DiagramItem, label?: DiagramItem): Choice;
+    }
+
+    type StartOptions = {
+        type?: string;
+        label?: string;
+    }
+
+    export class Start extends FakeSVG {
+        type: string;
+        label?: string;
+        constructor(options?: StartOptions)
+    }
+
+    type EndOptions = {
+        type?: string;
+    }
+
+    export class End extends FakeSVG {
+        type: string;
+        constructor(options?: EndOptions);
+    }
+
+    type TerminalOptions = {
+        href?: string;
+        title?: DiagramItem;
+        cls?: string;
+    }
+
+    export class Terminal extends FakeSVG {
+        text: string;
+        href?: string;
+        title?: DiagramItem;
+        cls?: string;
+        constructor(text: string, options?: TerminalOptions);
+    }
+
+    type NonTerminalOptions = TerminalOptions;
+
+    export class NonTerminal extends FakeSVG {
+        text: string;
+        href?: string;
+        title?: DiagramItem;
+        cls?: string;
+        constructor(text: string, options?: NonTerminalOptions);
+    }
+
+    type CommentOptions = TerminalOptions;
+
+    export class Comment extends FakeSVG {
+        text: string;
+        href?: string;
+        title?: DiagramItem;
+        cls?: string;
+        constructor(text: string, options?: CommentOptions);
+    }
+
+    export class Skip extends FakeSVG {
+        constructor();
+    }
+
+    type BlockOptions = {
+        width?: number;
+        up?: number;
+        height?: number;
+        down?: number;
+        needsSpace?: boolean;
+    }
+
+    export class Block extends FakeSVG {
+        constructor(options?: BlockOptions);
+    }
+
+    export default {
+        Diagram: (args: DiagramItem[]) => new Diagram(),
+        ComplexDiagram: (args: DiagramItem[]) => new ComplexDiagram(),
+        Sequence: (args: DiagramItem[]) => new Sequence(),
+        Stack: (args: DiagramItem[]) => new Stack(),
+        OptionalSequence: (args: DiagramItem[]) => new OptionalSequence(),
+        AlternatingSequence: (args: DiagramItem[]) => new AlternatingSequence(),
+        Choice: (normal: number, args: DiagramItem[]) => new Choice(),
+        HorizontalChoice: (args: DiagramItem[]) => new HorizontalChoice(),
+        MultipleChoice: (args: DiagramItem[]) => new MultipleChoice(),
+        Optional: (item: DiagramItem, skip?: 'skip') => new Choice(),
+        OneOrMore: (item: DiagramItem, rep?: DiagramItem) => new OneOrMore(),
+        ZeroOrMore: (item: DiagramItem, rep?: DiagramItem, skip?: 'skip') => new ZeroOrMore(),
+        Start: (options?: StartOptions) => new Start(),
+        End: (options?: EndOptions) => new End(),
+        Terminal: (text: string, options?: TerminalOptions) => new Terminal(),
+        NonTerminal: (text: string, options?: NonTerminalOptions) => new NonTerminal(),
+        Comment: (text: string, options?: CommentOptions) => new Comment(),
+        Skip: () => new Skip(),
+        Block: (options?: BlockOptions) => new Block()
+    };
+
+}

--- a/packages/langium-railroad/tsconfig.json
+++ b/packages/langium-railroad/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "lib",
+    "node_modules"
+  ]
+}

--- a/packages/langium-sprotty/package.json
+++ b/packages/langium-sprotty/package.json
@@ -26,7 +26,7 @@
     "watch": "tsc --watch",
     "lint": "eslint src --ext .ts",
     "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "langium": "~1.2.0",

--- a/packages/langium-vscode/README.md
+++ b/packages/langium-vscode/README.md
@@ -1,8 +1,9 @@
 # Langium Support for VS Code
 
-This extension contributes a language server for the [Langium](https://langium.org) grammar declaration language. It is built with Langium itself.
+This extension contributes support for the [Langium](https://langium.org) grammar declaration language. The underlying language server is built with Langium itself.
 
-Contributed features:
+## Language Features
+
  * Syntax highlighting
  * Completion
  * Diagnostics
@@ -12,3 +13,9 @@ Contributed features:
  * Document highlighting
  * Document symbols
  * Semantic tokens highlighting
+
+## Syntax Diagrams
+
+Langium grammar files can be visualised as syntax diagrams using the *Show Railroad Syntax Diagram* button that appears in the tab bar of `.langium` files.
+
+![Example Syntax Diagram](https://github.com/langium/langium/assets/4377073/fe50828b-2a2a-474e-b065-8a05b3ce23cf)

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -22,7 +22,7 @@
     "commands": [
       {
         "command": "langium.showRailroadDiagram",
-        "title": "Show railroad syntax diagram",
+        "title": "Show Railroad Syntax Diagram",
         "category": "Langium",
         "icon": "$(list-tree)"
       }

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -19,6 +19,23 @@
     "vscode": "^1.67.0"
   },
   "contributes": {
+    "commands": [
+      {
+        "command": "langium.showRailroadDiagram",
+        "title": "Show railroad syntax diagram",
+        "category": "Langium",
+        "icon": "$(list-tree)"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "langium.showRailroadDiagram",
+          "when": "editorLangId == langium",
+          "group": "navigation"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "langium",
@@ -73,6 +90,7 @@
   },
   "dependencies": {
     "langium": "1.2.0",
+    "langium-railroad": "1.2.0",
     "vscode-languageserver": "~8.0.2",
     "ignore": "~5.2.4"
   },

--- a/packages/langium-vscode/package.json
+++ b/packages/langium-vscode/package.json
@@ -73,7 +73,8 @@
     }
   },
   "activationEvents": [
-    "onLanguage:langium"
+    "onLanguage:langium",
+    "onWebviewPanel:railroadDiagram"
   ],
   "vsce": {
     "dependencies": false

--- a/packages/langium-vscode/src/extension.ts
+++ b/packages/langium-vscode/src/extension.ts
@@ -7,13 +7,14 @@
 import * as vscode from 'vscode';
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node';
+import { registerRailroadWebview } from './railroad-webview';
 
 let client: LanguageClient;
 
 // Called by vscode on activation event, see package.json "activationEvents"
-export function activate(context: vscode.ExtensionContext): void {
-    client = startLanguageClient(context);
-
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    client = await startLanguageClient(context);
+    registerRailroadWebview(client);
     // cs: TODO rework and update the template decoration feature, if feasible
     //  see also https://github.com/langium/langium/issues/841
     // configureTemplateDecoration(context);
@@ -26,7 +27,7 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+async function startLanguageClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
     const serverModule = context.asAbsolutePath('./out/language-server/main');
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
@@ -66,7 +67,7 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     );
 
     // Start the client. This will also launch the server
-    client.start();
+    await client.start();
     return client;
 }
 

--- a/packages/langium-vscode/src/language-server/main.ts
+++ b/packages/langium-vscode/src/language-server/main.ts
@@ -9,7 +9,7 @@ import { createLangiumGrammarServices, startLanguageServer } from 'langium';
 import { NodeFileSystem } from 'langium/node';
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
 import { LangiumGrammarWorkspaceManager } from './grammar-workspace-manager';
-import { registerRailroadHandler } from './railroad-handler';
+import { registerRailroadConnectionHandler } from './railroad-handler';
 
 const connection = createConnection(ProposedFeatures.all);
 
@@ -20,5 +20,5 @@ export const LangiumGrammarSharedModule: Module<LangiumSharedServices, PartialLa
 };
 
 const { shared, grammar } = createLangiumGrammarServices({ connection, ...NodeFileSystem }, LangiumGrammarSharedModule);
-registerRailroadHandler(connection, grammar);
+registerRailroadConnectionHandler(connection, grammar);
 startLanguageServer(shared);

--- a/packages/langium-vscode/src/language-server/main.ts
+++ b/packages/langium-vscode/src/language-server/main.ts
@@ -9,6 +9,7 @@ import { createLangiumGrammarServices, startLanguageServer } from 'langium';
 import { NodeFileSystem } from 'langium/node';
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
 import { LangiumGrammarWorkspaceManager } from './grammar-workspace-manager';
+import { registerRailroadHandler } from './railroad-handler';
 
 const connection = createConnection(ProposedFeatures.all);
 
@@ -18,5 +19,6 @@ export const LangiumGrammarSharedModule: Module<LangiumSharedServices, PartialLa
     }
 };
 
-const { shared } = createLangiumGrammarServices({ connection, ...NodeFileSystem }, LangiumGrammarSharedModule);
+const { shared, grammar } = createLangiumGrammarServices({ connection, ...NodeFileSystem }, LangiumGrammarSharedModule);
+registerRailroadHandler(connection, grammar);
 startLanguageServer(shared);

--- a/packages/langium-vscode/src/language-server/messages.ts
+++ b/packages/langium-vscode/src/language-server/messages.ts
@@ -1,0 +1,8 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+export const DOCUMENTS_VALIDATED_NOTIFICATION = 'documentsValidated';
+export const RAILROAD_DIAGRAM_REQUEST = 'railroadDiagram';

--- a/packages/langium-vscode/src/language-server/railroad-handler.ts
+++ b/packages/langium-vscode/src/language-server/railroad-handler.ts
@@ -29,7 +29,11 @@ export function registerRailroadConnectionHandler(connection: Connection, servic
                 return undefined;
             }
             const generatedRailroadHtml = createGrammarDiagramHtml(document.parseResult.value as Grammar, {
-                javascript: `const vscode = acquireVsCodeApi(); vscode.setState(${JSON.stringify(uri)});`
+                // Setting the state to the current uri allows us to open the webview on vscode restart
+                javascript: `
+                    const vscode = acquireVsCodeApi();
+                    vscode.setState(${JSON.stringify(uri)});
+                `
             });
             return generatedRailroadHtml;
         } catch {

--- a/packages/langium-vscode/src/language-server/railroad-handler.ts
+++ b/packages/langium-vscode/src/language-server/railroad-handler.ts
@@ -1,0 +1,36 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { Grammar, LangiumServices } from 'langium';
+import { DocumentState } from 'langium';
+import type { Connection} from 'vscode-languageserver';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
+import { DOCUMENTS_VALIDATED_NOTIFICATION, RAILROAD_DIAGRAM_REQUEST } from './messages';
+import { createGrammarDiagramHtml } from 'langium-railroad';
+
+export function registerRailroadHandler(connection: Connection, services: LangiumServices): void {
+    const documentBuilder = services.shared.workspace.DocumentBuilder;
+    const documents = services.shared.workspace.LangiumDocuments;
+    documentBuilder.onBuildPhase(DocumentState.Validated, documents => {
+        const uris = documents.map(e => e.uri.toString());
+        connection.sendNotification(DOCUMENTS_VALIDATED_NOTIFICATION, uris);
+    });
+    connection.onRequest(RAILROAD_DIAGRAM_REQUEST, (uri: string) => {
+        try {
+            const parsedUri = URI.parse(uri);
+            const document = documents.getOrCreateDocument(parsedUri);
+            if (document.diagnostics?.some(e => e.severity === DiagnosticSeverity.Error)) {
+                return undefined;
+            }
+            const generatedRailroadHtml = createGrammarDiagramHtml(document.parseResult.value as Grammar);
+            return generatedRailroadHtml;
+        } catch {
+            // Document couldn't be found or uri was invalid, just return nothing
+            return undefined;
+        }
+    });
+}

--- a/packages/langium-vscode/src/railroad-webview.ts
+++ b/packages/langium-vscode/src/railroad-webview.ts
@@ -9,8 +9,10 @@ import type { LanguageClient } from 'vscode-languageclient/node';
 import { DOCUMENTS_VALIDATED_NOTIFICATION, RAILROAD_DIAGRAM_REQUEST } from './language-server/messages';
 
 export function registerRailroadWebview(client: LanguageClient): void {
-    vscode.commands.registerCommand('langium.showRailroadDiagram', (uri: vscode.Uri) => {
-        RailroadDiagramPanel.createOrShow(client, uri);
+    vscode.commands.registerCommand('langium.showRailroadDiagram', (uri?: vscode.Uri) => {
+        if (uri instanceof vscode.Uri) {
+            RailroadDiagramPanel.createOrShow(client, uri);
+        }
     });
     client.onNotification(DOCUMENTS_VALIDATED_NOTIFICATION, (uris: string[]) => {
         if (RailroadDiagramPanel.current && uris.includes(RailroadDiagramPanel.current.uri)) {

--- a/packages/langium-vscode/src/railroad-webview.ts
+++ b/packages/langium-vscode/src/railroad-webview.ts
@@ -35,6 +35,9 @@ class RailroadDiagramSerializer implements vscode.WebviewPanelSerializer {
         if (typeof state === 'string') {
             const uri = vscode.Uri.parse(state);
             RailroadDiagramPanel.revive(webviewPanel, this.client, uri);
+        } else {
+            // Invalid state, just close the webview
+            webviewPanel.dispose();
         }
         return Promise.resolve();
     }
@@ -75,6 +78,9 @@ export class RailroadDiagramPanel implements vscode.Disposable {
         this.uri = uri.toString();
         this.client = client;
         this.panel = panel;
+        this.panel.webview.options = {
+            enableScripts: true
+        };
         vscode.window.onDidChangeActiveTextEditor(e => {
             if (e?.document.uri.path.endsWith('.langium')) {
                 this.update(e.document.uri.toString());

--- a/packages/langium-vscode/src/railroad-webview.ts
+++ b/packages/langium-vscode/src/railroad-webview.ts
@@ -53,7 +53,7 @@ export class RailroadDiagramPanel implements vscode.Disposable {
     private disposables: vscode.Disposable[] = [];
 
     static current?: RailroadDiagramPanel;
-    static readonly viewType = 'railroadDiagram';
+    static readonly viewType = 'LangiumRailroadDiagram';
 
     static createOrShow(client: LanguageClient, fileUri: vscode.Uri): void {
         if (this.current) {

--- a/packages/langium-vscode/src/railroad-webview.ts
+++ b/packages/langium-vscode/src/railroad-webview.ts
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import * as vscode from 'vscode';
+import type { LanguageClient } from 'vscode-languageclient/node';
+import { DOCUMENTS_VALIDATED_NOTIFICATION, RAILROAD_DIAGRAM_REQUEST } from './language-server/messages';
+
+export function registerRailroadWebview(client: LanguageClient): void {
+    vscode.commands.registerCommand('langium.showRailroadDiagram', (uri: vscode.Uri) => {
+        RailroadDiagramPanel.createOrShow(client, uri);
+    });
+    client.onNotification(DOCUMENTS_VALIDATED_NOTIFICATION, (uris: string[]) => {
+        if (RailroadDiagramPanel.current && uris.includes(RailroadDiagramPanel.current.uri)) {
+            RailroadDiagramPanel.current.update();
+        }
+    });
+}
+
+export class RailroadDiagramPanel implements vscode.Disposable {
+
+    uri: string;
+    client: LanguageClient;
+    panel: vscode.WebviewPanel;
+
+    private disposables: vscode.Disposable[] = [];
+
+    static current?: RailroadDiagramPanel;
+
+    static viewType = 'railroadDiagram';
+
+    static createOrShow(client: LanguageClient, fileUri: vscode.Uri): void {
+        if (this.current) {
+            this.current?.update(fileUri.toString());
+            return;
+        }
+        const panel = vscode.window.createWebviewPanel(
+            RailroadDiagramPanel.viewType,
+            'Railroad Diagram ' + getFileName(fileUri.path),
+            vscode.ViewColumn.Beside,
+        );
+        this.current = new RailroadDiagramPanel(client, panel, fileUri);
+        this.current.update();
+    }
+
+    constructor(client: LanguageClient, panel: vscode.WebviewPanel, uri: vscode.Uri) {
+        this.uri = uri.toString();
+        this.client = client;
+        this.panel = panel;
+        vscode.window.onDidChangeActiveTextEditor(e => {
+            if (e?.document.uri.path.endsWith('.langium')) {
+                this.update(e.document.uri.toString());
+            }
+        }, undefined, this.disposables);
+        panel.onDidDispose(() => {
+            this.dispose();
+        }, undefined, this.disposables);
+    }
+
+    dispose() {
+        RailroadDiagramPanel.current = undefined;
+        this.disposables.forEach(e => e.dispose());
+    }
+
+    async update(uri?: string): Promise<void> {
+        if (uri) {
+            this.uri = uri;
+        }
+        try {
+            this.panel.title = 'Railroad Diagram ' + getFileName(this.uri);
+            const railroad: string | undefined = await this.client.sendRequest(RAILROAD_DIAGRAM_REQUEST, this.uri);
+            if (railroad) {
+                this.panel.webview.html = railroad;
+            }
+        } catch {
+            // Failed updating the webview
+            // It might already be disposed
+        }
+    }
+
+}
+
+function getFileName(uri: string): string {
+    return uri.substring(uri.lastIndexOf('/') + 1);
+}

--- a/packages/langium-vscode/src/railroad-webview.ts
+++ b/packages/langium-vscode/src/railroad-webview.ts
@@ -10,6 +10,7 @@ import { DOCUMENTS_VALIDATED_NOTIFICATION, RAILROAD_DIAGRAM_REQUEST } from './la
 
 export function registerRailroadWebview(client: LanguageClient): void {
     vscode.commands.registerCommand('langium.showRailroadDiagram', (uri?: vscode.Uri) => {
+        uri ??= vscode.window.activeTextEditor?.document.uri;
         if (uri instanceof vscode.Uri) {
             RailroadDiagramPanel.createOrShow(client, uri);
         }

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint src test --ext .ts",
     "langium:generate": "langium generate",
     "publish:next": "npm --no-git-tag-version version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" && npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "chevrotain": "~10.4.2",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,6 +4,7 @@
     "references": [
         { "path": "packages/langium" },
         { "path": "packages/langium/tsconfig.test.json" },
+        { "path": "packages/langium-railroad" },
         { "path": "packages/langium-cli" },
         { "path": "packages/langium-cli/tsconfig.test.json" },
         { "path": "packages/langium-sprotty" },


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/827
Closes https://github.com/langium/langium/issues/1062

This change introduces a new package, `langium-railroad` that is able to generate railroad syntax diagrams from Langium grammars. The package is reused in `langium-cli` and `langium-vscode`:

1. To generate a railroad html file for each entry grammar (if specified in the langium-config.json).
2. Adds a preview command to the current langium editor that shows a webview with the railroad syntax diagram for the currently selected langium editor.

The vscode webview follows the current editor and updates on changes to the grammar file.

The new `langium-railroad` package can also be used in the playground for an inline syntax diagram view of the current grammar.