### PR TITLE
fix(generator): prevent copied `syntaxes` from being  `syntaxes` child dir

### DIFF
--- a/packages/generator-langium/templates/web/.package.json
+++ b/packages/generator-langium/templates/web/.package.json
@@ -4,7 +4,7 @@
         "prepare:public": "shx mkdir -p ./public && shx cp -fr ./src/static/* ./public/",
         "copy:monaco-editor-wrapper": "shx cp -fr ./node_modules/monaco-editor-wrapper/bundle ./public/monaco-editor-wrapper",
         "copy:monaco-workers": "shx cp -fr ./node_modules/monaco-editor-workers/dist/ ./public/monaco-editor-workers",
-        "copy:monarch-syntax": "shx cp -fr ./out/syntaxes/ ./public/syntaxes",
+        "copy:monarch-syntax": "shx cp -fr ./out/syntaxes/ ./public/",
         "build:web": "npm run build && npm run build:monarch && npm run prepare:public && npm run build:worker && npm run copy:monaco-editor-wrapper && npm run copy:monaco-workers && npm run copy:monarch-syntax",
         "build:monarch": "tsc -b tsconfig.monarch.json",
         "serve": "node ./out/web/app.js"

--- a/packages/generator-langium/templates/web/.package.json
+++ b/packages/generator-langium/templates/web/.package.json
@@ -4,7 +4,7 @@
         "prepare:public": "shx mkdir -p ./public && shx cp -fr ./src/static/* ./public/",
         "copy:monaco-editor-wrapper": "shx cp -fr ./node_modules/monaco-editor-wrapper/bundle ./public/monaco-editor-wrapper",
         "copy:monaco-workers": "shx cp -fr ./node_modules/monaco-editor-workers/dist/ ./public/monaco-editor-workers",
-        "copy:monarch-syntax": "shx cp -fr ./out/syntaxes/ ./public/",
+        "copy:monarch-syntax": "shx cp -fr ./out/syntaxes ./public/syntaxes",
         "build:web": "npm run build && npm run build:monarch && npm run prepare:public && npm run build:worker && npm run copy:monaco-editor-wrapper && npm run copy:monaco-workers && npm run copy:monarch-syntax",
         "build:monarch": "tsc -b tsconfig.monarch.json",
         "serve": "node ./out/web/app.js"


### PR DESCRIPTION
When executing the `copy:monarch-syntax` script, it performs the following:

```
public/
├── ...
├── syntaxes/                       # old from HelloWorld example
│   ├── language.monarch.js         # old from HelloWorld example
│   ├── language.monarch.js.map     # old from HelloWorld example
│   │
│   └── syntaxes/                   # new from actual grammar
│       ├── language.monarch.js     # new from actual grammar
│       └── language.monarch.js.map # new from actual grammar
└── ...
```

Whereas is should be:

```
public/
├── ...
├── syntaxes/                   # new from actual grammar
│   ├── language.monarch.js     # new from actual grammar
│   └── language.monarch.js.map # new from actual grammar
└── ...
```
