### PR TITLE
Perform name segment resolving lazily

### DIFF
--- a/packages/langium/src/grammar/references/grammar-scope.ts
+++ b/packages/langium/src/grammar/references/grammar-scope.ts
@@ -9,7 +9,7 @@ import type { LangiumServices } from '../../services';
 import type { AstNode, AstNodeDescription, ReferenceInfo } from '../../syntax-tree';
 import type { Stream } from '../../utils/stream';
 import type { AstNodeLocator } from '../../workspace/ast-node-locator';
-import type { LangiumDocument, PrecomputedScopes } from '../../workspace/documents';
+import type { DocumentSegment, LangiumDocument, PrecomputedScopes } from '../../workspace/documents';
 import { DefaultScopeComputation } from '../../references/scope-computation';
 import { DefaultScopeProvider, EMPTY_SCOPE, StreamScope } from '../../references/scope-provider';
 import { findRootNode, getContainerOfType, getDocument, streamAllContents } from '../../utils/ast-util';
@@ -132,11 +132,14 @@ export class LangiumGrammarScopeComputation extends DefaultScopeComputation {
     }
 
     protected createInterfaceDescription(node: AstNode, name: string, document: LangiumDocument = getDocument(node)): AstNodeDescription {
-        const nameNode = this.nameProvider.getNameNode(node) ?? node.$cstNode;
+        let nameNodeSegment: DocumentSegment | undefined;
+        const nameSegmentGetter = () => nameNodeSegment ??= toDocumentSegment(this.nameProvider.getNameNode(node) ?? node.$cstNode);
         return {
             node,
             name,
-            nameSegment: toDocumentSegment(nameNode),
+            get nameSegment() {
+                return nameSegmentGetter();
+            },
             selectionSegment: toDocumentSegment(node.$cstNode),
             type: 'Interface',
             documentUri: document.uri,

--- a/packages/langium/src/workspace/ast-descriptions.ts
+++ b/packages/langium/src/workspace/ast-descriptions.ts
@@ -52,11 +52,14 @@ export class DefaultAstNodeDescriptionProvider implements AstNodeDescriptionProv
         if (!name) {
             throw new Error(`Node at path ${path} has no name.`);
         }
-        const nameNode = this.nameProvider.getNameNode(node) ?? node.$cstNode;
+        let nameNodeSegment: DocumentSegment | undefined;
+        const nameSegmentGetter = () => nameNodeSegment ??= toDocumentSegment(this.nameProvider.getNameNode(node) ?? node.$cstNode);
         return {
             node,
             name,
-            nameSegment: toDocumentSegment(nameNode),
+            get nameSegment() {
+                return nameSegmentGetter();
+            },
             selectionSegment: toDocumentSegment(node.$cstNode),
             type: node.$type,
             documentUri: document.uri,


### PR DESCRIPTION
The current AST descriptions all contain the `nameSegment`, which is rarely used, but fairly costly to compute. This change makes the value lazily evaluated.