### PR TITLE
Add comment provider

### DIFF
--- a/packages/langium/src/default-module.ts
+++ b/packages/langium/src/default-module.ts
@@ -46,6 +46,7 @@ import { DefaultIndexManager } from './workspace/index-manager';
 import { DefaultWorkspaceManager } from './workspace/workspace-manager';
 import { DefaultLexer } from './parser/lexer';
 import { JSDocDocumentationProvider } from './documentation';
+import { DefaultCommentProvider } from './documentation/comment-provider';
 import { LangiumParserErrorMessageProvider } from './parser/langium-parser';
 
 /**
@@ -62,6 +63,7 @@ export interface DefaultModuleContext {
 export function createDefaultModule(context: DefaultModuleContext): Module<LangiumServices, LangiumDefaultServices> {
     return {
         documentation: {
+            CommentProvider: (services) => new DefaultCommentProvider(services),
             DocumentationProvider: (services) => new JSDocDocumentationProvider(services)
         },
         parser: {

--- a/packages/langium/src/documentation/comment-provider.ts
+++ b/packages/langium/src/documentation/comment-provider.ts
@@ -5,6 +5,7 @@
  ******************************************************************************/
 
 import type { GrammarConfig } from '../grammar';
+import type { AstNodeWithComment } from '../serializer';
 import type { LangiumServices } from '../services';
 import type { AstNode } from '../syntax-tree';
 import { findCommentNode } from '../utils/cst-util';
