### PR TITLE
Refactored document builder and affected analysis

### DIFF
--- a/examples/arithmetics/src/cli/cli-util.ts
+++ b/examples/arithmetics/src/cli/cli-util.ts
@@ -22,7 +22,7 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
+    await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {

--- a/examples/domainmodel/src/cli/cli-util.ts
+++ b/examples/domainmodel/src/cli/cli-util.ts
@@ -23,7 +23,7 @@ export async function extractDocument<T extends AstNode>(fileName: string, exten
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
+    await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {

--- a/examples/domainmodel/src/language-server/domain-model-naming.ts
+++ b/examples/domainmodel/src/language-server/domain-model-naming.ts
@@ -25,7 +25,7 @@ export class QualifiedNameProvider {
             prefix = (isPackageDeclaration(prefix.$container)
                 ? this.getQualifiedName(prefix.$container, prefix.name) : prefix.name);
         }
-        return (prefix ? prefix + '.' : '') + name;
+        return prefix ? prefix + '.' + name : name;
     }
 
 }

--- a/examples/domainmodel/src/language-server/domain-model-scope.ts
+++ b/examples/domainmodel/src/language-server/domain-model-scope.ts
@@ -52,7 +52,7 @@ export class DomainModelScopeComputation extends DefaultScopeComputation {
         const localDescriptions: AstNodeDescription[] = [];
         for (const element of container.elements) {
             await interruptAndCheck(cancelToken);
-            if (isType(element)) {
+            if (isType(element) && element.name) {
                 const description = this.descriptions.createDescription(element, element.name, document);
                 localDescriptions.push(description);
             } else if (isPackageDeclaration(element)) {

--- a/examples/requirements/src/cli/cli-util.ts
+++ b/examples/requirements/src/cli/cli-util.ts
@@ -40,7 +40,7 @@ export async function extractDocuments(fileName: string, services: LangiumServic
     await services.shared.workspace.WorkspaceManager.initializeWorkspace(folders);
 
     const documents = services.shared.workspace.LangiumDocuments.all.toArray();
-    await services.shared.workspace.DocumentBuilder.build(documents, { validationChecks: 'all' });
+    await services.shared.workspace.DocumentBuilder.build(documents, { validation: true });
 
     documents.forEach(document => {
         const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);

--- a/examples/statemachine/src/cli/cli-util.ts
+++ b/examples/statemachine/src/cli/cli-util.ts
@@ -22,7 +22,7 @@ export async function extractDocument(fileName: string, extensions: string[], se
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
+    await services.shared.workspace.DocumentBuilder.build([document], { validation: true });
 
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {

--- a/packages/langium-cli/src/generate.ts
+++ b/packages/langium-cli/src/generate.ts
@@ -136,7 +136,7 @@ async function relinkGrammars(grammars: Grammar[]): Promise<void> {
         return newDoc;
     });
     newDocuments.forEach(e => langiumDocuments.addDocument(e));
-    await documentBuilder.build(newDocuments, { validationChecks: 'none' });
+    await documentBuilder.build(newDocuments, { validation: false });
 }
 
 async function buildAll(config: LangiumConfig): Promise<Map<string, LangiumDocument>> {
@@ -155,7 +155,7 @@ async function buildAll(config: LangiumConfig): Promise<Map<string, LangiumDocum
         map.set(doc.uri.fsPath, doc);
     }
     await sharedServices.workspace.DocumentBuilder.build(documents.all.toArray(), {
-        validationChecks: 'all'
+        validation: true
     });
     return map;
 }

--- a/packages/langium/src/references/linker.ts
+++ b/packages/langium/src/references/linker.ts
@@ -19,9 +19,11 @@ import { DocumentState } from '../workspace/documents';
  * Language-specific service for resolving cross-references in the AST.
  */
 export interface Linker {
+
     /**
      * Links all cross-references within the specified document. The default implementation loads only target
-     * elements from documents that are present in the `LangiumDocuments` service.
+     * elements from documents that are present in the `LangiumDocuments` service. The linked references are
+     * stored in the document's `references` property.
      *
      * @param document A LangiumDocument that shall be linked.
      * @param cancelToken A token for cancelling the operation.
@@ -62,6 +64,7 @@ export interface Linker {
      * @returns the desired Reference node, whose behavior wrt. resolving the cross reference is implementation specific.
      */
     buildReference(node: AstNode, property: string, refNode: CstNode | undefined, refText: string): Reference;
+
 }
 
 interface DefaultReference extends Reference {
@@ -87,7 +90,6 @@ export class DefaultLinker implements Linker {
             await interruptAndCheck(cancelToken);
             streamReferences(node).forEach(ref => this.doLink(ref, document));
         }
-        document.state = DocumentState.Linked;
     }
 
     protected doLink(refInfo: ReferenceInfo, document: LangiumDocument): void {

--- a/packages/langium/src/test/langium-test.ts
+++ b/packages/langium/src/test/langium-test.ts
@@ -449,7 +449,7 @@ export interface ValidationResult<T extends AstNode = AstNode> {
 export function validationHelper<T extends AstNode = AstNode>(services: LangiumServices): (input: string) => Promise<ValidationResult<T>> {
     const parse = parseHelper<T>(services);
     return async (input) => {
-        const document = await parse(input, { validationChecks: 'all' });
+        const document = await parse(input, { validation: true });
         return { document, diagnostics: document.diagnostics ?? [] };
     };
 }

--- a/packages/langium/src/utils/grammar-util.ts
+++ b/packages/langium/src/utils/grammar-util.ts
@@ -312,7 +312,7 @@ export async function createServicesForGrammar(config: {
         : getDocument(config.grammar);
     const grammarNode = grammarDocument.parseResult.value as ast.Grammar;
     const documentBuilder = grammarServices.shared.workspace.DocumentBuilder;
-    await documentBuilder.build([grammarDocument], { validationChecks: 'none' });
+    await documentBuilder.build([grammarDocument], { validation: false });
 
     const parserConfig = config.parserConfig ?? {
         skipValidations: false

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -23,9 +23,9 @@ export interface ValidationOptions {
     category?: ValidationCategory
     /** If true, no further diagnostics are reported if there are lexing errors. */
     stopAfterLexingErrors?: boolean
-    /** If true, no further diagnostics are reported if there are lexing or parsing errors. */
+    /** If true, no further diagnostics are reported if there are parsing errors. */
     stopAfterParsingErrors?: boolean
-    /** If true, no further diagnostics are reported if there are lexing, parsing or linking errors. */
+    /** If true, no further diagnostics are reported if there are linking errors. */
     stopAfterLinkingErrors?: boolean
 }
 
@@ -61,17 +61,17 @@ export class DefaultDocumentValidator implements DocumentValidator {
         await interruptAndCheck(cancelToken);
 
         this.processLexingErrors(parseResult, diagnostics, options);
-        if (options.stopAfterLexingErrors && diagnostics.length > 0) {
+        if (options.stopAfterLexingErrors && diagnostics.some(d => d.code === DocumentValidator.LexingError)) {
             return diagnostics;
         }
 
         this.processParsingErrors(parseResult, diagnostics, options);
-        if (options.stopAfterParsingErrors && diagnostics.length > 0) {
+        if (options.stopAfterParsingErrors && diagnostics.some(d => d.code === DocumentValidator.ParsingError)) {
             return diagnostics;
         }
 
         this.processLinkingErrors(document, diagnostics, options);
-        if (options.stopAfterLinkingErrors && diagnostics.length > 0) {
+        if (options.stopAfterLinkingErrors && diagnostics.some(d => d.code === DocumentValidator.LinkingError)) {
             return diagnostics;
         }
 

--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -19,7 +19,10 @@ import { tokenToRange } from '../utils/cst-util';
 import { interruptAndCheck, isOperationCancelled } from '../utils/promise-util';
 
 export interface ValidationOptions {
-    /** If this is set, only the checks associated with this category are executed; otherwise all checks are executed. */
+    /**
+     * If this is set, only the checks associated with this category are executed; otherwise
+     * all checks are executed. The default category if not specified is `'fast'`.
+     */
     category?: ValidationCategory
     /** If true, no further diagnostics are reported if there are lexing errors. */
     stopAfterLexingErrors?: boolean

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -59,6 +59,13 @@ export type ValidationChecks<T> = {
     AstNode?: ValidationCheck<AstNode>;
 }
 
+/**
+ * `fast` checks can be executed after every document change (i.e. as the user is typing). If a check
+ * is too slow it can delay the response to document changes, yielding bad user experience. By marking
+ * it as `slow`, it will be skipped for normal as-you-type validation. Then it's up to you when to
+ * schedule these long-running checks: after the fast checks are done, or after saving a document,
+ * or with an explicit command, etc.
+ */
 export type ValidationCategory = 'fast' | 'slow'
 
 type ValidationCheckEntry = {

--- a/packages/langium/src/validation/validation-registry.ts
+++ b/packages/langium/src/validation/validation-registry.ts
@@ -72,7 +72,7 @@ export type ValidationChecks<T> = {
 export type ValidationCategory = 'fast' | 'slow' | 'built-in'
 
 export namespace ValidationCategory {
-    export const all: ValidationCategory[] = ['fast', 'slow', 'built-in'];
+    export const all: readonly ValidationCategory[] = ['fast', 'slow', 'built-in'];
 }
 
 type ValidationCheckEntry = {

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -19,11 +19,19 @@ import { stream } from '../utils/stream';
 import { DocumentState } from './documents';
 
 export interface BuildOptions {
+    /**
+     * Control the validation phase with this option:
+     *  - `true` enables all validation checks
+     *  - An object with the `category` property enables a subset of validation checks
+     *  - `false` or `undefined` disables all validation checks
+     */
     validation?: boolean | ValidationOptions
 }
 
 export interface DocumentBuildState {
+    /** Whether a document has completed its last build process. */
     completed: boolean
+    /** The options used for the last build process. */
     options: BuildOptions
 }
 
@@ -206,8 +214,8 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
             this.indexManager.updateReferences(doc, cancelToken)
         );
         // 5. Validation
-        const validateDocs = documents.filter(doc => this.shouldValidate(doc));
-        await this.runCancelable(validateDocs, DocumentState.Validated, cancelToken, doc =>
+        const toBeValidated = documents.filter(doc => this.shouldValidate(doc));
+        await this.runCancelable(toBeValidated, DocumentState.Validated, cancelToken, doc =>
             this.validate(doc, cancelToken)
         );
 
@@ -264,7 +272,8 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
 
     /**
      * Determine whether the given document should be validated during a build. The default
-     * implementation checks the `validation` property of the build options.
+     * implementation checks the `validation` property of the build options. If it's set to `true`
+     * or a `ValidationOptions` object, the document is included in the validation phase.
      */
     protected shouldValidate(document: LangiumDocument): boolean {
         return Boolean(this.getBuildOptions(document).validation);

--- a/packages/langium/src/workspace/document-builder.ts
+++ b/packages/langium/src/workspace/document-builder.ts
@@ -95,6 +95,9 @@ export class DefaultDocumentBuilder implements DocumentBuilder {
     }
 
     async build<T extends AstNode>(documents: Array<LangiumDocument<T>>, options: BuildOptions = {}, cancelToken = CancellationToken.None): Promise<void> {
+        for (const document of documents) {
+            this.buildState.delete(document.uri.toString());
+        }
         await this.buildDocuments(documents, options, cancelToken);
     }
 

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -13,7 +13,6 @@ import type { AstNode, AstNodeDescription, Reference } from '../syntax-tree';
 import type { Mutable } from '../utils/ast-util';
 import type { MultiMap } from '../utils/collections';
 import type { Stream } from '../utils/stream';
-import type { BuildOptions } from './document-builder';
 import type { FileSystemProvider } from './file-system-provider';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
@@ -32,10 +31,6 @@ export interface LangiumDocument<T extends AstNode = AstNode> {
     state: DocumentState;
     /** The parse result holds the Abstract Syntax Tree (AST) and potentially also parser / lexer errors */
     parseResult: ParseResult<T>;
-    /** The presence of this property indicates that a build was started without finishing (yet) */
-    build?: {
-        options: BuildOptions
-    }
     /** Result of the scope precomputation phase */
     precomputedScopes?: PrecomputedScopes;
     /** An array of all cross-references found in the AST while linking */
@@ -360,7 +355,6 @@ export class DefaultLangiumDocuments implements LangiumDocuments {
         const langiumDoc = this.documentMap.get(uriString);
         if (langiumDoc) {
             langiumDoc.state = DocumentState.Changed;
-            langiumDoc.build = undefined;
             langiumDoc.precomputedScopes = undefined;
             langiumDoc.references = [];
             langiumDoc.diagnostics = [];

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -242,7 +242,6 @@ export class DefaultLangiumDocumentFactory implements LangiumDocumentFactory {
 
         document.parseResult = this.parse(document.uri, text);
         (document.parseResult.value as Mutable<AstNode>).$document = document;
-        document.state = DocumentState.Parsed;
         return document;
     }
 
@@ -357,7 +356,7 @@ export class DefaultLangiumDocuments implements LangiumDocuments {
             langiumDoc.state = DocumentState.Changed;
             langiumDoc.precomputedScopes = undefined;
             langiumDoc.references = [];
-            langiumDoc.diagnostics = [];
+            langiumDoc.diagnostics = undefined;
         }
         return langiumDoc;
     }

--- a/packages/langium/src/workspace/documents.ts
+++ b/packages/langium/src/workspace/documents.ts
@@ -13,6 +13,7 @@ import type { AstNode, AstNodeDescription, Reference } from '../syntax-tree';
 import type { Mutable } from '../utils/ast-util';
 import type { MultiMap } from '../utils/collections';
 import type { Stream } from '../utils/stream';
+import type { BuildOptions } from './document-builder';
 import type { FileSystemProvider } from './file-system-provider';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
@@ -31,6 +32,10 @@ export interface LangiumDocument<T extends AstNode = AstNode> {
     state: DocumentState;
     /** The parse result holds the Abstract Syntax Tree (AST) and potentially also parser / lexer errors */
     parseResult: ParseResult<T>;
+    /** The presence of this property indicates that a build was started without finishing (yet) */
+    build?: {
+        options: BuildOptions
+    }
     /** Result of the scope precomputation phase */
     precomputedScopes?: PrecomputedScopes;
     /** An array of all cross-references found in the AST while linking */
@@ -355,8 +360,9 @@ export class DefaultLangiumDocuments implements LangiumDocuments {
         const langiumDoc = this.documentMap.get(uriString);
         if (langiumDoc) {
             langiumDoc.state = DocumentState.Changed;
-            langiumDoc.references = [];
+            langiumDoc.build = undefined;
             langiumDoc.precomputedScopes = undefined;
+            langiumDoc.references = [];
             langiumDoc.diagnostics = [];
         }
         return langiumDoc;

--- a/packages/langium/src/workspace/index-manager.ts
+++ b/packages/langium/src/workspace/index-manager.ts
@@ -10,7 +10,7 @@ import type { LangiumSharedServices } from '../services';
 import type { AstNode, AstNodeDescription, AstReflection } from '../syntax-tree';
 import type { Stream } from '../utils/stream';
 import type { ReferenceDescription } from './ast-descriptions';
-import type { LangiumDocument, LangiumDocuments } from './documents';
+import type { LangiumDocument } from './documents';
 import { CancellationToken } from 'vscode-languageserver';
 import { getDocument } from '../utils/ast-util';
 import { stream } from '../utils/stream';
@@ -51,12 +51,14 @@ export interface IndexManager {
     updateReferences(document: LangiumDocument, cancelToken?: CancellationToken): Promise<void>;
 
     /**
-     * Returns all documents that could be affected by changes in the documents
-     * identified by the given URIs.
+     * Determine whether the given document could be affected by changes of the documents
+     * identified by the given URIs (second parameter). The document is typically regarded as
+     * affected if it contains a reference to any of the changed files.
      *
-     * @param uris The document URIs which may affect other documents.
+     * @param document Document to check whether it's affected
+     * @param changedUris URIs of the changed documents
      */
-    getAffectedDocuments(uris: URI[]): Stream<LangiumDocument>;
+    isAffected(document: LangiumDocument, changedUris: Set<string>): boolean;
 
     /**
      * Compute a global scope, optionally filtered using a type identifier.
@@ -81,7 +83,6 @@ export interface IndexManager {
 export class DefaultIndexManager implements IndexManager {
 
     protected readonly serviceRegistry: ServiceRegistry;
-    protected readonly langiumDocuments: () => LangiumDocuments;
     protected readonly astReflection: AstReflection;
 
     protected readonly simpleIndex: Map<string, AstNodeDescription[]> = new Map<string, AstNodeDescription[]>();
@@ -91,7 +92,6 @@ export class DefaultIndexManager implements IndexManager {
     constructor(services: LangiumSharedServices) {
         this.serviceRegistry = services.ServiceRegistry;
         this.astReflection = services.AstReflection;
-        this.langiumDocuments = () => services.workspace.LangiumDocuments;
     }
 
     findAllReferences(targetNode: AstNode, astNodePath: string): Stream<ReferenceDescription> {
@@ -149,38 +149,12 @@ export class DefaultIndexManager implements IndexManager {
         document.state = DocumentState.IndexedReferences;
     }
 
-    getAffectedDocuments(uris: URI[]): Stream<LangiumDocument> {
-        return this.langiumDocuments().all.filter(e => {
-            if (uris.some(uri => equalURI(e.uri, uri))) {
-                return false;
-            }
-            for (const uri of uris) {
-                if (this.isAffected(e, uri)) {
-                    return true;
-                }
-            }
+    isAffected(document: LangiumDocument, changedUris: Set<string>): boolean {
+        const references = this.referenceIndex.get(document.uri.toString());
+        if (!references) {
             return false;
-        });
-    }
-
-    /**
-     * Determine whether the given document could be affected by a change of the document
-     * identified by the given URI (second parameter).
-     */
-    protected isAffected(document: LangiumDocument, changed: URI): boolean {
-        // Cache the uri string
-        const changedUriString = changed.toString();
-        const documentUri = document.uri.toString();
-        // The document is affected if it contains linking errors
-        if (document.references.some(e => e.error !== undefined)) {
-            return true;
         }
-        const references = this.referenceIndex.get(documentUri);
-        // ...or if it contains a reference to the changed file
-        if (references) {
-            return references.filter(e => !e.local).some(e => equalURI(e.targetUri, changedUriString));
-        }
-        return false;
+        return references.some(ref => !ref.local && changedUris.has(ref.targetUri.toString()));
     }
 
 }

--- a/packages/langium/src/workspace/index-manager.ts
+++ b/packages/langium/src/workspace/index-manager.ts
@@ -15,7 +15,6 @@ import { CancellationToken } from 'vscode-languageserver';
 import { getDocument } from '../utils/ast-util';
 import { stream } from '../utils/stream';
 import { equalURI } from '../utils/uri-util';
-import { DocumentState } from './documents';
 
 /**
  * The index manager is responsible for keeping metadata about symbols and cross-references
@@ -139,14 +138,12 @@ export class DefaultIndexManager implements IndexManager {
             data.node = undefined; // clear reference to the AST Node
         }
         this.simpleIndex.set(document.uri.toString(), exports);
-        document.state = DocumentState.IndexedContent;
     }
 
     async updateReferences(document: LangiumDocument, cancelToken = CancellationToken.None): Promise<void> {
         const services = this.serviceRegistry.getServices(document.uri);
         const indexData: ReferenceDescription[] = await services.workspace.ReferenceDescriptionProvider.createDescriptions(document, cancelToken);
         this.referenceIndex.set(document.uri.toString(), indexData);
-        document.state = DocumentState.IndexedReferences;
     }
 
     isAffected(document: LangiumDocument, changedUris: Set<string>): boolean {

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -37,7 +37,7 @@ export interface WorkspaceManager {
 
 export class DefaultWorkspaceManager implements WorkspaceManager {
 
-    initialBuildOptions: BuildOptions | undefined = undefined;
+    initialBuildOptions: BuildOptions = {};
 
     protected readonly serviceRegistry: ServiceRegistry;
     protected readonly langiumDocuments: LangiumDocuments;

--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -11,7 +11,7 @@ import type { WorkspaceFolder } from 'vscode-languageserver';
 import type { ServiceRegistry } from '../service-registry';
 import type { LangiumSharedServices } from '../services';
 import type { MutexLock } from '../utils/promise-util';
-import type { DocumentBuilder } from './document-builder';
+import type { BuildOptions, DocumentBuilder } from './document-builder';
 import type { LangiumDocument, LangiumDocuments } from './documents';
 import type { FileSystemNode, FileSystemProvider } from './file-system-provider';
 
@@ -20,6 +20,9 @@ import type { FileSystemNode, FileSystemProvider } from './file-system-provider'
  * This service is shared between all languages of a language server.
  */
 export interface WorkspaceManager {
+
+    /** The options used for the initial workspace build. */
+    initialBuildOptions: BuildOptions | undefined;
 
     /**
      * Does the initial indexing of workspace folders.
@@ -33,6 +36,8 @@ export interface WorkspaceManager {
 }
 
 export class DefaultWorkspaceManager implements WorkspaceManager {
+
+    initialBuildOptions: BuildOptions | undefined = undefined;
 
     protected readonly serviceRegistry: ServiceRegistry;
     protected readonly langiumDocuments: LangiumDocuments;
@@ -79,7 +84,7 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
         // Only after creating all documents do we check whether we need to cancel the initialization
         // The document builder will later pick up on all unprocessed documents
         await interruptAndCheck(cancelToken);
-        await this.documentBuilder.build(documents, undefined, cancelToken);
+        await this.documentBuilder.build(documents, this.initialBuildOptions, cancelToken);
     }
 
     /**

--- a/packages/langium/test/workspace/ast-node-locator.test.ts
+++ b/packages/langium/test/workspace/ast-node-locator.test.ts
@@ -6,7 +6,8 @@
 
 import type { Alternatives, Grammar, ParserRule } from '../../src/grammar/generated/ast';
 import { describe, expect, test } from 'vitest';
-import { createLangiumGrammarServices, EmptyFileSystem } from '../../src';
+import { createLangiumGrammarServices } from '../../src/grammar/langium-grammar-module';
+import { EmptyFileSystem } from '../../src/workspace/file-system-provider';
 import { parseHelper } from '../../src/test';
 
 describe('DefaultAstNodeLocator', () => {

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -171,6 +171,14 @@ describe('DefaultDocumentBuilder', () => {
             'Value is too large: 11',
             'Bar is too long: AnotherStrangeBar'
         ]);
+
+        // Re-running the fast checks should not lead to duplicate diagnostics
+        await builder.build([document1], { validation: { categories: ['fast'] } });
+        expect(document1.state).toBe(DocumentState.Validated);
+        expect(document1.diagnostics?.map(d => d.message)).toEqual([
+            'Value is too large: 11',
+            'Bar is too long: AnotherStrangeBar'
+        ]);
     });
 
     test('reruns all validation checks if requested', async () => {

--- a/packages/langium/test/workspace/document-builder.test.ts
+++ b/packages/langium/test/workspace/document-builder.test.ts
@@ -1,0 +1,169 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { LangiumServices } from '../../src/services';
+import type { AstNode, Reference } from '../../src/syntax-tree';
+import type { ValidationChecks } from '../../src/validation/validation-registry';
+import type { LangiumDocument } from '../../src/workspace/documents';
+import { describe, expect, test } from 'vitest';
+import { CancellationTokenSource } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+import { createLangiumGrammarServices } from '../../src/grammar/langium-grammar-module';
+import { createServicesForGrammar } from '../../src/utils/grammar-util';
+import { isOperationCancelled } from '../../src/utils/promise-util';
+import { DocumentState } from '../../src/workspace/documents';
+import { EmptyFileSystem } from '../../src/workspace/file-system-provider';
+
+describe('DefaultDocumentBuilder', () => {
+    const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
+    async function createServices() {
+        const grammar = `
+            grammar Test
+            entry Model:
+                (foos+=Foo | bars+=Bar)*;
+            Foo:
+                'foo' value=INT bar=[Bar];
+            Bar:
+                'bar' name=ID;
+            terminal INT returns number: /[0-9]+/;
+            terminal ID: /[_a-zA-Z][\\w_]*/;
+            hidden terminal WS: /\\s+/;
+        `;
+        const services = await createServicesForGrammar({ grammar, grammarServices });
+        const checks: ValidationChecks<TestAstType> = {
+            Foo: (node, accept) => {
+                if (node.value > 10) {
+                    accept('warning', 'Value is too large: ' + node.value, { node });
+                }
+            }
+        };
+        services.validation.ValidationRegistry.register(checks);
+        return services;
+    }
+
+    test('resumes document build after cancellation', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const document1 = documentFactory.fromString(`
+            foo 1 A
+            foo 11 B
+            bar A
+            bar B
+        `, URI.parse('file:///test1.txt'));
+        documents.addDocument(document1);
+        const document2 = documentFactory.fromString(`
+            foo 1 C
+            foo 11 D
+            bar C
+            bar D
+        `, URI.parse('file:///test2.txt'));
+        documents.addDocument(document2);
+
+        const builder = services.shared.workspace.DocumentBuilder;
+        const tokenSource1 = new CancellationTokenSource();
+        builder.onBuildPhase(DocumentState.IndexedContent, () => {
+            tokenSource1.cancel();
+        });
+        try {
+            await builder.build([document1, document2], {}, tokenSource1.token);
+        } catch (err) {
+            expect(isOperationCancelled(err)).toBe(true);
+        }
+        expect(document1.state).toBe(DocumentState.IndexedContent);
+        expect(document2.state).toBe(DocumentState.IndexedContent);
+
+        addTextDocument(document1, services);
+        await builder.update([document1.uri], []);
+        // While the first document is built with validation due to its reported update, the second one
+        // is resumed with its initial build options, which did not include validation.
+        expect(document1.state).toBe(DocumentState.Validated);
+        expect(document1.diagnostics?.map(d => d.message)).toEqual([
+            'Value is too large: 11'
+        ]);
+        expect(document2.state).toBe(DocumentState.IndexedReferences);
+        expect(document2.diagnostics).toBeUndefined();
+    });
+
+    test('includes document with references to updated document', async () => {
+        const services = await createServices();
+        const documentFactory = services.shared.workspace.LangiumDocumentFactory;
+        const documents = services.shared.workspace.LangiumDocuments;
+        const document1 = documentFactory.fromString(`
+            foo 1 A
+            foo 11 B
+            bar A
+            bar B
+        `, URI.parse('file:///test1.txt'));
+        documents.addDocument(document1);
+        const document2 = documentFactory.fromString(`
+            foo 1 C
+            foo 11 A
+            bar C
+        `, URI.parse('file:///test2.txt'));
+        documents.addDocument(document2);
+
+        const builder = services.shared.workspace.DocumentBuilder;
+        await builder.build([document1, document2], {});
+        expect(document1.state).toBe(DocumentState.IndexedReferences);
+        expect(document1.references.filter(r => r.error !== undefined)).toHaveLength(0);
+        expect(document2.state).toBe(DocumentState.IndexedReferences);
+        expect(document2.references.filter(r => r.error !== undefined)).toHaveLength(0);
+
+        addTextDocument(document1, services);
+        TextDocument.update(document1.textDocument, [{
+            // Change `foo 1 A` to `foo 1 D`, breaking the local reference
+            range: { start: { line: 1, character: 18 }, end: { line: 1, character: 19 } },
+            text: 'D'
+        }], 1);
+        addTextDocument(document2, services);
+        builder.updateBuildOptions = {
+            validation: {
+                // Only the linking error is reported for the first document
+                stopAfterLinkingErrors: true
+            }
+        };
+        await builder.update([document1.uri], []);
+        expect(document1.state).toBe(DocumentState.Validated);
+        expect(document1.diagnostics?.map(d => d.message)).toEqual([
+            'Could not resolve reference to Bar named \'D\'.'
+        ]);
+        expect(document2.state).toBe(DocumentState.Validated);
+        expect(document2.diagnostics?.map(d => d.message)).toEqual([
+            'Value is too large: 11'
+        ]);
+    });
+
+});
+
+/**
+ * Add the given document to the TextDocuments service, simulating it being opened in an editor.
+ */
+function addTextDocument(doc: LangiumDocument, services: LangiumServices) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const textDocuments = services.shared.workspace.TextDocuments as any;
+    textDocuments._syncedDocuments.set(doc.uri.toString(), doc.textDocument);
+}
+
+type TestAstType = {
+    Model: Model
+    Foo: Foo
+    Bar: Bar
+}
+
+interface Model extends AstNode {
+    foos: Foo[]
+}
+
+interface Foo extends AstNode {
+    value: number
+    bar: Reference<Bar>
+}
+
+interface Bar extends AstNode {
+    name: string
+}

--- a/packages/langium/test/workspace/document-validator.test.ts
+++ b/packages/langium/test/workspace/document-validator.test.ts
@@ -1,0 +1,110 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { ValidationChecks } from '../../src/validation/validation-registry';
+import type { AstNode } from '../../src/syntax-tree';
+import { describe, expect, test } from 'vitest';
+import { createLangiumGrammarServices } from '../../src/grammar/langium-grammar-module';
+import { createServicesForGrammar } from '../../src/utils/grammar-util';
+import { EmptyFileSystem } from '../../src/workspace/file-system-provider';
+import { URI } from 'vscode-uri';
+
+describe('DefaultDocumentValidator', () => {
+    const grammarServices = createLangiumGrammarServices(EmptyFileSystem).grammar;
+    async function createServices() {
+        const grammar = `
+            grammar Test
+            entry Model:
+                foos+=Foo*;
+            Foo:
+                'foo' value=INT;
+            terminal INT returns number: /[0-9]+/;
+            hidden terminal WS: /\\s+/;
+        `;
+        const services = await createServicesForGrammar({ grammar, grammarServices });
+        const checks: ValidationChecks<TestAstType> = {
+            Foo: (node, accept) => {
+                if (node.value > 10) {
+                    accept('warning', 'Value is too large: ' + node.value, { node });
+                }
+            }
+        };
+        services.validation.ValidationRegistry.register(checks);
+        return services;
+    }
+
+    test('validates with lexing error', async () => {
+        const services = await createServices();
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString(`
+            foo 1
+            foo 11
+            foo bar 2
+        `, URI.parse('file:///test.txt'));
+        const diagnostics = await services.validation.DocumentValidator.validateDocument(document);
+        expect(diagnostics.map(d => d.message)).toEqual([
+            'unexpected character: ->b<- at offset: 54, skipped 3 characters.',
+            'Value is too large: 11'
+        ]);
+    });
+
+    test('validates with parsing error', async () => {
+        const services = await createServices();
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString(`
+            foo 1
+            foo 11
+            foo foo 2
+        `, URI.parse('file:///test.txt'));
+        const diagnostics = await services.validation.DocumentValidator.validateDocument(document);
+        expect(diagnostics.map(d => d.message)).toEqual([
+            'Expecting token of type \'INT\' but found `foo`.',
+            'Value is too large: 11'
+        ]);
+    });
+
+    test('stops validating after lexing error if requested', async () => {
+        const services = await createServices();
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString(`
+            foo 1
+            foo 11
+            foo bar 2
+        `, URI.parse('file:///test.txt'));
+        const diagnostics = await services.validation.DocumentValidator.validateDocument(document, {
+            stopAfterLexingErrors: true
+        });
+        expect(diagnostics.map(d => d.message)).toEqual([
+            'unexpected character: ->b<- at offset: 54, skipped 3 characters.'
+        ]);
+    });
+
+    test('stops validating after parsing error if requested', async () => {
+        const services = await createServices();
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString(`
+            foo 1
+            foo 11
+            foo foo 2
+        `, URI.parse('file:///test.txt'));
+        const diagnostics = await services.validation.DocumentValidator.validateDocument(document, {
+            stopAfterParsingErrors: true
+        });
+        expect(diagnostics.map(d => d.message)).toEqual([
+            'Expecting token of type \'INT\' but found `foo`.'
+        ]);
+    });
+
+});
+
+type TestAstType = {
+    Model: Model
+    Foo: Foo
+}
+
+interface Model extends AstNode {
+    foos: Foo[]
+}
+
+interface Foo extends AstNode {
+    value: number
+}

--- a/packages/langium/test/workspace/validation-registry.test.ts
+++ b/packages/langium/test/workspace/validation-registry.test.ts
@@ -65,7 +65,7 @@ describe('ValidationRegistry', () => {
             ParserRule: () => { appliedChecks.push('b'); }
         };
         registry.register(checks2, undefined, 'fast');
-        registry.getChecks('ParserRule', 'fast').forEach(check => (check as () => void)());
+        registry.getChecks('ParserRule', ['fast']).forEach(check => (check as () => void)());
         expect(appliedChecks).toEqual(['a', 'b']);
     });
 
@@ -80,7 +80,7 @@ describe('ValidationRegistry', () => {
             ParserRule: () => { appliedChecks.push('b'); }
         };
         registry.register(checks2, undefined, 'slow');
-        registry.getChecks('ParserRule', 'slow').forEach(check => (check as () => void)());
+        registry.getChecks('ParserRule', ['slow']).forEach(check => (check as () => void)());
         expect(appliedChecks).toEqual(['b']);
     });
 

--- a/packages/langium/test/workspace/validation-registry.test.ts
+++ b/packages/langium/test/workspace/validation-registry.test.ts
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { LangiumGrammarAstType } from '../../src/grammar/generated/ast';
+import type { ValidationChecks } from '../../src/validation/validation-registry';
+import type { LangiumServices } from '../../src/services';
+import { describe, expect, test } from 'vitest';
+import { LangiumGrammarAstReflection } from '../../src/grammar/generated/ast';
+import { ValidationRegistry } from '../../src/validation/validation-registry';
+
+describe('ValidationRegistry', () => {
+    function createRegistry(): ValidationRegistry {
+        // Create a minimal set of services so we can start with an empty registry
+        const services = {
+            shared: {
+                AstReflection: new LangiumGrammarAstReflection()
+            }
+        } as unknown as LangiumServices;
+        return new ValidationRegistry(services);
+    }
+
+    test('registers array of checks', () => {
+        const appliedChecks: string[] = [];
+        const registry = createRegistry();
+        const checks: ValidationChecks<LangiumGrammarAstType> = {
+            ParserRule: [
+                () => { appliedChecks.push('a'); },
+                () => { appliedChecks.push('b'); }
+            ]
+        };
+        registry.register(checks);
+        registry.getChecks('ParserRule').forEach(check => (check as () => void)());
+        expect(appliedChecks).toEqual(['a', 'b']);
+    });
+
+    test('registers check with proper `this`', () => {
+        const appliedChecks: string[] = [];
+        const registry = createRegistry();
+        class Validations {
+            foo = 'bar';
+            check(): void {
+                appliedChecks.push(this.foo);
+            }
+        }
+        const validations = new Validations();
+        const checks: ValidationChecks<LangiumGrammarAstType> = {
+            ParserRule: validations.check
+        };
+        registry.register(checks, validations);
+        registry.getChecks('ParserRule').forEach(check => (check as () => void)());
+        expect(appliedChecks).toEqual(['bar']);
+    });
+
+    test("uses 'fast' as default category", () => {
+        const appliedChecks: string[] = [];
+        const registry = createRegistry();
+        const checks1: ValidationChecks<LangiumGrammarAstType> = {
+            ParserRule: () => { appliedChecks.push('a'); }
+        };
+        registry.register(checks1);
+        const checks2: ValidationChecks<LangiumGrammarAstType> = {
+            ParserRule: () => { appliedChecks.push('b'); }
+        };
+        registry.register(checks2, undefined, 'fast');
+        registry.getChecks('ParserRule', 'fast').forEach(check => (check as () => void)());
+        expect(appliedChecks).toEqual(['a', 'b']);
+    });
+
+    test("gives only 'slow' checks when requested", () => {
+        const appliedChecks: string[] = [];
+        const registry = createRegistry();
+        const checks1: ValidationChecks<LangiumGrammarAstType> = {
+            ParserRule: () => { appliedChecks.push('a'); }
+        };
+        registry.register(checks1, undefined, 'fast');
+        const checks2: ValidationChecks<LangiumGrammarAstType> = {
+            ParserRule: () => { appliedChecks.push('b'); }
+        };
+        registry.register(checks2, undefined, 'slow');
+        registry.getChecks('ParserRule', 'slow').forEach(check => (check as () => void)());
+        expect(appliedChecks).toEqual(['b']);
+    });
+
+});


### PR DESCRIPTION
This PR fixes two issues that have not been noticed until recently:
 - When you open a DSL file, the whole workspace is validated even if the initial build skips validation. This is because `DefaultDocumentBuilder.collectDocuments` includes all documents for which `state < DocumentState.Validated`.
 - Even if you fix that, the whole workspace is validated in most cases:
     - The language extension is often activated when a DSL file is opened for the first time.
     - After starting and initializing the language server, the client immediately sends a `didOpen` notification, which triggers an update of the respective `TextDocument` (that's the standard behavior of `TextDocuments` provided by Microsoft).
     - The update cancels the initial build if it's still running (if the workspace is sufficiently large, it's very likely that it's still running).
     - The documents sent to the `DocumentBuilder` for the initial build are now continued with the new `BuildOptions`, which enable validation.

The issues are fixed with the following changes:
 - `DocumentBuilder` tracks the state of building (completed or not), including the last used build options.
 - This new information is now used to collect unfinished documents after a previous build was canceled.
 - Every document has its individual options during build; this is currently used to control validation.

Additional improvements:
 - API changes to simplify `IndexManager` and improve performance with large workspaces.
 - Added a public `initialBuildOptions` property to `WorkspaceManager` to control validation for the initial build.
 - Added a public `updateBuildOptions` property to `DocumentBuilder` to control validation for updates (document changes).
 - Added validation categories `'fast'` (default) and `'slow'`. You can set the category when you register a record of validation checks. The category can be selected in the build options. If no category is specified, all checks are executed.
 - Lexer, parser and linker errors are collected if the `'built-in'` validation category is enabled.
 - Added more validation options to enable reporting only partial results, e.g. don't do custom validations if there are parsing errors.
 - Made document builder phases more consistent: the `state` of the document is always set by the document builder