### PR TITLE
Use `RootCstNode` for root node property

### DIFF
--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -219,7 +219,7 @@ export interface CstNode extends DocumentSegment {
     /** The actual text */
     readonly text: string;
     /** The root CST node */
-    readonly root: CompositeCstNode;
+    readonly root: RootCstNode;
     /** The grammar element from which this node was parsed */
     readonly feature: AbstractElement;
     /** The AST node created from this CST node */


### PR DESCRIPTION
We already assume that the `root` property is a root node [here](https://github.com/langium/langium/blob/0cd59e78a0b8e1dd681a379df2f1c06debee514a/packages/langium/src/parser/cst-node-builder.ts#L109). This fact wasn't reflected in the type yet.