@@ -13,13 +14,6 @@ import { findCommentNode } from '../utils/cst-util';
  * Provides comments for AST nodes.
  */
 export interface CommentProvider {
-    /**
-     * Defines the token types that are considered as comments.
-     *
-     * The default implementation `DefaultCommentProvider` will return the `multilineCommentRules` from the grammar config.
-     */
-    getCommentTokenTypes(): string[];
-
     /**
      * Returns the comment associated with the specified AST node.
      * @param node The AST node to get the comment for.
@@ -33,10 +27,10 @@ export class DefaultCommentProvider implements CommentProvider {
     constructor(services: LangiumServices) {
         this.grammarConfig = () => services.parser.GrammarConfig;
     }
-    getCommentTokenTypes(): string[] {
-        return this.grammarConfig().multilineCommentRules;
-    }
     getComment(node: AstNode): string | undefined {
-        return findCommentNode(node.$cstNode, this.getCommentTokenTypes())?.text;
+        if('$comment' in node) {
+            return (node as AstNodeWithComment).$comment;
+        }
+        return findCommentNode(node.$cstNode, this.grammarConfig().multilineCommentRules)?.text;
     }
 }

--- a/packages/langium/src/documentation/comment-provider.ts
+++ b/packages/langium/src/documentation/comment-provider.ts
@@ -1,0 +1,22 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import type { AstNode } from '../syntax-tree';
+import { findCommentNode } from '../utils/cst-util';
+
+export interface CommentProvider {
+    getCommentTokenTypes(): string[];
+    getComment(node: AstNode): string | undefined;
+}
+
+export class DefaultCommentProvider implements CommentProvider {
+    getCommentTokenTypes(): string[] {
+        return ['SL_COMMENT', 'ML_COMMENT'];
+    }
+    getComment(node: AstNode): string | undefined {
+        return findCommentNode(node.$cstNode, this.getCommentTokenTypes())?.text;
+    }
+}

--- a/packages/langium/src/documentation/comment-provider.ts
+++ b/packages/langium/src/documentation/comment-provider.ts
@@ -15,12 +15,12 @@ export interface CommentProvider {
 }
 
 export class DefaultCommentProvider implements CommentProvider {
-    protected readonly grammarConfig: GrammarConfig;
+    protected readonly grammarConfig: () => GrammarConfig;
     constructor(services: LangiumServices) {
-        this.grammarConfig = services.parser.GrammarConfig;
+        this.grammarConfig = () => services.parser.GrammarConfig;
     }
     getCommentTokenTypes(): string[] {
-        return this.grammarConfig.multilineCommentRules;
+        return this.grammarConfig().multilineCommentRules;
     }
     getComment(node: AstNode): string | undefined {
         return findCommentNode(node.$cstNode, this.getCommentTokenTypes())?.text;

--- a/packages/langium/src/documentation/comment-provider.ts
+++ b/packages/langium/src/documentation/comment-provider.ts
@@ -9,8 +9,22 @@ import type { LangiumServices } from '../services';
 import type { AstNode } from '../syntax-tree';
 import { findCommentNode } from '../utils/cst-util';
 
+/**
+ * Provides comments for AST nodes.
+ */
 export interface CommentProvider {
+    /**
+     * Defines the token types that are considered as comments.
+     *
+     * The default implementation `DefaultCommentProvider` will return the `multilineCommentRules` from the grammar config.
+     */
     getCommentTokenTypes(): string[];
+
+    /**
+     * Returns the comment associated with the specified AST node.
+     * @param node The AST node to get the comment for.
+     * @returns The comment associated with the specified AST node or `undefined` if there is no comment.
+     */
     getComment(node: AstNode): string | undefined;
 }
 

--- a/packages/langium/src/documentation/comment-provider.ts
+++ b/packages/langium/src/documentation/comment-provider.ts
@@ -4,6 +4,8 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import type { GrammarConfig } from '../grammar';
+import type { LangiumServices } from '../services';
 import type { AstNode } from '../syntax-tree';
 import { findCommentNode } from '../utils/cst-util';
 
@@ -13,8 +15,12 @@ export interface CommentProvider {
 }
 
 export class DefaultCommentProvider implements CommentProvider {
+    protected readonly grammarConfig: GrammarConfig;
+    constructor(services: LangiumServices) {
+        this.grammarConfig = services.parser.GrammarConfig;
+    }
     getCommentTokenTypes(): string[] {
-        return ['SL_COMMENT', 'ML_COMMENT'];
+        return this.grammarConfig.multilineCommentRules;
     }
     getComment(node: AstNode): string | undefined {
         return findCommentNode(node.$cstNode, this.getCommentTokenTypes())?.text;

--- a/packages/langium/src/documentation/comment-provider.ts
+++ b/packages/langium/src/documentation/comment-provider.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import type { GrammarConfig } from '../grammar';
-import type { AstNodeWithComment } from '../serializer';
+import { isAstNodeWithComment } from '../serializer';
 import type { LangiumServices } from '../services';
 import type { AstNode } from '../syntax-tree';
 import { findCommentNode } from '../utils/cst-util';
@@ -28,8 +28,8 @@ export class DefaultCommentProvider implements CommentProvider {
         this.grammarConfig = () => services.parser.GrammarConfig;
     }
     getComment(node: AstNode): string | undefined {
-        if('$comment' in node) {
-            return (node as AstNodeWithComment).$comment;
+        if(isAstNodeWithComment(node)) {
+            return node.$comment;
         }
         return findCommentNode(node.$cstNode, this.grammarConfig().multilineCommentRules)?.text;
     }

--- a/packages/langium/src/documentation/documentation-provider.ts
+++ b/packages/langium/src/documentation/documentation-provider.ts
@@ -35,9 +35,9 @@ export class JSDocDocumentationProvider implements DocumentationProvider {
     }
 
     getDocumentation(node: AstNode): string | undefined {
-        const lastNode = this.commentProvider.getComment(node);
-        if (isLeafCstNode(lastNode) && isJSDoc(lastNode)) {
-            const parsedJSDoc = parseJSDoc(lastNode);
+        const comment = this.commentProvider.getComment(node);
+        if (comment && isJSDoc(comment)) {
+            const parsedJSDoc = parseJSDoc(comment);
             return parsedJSDoc.toMarkdown({
                 renderLink: (link, display) => {
                     return this.documentationLinkRenderer(node, link, display);

--- a/packages/langium/src/documentation/documentation-provider.ts
+++ b/packages/langium/src/documentation/documentation-provider.ts
@@ -4,13 +4,12 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import type { GrammarConfig } from '../grammar/grammar-config';
 import type { LangiumServices } from '../services';
 import type { AstNode, AstNodeDescription } from '../syntax-tree';
 import type { IndexManager } from '../workspace/index-manager';
+import type { CommentProvider } from './comment-provider';
 import { isLeafCstNode } from '../syntax-tree';
 import { getDocument } from '../utils/ast-util';
-import { findCommentNode } from '../utils/cst-util';
 import { isJSDoc, parseJSDoc } from './jsdoc';
 
 /**
@@ -28,15 +27,15 @@ export interface DocumentationProvider {
 export class JSDocDocumentationProvider implements DocumentationProvider {
 
     protected readonly indexManager: IndexManager;
-    protected readonly grammarConfig: GrammarConfig;
+    protected readonly commentProvider: CommentProvider;
 
     constructor(services: LangiumServices) {
         this.indexManager = services.shared.workspace.IndexManager;
-        this.grammarConfig = services.parser.GrammarConfig;
+        this.commentProvider = services.documentation.CommentProvider;
     }
 
     getDocumentation(node: AstNode): string | undefined {
-        const lastNode = findCommentNode(node.$cstNode, this.grammarConfig.multilineCommentRules);
+        const lastNode = this.commentProvider.getComment(node);
         if (isLeafCstNode(lastNode) && isJSDoc(lastNode)) {
             const parsedJSDoc = parseJSDoc(lastNode);
             return parsedJSDoc.toMarkdown({

--- a/packages/langium/src/documentation/documentation-provider.ts
+++ b/packages/langium/src/documentation/documentation-provider.ts
@@ -8,7 +8,6 @@ import type { LangiumServices } from '../services';
 import type { AstNode, AstNodeDescription } from '../syntax-tree';
 import type { IndexManager } from '../workspace/index-manager';
 import type { CommentProvider } from './comment-provider';
-import { isLeafCstNode } from '../syntax-tree';
 import { getDocument } from '../utils/ast-util';
 import { isJSDoc, parseJSDoc } from './jsdoc';
 

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -33,7 +33,7 @@ export interface AstNodeWithTextRegion extends AstNode {
 }
 
 /**
- * {@link AstNode}s that may carry a comment CST node in front of itself.
+ * {@link AstNode}s that may carry a semantically relevant comment.
  */
 export interface AstNodeWithComment extends AstNode {
     $comment?: string;

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -142,10 +142,8 @@ export class DefaultJsonSerializer implements JsonSerializer {
                 astNode.$sourceText = value.$cstNode?.text;
             }
             if (comments && isAstNode(value)) {
-                astNode ??= {
-                    ...value,
-                    $comment: this.commentProvider.getComment(value)
-                } as AstNodeWithComment;
+                astNode ??= { ...value };
+                (astNode as AstNodeWithComment).$comment =  this.commentProvider.getComment(value);
             }
             return astNode ?? value;
         }

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -13,12 +13,14 @@ import type { DocumentSegment } from '../workspace/documents';
 import { isAstNode, isReference } from '../syntax-tree';
 import { getDocument } from '../utils/ast-util';
 import { findNodesForProperty } from '../utils/grammar-util';
+import type { CommentProvider } from '../documentation/comment-provider';
 
 export interface JsonSerializeOptions {
     space?: string | number;
     refText?: boolean;
     sourceText?: boolean;
     textRegions?: boolean;
+    comments?: boolean;
     replacer?: (key: string, value: unknown, defaultReplacer: (key: string, value: unknown) => unknown) => unknown
 }
 
@@ -28,6 +30,13 @@ export interface JsonSerializeOptions {
 export interface AstNodeWithTextRegion extends AstNode {
     $sourceText?: string;
     $textRegion?: AstNodeRegionWithAssignments;
+}
+
+/**
+ * {@link AstNode}s that may carry a comment CST node in front of itself.
+ */
+export interface AstNodeWithComment extends AstNode {
+    $comment?: string;
 }
 
 /**
@@ -79,10 +88,12 @@ export class DefaultJsonSerializer implements JsonSerializer {
     protected ignoreProperties = new Set(['$container', '$containerProperty', '$containerIndex', '$document', '$cstNode']);
     protected readonly astNodeLocator: AstNodeLocator;
     protected readonly nameProvider: NameProvider;
+    protected readonly commentProvider: CommentProvider;
 
     constructor(services: LangiumServices) {
         this.astNodeLocator = services.workspace.AstNodeLocator;
         this.nameProvider = services.references.NameProvider;
+        this.commentProvider = services.documentation.CommentProvider;
     }
 
     serialize(node: AstNode, options?: JsonSerializeOptions): string {
@@ -99,7 +110,7 @@ export class DefaultJsonSerializer implements JsonSerializer {
         return root;
     }
 
-    protected replacer(key: string, value: unknown, { refText, sourceText, textRegions }: JsonSerializeOptions = {}): unknown {
+    protected replacer(key: string, value: unknown, { refText, sourceText, textRegions, comments }: JsonSerializeOptions = {}): unknown {
         if (this.ignoreProperties.has(key)) {
             return undefined;
         } else if (isReference(value)) {
@@ -129,6 +140,12 @@ export class DefaultJsonSerializer implements JsonSerializer {
             if (sourceText && !key && isAstNode(value)) {
                 astNode ??= { ...value };
                 astNode.$sourceText = value.$cstNode?.text;
+            }
+            if (comments && isAstNode(value)) {
+                astNode ??= {
+                    ...value,
+                    $comment: this.commentProvider.getComment(value)
+                } as AstNodeWithComment;
             }
             return astNode ?? value;
         }

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -147,7 +147,7 @@ export class DefaultJsonSerializer implements JsonSerializer {
             }
             if (comments && isAstNode(value)) {
                 astNode ??= { ...value };
-                (astNode as AstNodeWithComment).$comment =  this.commentProvider.getComment(value);
+                (astNode as AstNodeWithComment).$comment = this.commentProvider.getComment(value);
             }
             return astNode ?? value;
         }

--- a/packages/langium/src/serializer/json-serializer.ts
+++ b/packages/langium/src/serializer/json-serializer.ts
@@ -39,6 +39,10 @@ export interface AstNodeWithComment extends AstNode {
     $comment?: string;
 }
 
+export function isAstNodeWithComment(node: AstNode): node is AstNodeWithComment {
+    return typeof (node as AstNodeWithComment).$comment === 'string';
+}
+
 /**
  * A {@DocumentSegment} representing the definition area of an AstNode within the DSL text.
  * Usually contains text region information on all assigned property values of the AstNode,

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -56,6 +56,7 @@ import type { CodeLensProvider } from './lsp/code-lens-provider';
 import type { DeclarationProvider } from './lsp/declaration-provider';
 import type { DocumentationProvider } from './documentation/documentation-provider';
 import type { InlayHintProvider } from './lsp/inlay-hint-provider';
+import type { CommentProvider } from './documentation/comment-provider';
 import type { WorkspaceSymbolProvider } from './lsp/workspace-symbol-provider';
 import type { NodeKindProvider } from './lsp/node-kind-provider';
 import type { FuzzyMatcher } from './lsp/fuzzy-matcher';
@@ -113,6 +114,7 @@ export type LangiumDefaultServices = {
         Lexer: Lexer
     }
     documentation: {
+        CommentProvider: CommentProvider
         DocumentationProvider: DocumentationProvider
     }
     references: {

--- a/packages/langium/test/documentation/CommentProvider.test.ts
+++ b/packages/langium/test/documentation/CommentProvider.test.ts
@@ -1,0 +1,33 @@
+/******************************************************************************
+ * Copyright 2023 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { describe, expect, test } from 'vitest';
+import { parseHelper } from '../../src/test';
+import { EmptyFileSystem, createLangiumGrammarServices, streamAst } from '../../src';
+import { isAbstractRule } from '../../src/grammar/generated/ast';
+
+const services = createLangiumGrammarServices(EmptyFileSystem).grammar;
+const parse = parseHelper(services);
+
+describe('Comment provider', () => {
+    test('Get a comment', async () => {
+        const ast = (await parse(`
+            grammar Test
+            /** Rule */
+            entry Rule: 'rule' num=INT;
+            /** INT */
+            terminal INT: /\\d+/;
+        `)).parseResult.value;
+
+        const grammarComment = services.documentation.CommentProvider.getComment(ast);
+        expect(grammarComment).toBeUndefined();
+        streamAst(ast).filter(isAbstractRule).forEach(rule => {
+            const comment = services.documentation.CommentProvider.getComment(rule);
+            expect(comment).toBe(`/** ${rule.name} */`);
+        });
+        expect(ast).toBeDefined();
+    });
+});

--- a/packages/langium/test/documentation/comment-provider.test.ts
+++ b/packages/langium/test/documentation/comment-provider.test.ts
@@ -22,12 +22,12 @@ describe('Comment provider', () => {
             terminal INT: /\\d+/;
         `)).parseResult.value;
 
+        expect(ast).toBeDefined();
         const grammarComment = services.documentation.CommentProvider.getComment(ast);
         expect(grammarComment).toBeUndefined();
         streamAst(ast).filter(isAbstractRule).forEach(rule => {
             const comment = services.documentation.CommentProvider.getComment(rule);
             expect(comment).toBe(`/** ${rule.name} */`);
         });
-        expect(ast).toBeDefined();
     });
 });


### PR DESCRIPTION
- serializes to `$comment` property
- comes with default multiline comments
- replaces consumption of comments in documentation provider by a comment provider call

- one thing that bothers me is that comments can get duplicated (I guess)

```bnf
A ::= B c
B ::= a b
```

For file:

```
/** comment */
a b c
```

- because then `$comment(A) == $comment(B) == '/** comment */'`
- @msujew what do you think? Can we live with this or should we filter out the comment for upper nodes when a lower node already has the comment?