### PR TITLE
Add support for langium-cli mode

### DIFF
--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -134,6 +134,11 @@
             "description": "File extension used for TypeScript import statements. Empty by default",
             "type": "string"
         },
+        "mode": {
+            "description": "Mode for generating optimized code for the current environment",
+            "type": "string",
+            "enum": ["development", "production"]
+        },
         "chevrotainParserConfig": {
             "$ref": "#/$defs/chevrotainParserConfig"
         },

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -25,7 +25,7 @@ import fs from 'fs-extra';
 
 export type GenerateOptions = {
     file?: string;
-    mode?: string;
+    mode?: 'development' | 'production';
     watch: boolean;
 }
 
@@ -167,6 +167,9 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
             files: []
         };
     }
+    if (options.mode) {
+        config.mode = options.mode;
+    }
     const all = await buildAll(config);
     const buildResult: (success: boolean) => GeneratorResult = (success: boolean) => ({
         success,
@@ -246,7 +249,7 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
     const genAst = generateAst(grammarServices, grammars, config);
     await writeWithFail(path.resolve(output, 'ast.ts'), genAst, options);
 
-    const serializedGrammar = serializeGrammar(grammarServices, grammars, config, options);
+    const serializedGrammar = serializeGrammar(grammarServices, grammars, config);
     await writeWithFail(path.resolve(output, 'grammar.ts'), serializedGrammar, options);
 
     const genModule = generateModule(grammars, config, configMap);

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -25,7 +25,8 @@ import fs from 'fs-extra';
 
 export type GenerateOptions = {
     file?: string;
-    watch: boolean
+    mode?: string;
+    watch: boolean;
 }
 
 export type ExtractTypesOptions = {
@@ -245,7 +246,7 @@ export async function generate(config: LangiumConfig, options: GenerateOptions):
     const genAst = generateAst(grammarServices, grammars, config);
     await writeWithFail(path.resolve(output, 'ast.ts'), genAst, options);
 
-    const serializedGrammar = serializeGrammar(grammarServices, grammars, config);
+    const serializedGrammar = serializeGrammar(grammarServices, grammars, config, options);
     await writeWithFail(path.resolve(output, 'grammar.ts'), serializedGrammar, options);
 
     const genModule = generateModule(grammars, config, configMap);

--- a/packages/langium-cli/src/generator/grammar-serializer.ts
+++ b/packages/langium-cli/src/generator/grammar-serializer.ts
@@ -3,6 +3,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
+
 import type { Grammar, LangiumServices } from 'langium';
 import type { LangiumConfig } from '../package';
 import { CompositeGeneratorNode, NL, normalizeEOL, toString } from 'langium';
@@ -31,7 +32,9 @@ export function serializeGrammar(services: LangiumServices, grammars: Grammar[],
             const delimiter = production ? "'" : '`';
             // The json serializer returns strings with \n line delimiter by default
             // We need to translate these line endings to the OS specific line ending
-            const json = normalizeEOL(services.serializer.JsonSerializer.serialize(grammar, production ? undefined : { space: 2 }).replace(/\\/g, '\\\\').replace(/`/g, '\\`'));
+            const json = normalizeEOL(services.serializer.JsonSerializer.serialize(grammar, production ? undefined : { space: 2 })
+                .replace(/\\/g, '\\\\')
+                .replace(new RegExp(delimiter, 'g'), '\\' + delimiter));
             node.append(
                 'let loaded', grammar.name, 'Grammar: Grammar | undefined;', NL,
                 'export const ', grammar.name, 'Grammar = (): Grammar => loaded', grammar.name, 'Grammar ?? (loaded', grammar.name, 'Grammar = loadGrammarFromJson(', delimiter, json, delimiter, '));', NL

--- a/packages/langium-cli/src/generator/grammar-serializer.ts
+++ b/packages/langium-cli/src/generator/grammar-serializer.ts
@@ -8,9 +8,8 @@ import type { Grammar, LangiumServices } from 'langium';
 import type { LangiumConfig } from '../package';
 import { CompositeGeneratorNode, NL, normalizeEOL, toString } from 'langium';
 import { generatedHeader } from './util';
-import type { GenerateOptions } from '../generate';
 
-export function serializeGrammar(services: LangiumServices, grammars: Grammar[], config: LangiumConfig, options: GenerateOptions): string {
+export function serializeGrammar(services: LangiumServices, grammars: Grammar[], config: LangiumConfig): string {
     const node = new CompositeGeneratorNode();
     node.append(generatedHeader);
 
@@ -28,7 +27,7 @@ export function serializeGrammar(services: LangiumServices, grammars: Grammar[],
     for (let i = 0; i < grammars.length; i++) {
         const grammar = grammars[i];
         if (grammar.name) {
-            const production = (options.mode ?? config.mode) === 'production';
+            const production = config.mode === 'production';
             const delimiter = production ? "'" : '`';
             // The json serializer returns strings with \n line delimiter by default
             // We need to translate these line endings to the OS specific line ending

--- a/packages/langium-cli/src/langium.ts
+++ b/packages/langium-cli/src/langium.ts
@@ -7,7 +7,7 @@ import type { ExtractTypesOptions, GenerateOptions, GeneratorResult } from './ge
 import type { LangiumConfig } from './package';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { validate } from 'jsonschema';
 import { generate, generateTypes } from './generate';
 import { cliVersion, elapsedTime, getTime, log, schema } from './generator/util';
@@ -20,7 +20,7 @@ program
     .description('Generate code for a Langium grammar')
     .option('-f, --file <file>', 'the configuration file or package.json setting up the generator')
     .option('-w, --watch', 'enables watch mode', false)
-    .option('-m, --mode <mode>', 'use `development` or `production` for optimized builds for your current environment')
+    .addOption(new Option('-m, --mode <mode>', 'used mode for optimized builds for your current environment').choices(['development', 'production']))
     .action((options: GenerateOptions) => {
         runGenerator(options).catch(err => {
             console.error(err);

--- a/packages/langium-cli/src/langium.ts
+++ b/packages/langium-cli/src/langium.ts
@@ -20,6 +20,7 @@ program
     .description('Generate code for a Langium grammar')
     .option('-f, --file <file>', 'the configuration file or package.json setting up the generator')
     .option('-w, --watch', 'enables watch mode', false)
+    .option('-m, --mode <mode>', 'use `development` or `production` for optimized builds for your current environment')
     .action((options: GenerateOptions) => {
         runGenerator(options).catch(err => {
             console.error(err);

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -31,6 +31,8 @@ export interface LangiumConfig {
     out?: string
     /** File extension for import statements of generated files */
     importExtension?: string
+    /** Mode used to generate optimized files for development or production environments */
+    mode?: 'development' | 'production';
     /** Configure the chevrotain parser for all languages */
     chevrotainParserConfig?: IParserConfig,
     /** The following option is meant to be used only by Langium itself */


### PR DESCRIPTION
To improve bundle size when building a Langium based language server/parser, generating more succinct code is beneficial. This change adds a `--mode` argument for generating a compressed version of the grammar json.