### PR TITLE
Move shared LSP services to language services

### DIFF
--- a/packages/langium/src/lsp/code-lens-provider.ts
+++ b/packages/langium/src/lsp/code-lens-provider.ts
@@ -10,5 +10,4 @@ import type { LangiumDocument } from '../workspace/documents';
 
 export interface CodeLensProvider {
     provideCodeLens(document: LangiumDocument, params: CodeLensParams, cancelToken?: CancellationToken): MaybePromise<CodeLens[] | undefined>
-    resolveCodeLens?(params: CodeLens, cancelToken?: CancellationToken): MaybePromise<CodeLens>
 }

--- a/packages/langium/src/lsp/document-link-provider.ts
+++ b/packages/langium/src/lsp/document-link-provider.ts
@@ -15,21 +15,8 @@ export interface DocumentLinkProvider {
     /**
      * Handle a document links request.
      *
-     * The document links returned in this method don't need to contain all information necessary to resolve the link.
-     * Instead, the {@link resolveDocumentLink} method can be used to provide further information about the link.
-     *
      * @throws `OperationCancelled` if cancellation is detected during execution
      * @throws `ResponseError` if an error is detected that should be sent as response to the client
      */
     getDocumentLinks(document: LangiumDocument, params: DocumentLinkParams, cancelToken?: CancellationToken): MaybePromise<DocumentLink[]>;
-    /**
-     * Handle a resolve link request. Allows to provide additional information for a document link.
-     *
-     * This request is performed when a user clicks on a link provided by the {@link getDocumentLinks} method.
-     * Only needs to be implemented if full document link creation is expensive.
-     *
-     * @throws `OperationCancelled` if cancellation is detected during execution
-     * @throws `ResponseError` if an error is detected that should be sent as response to the client
-     */
-    resolveDocumentLink?(documentLink: DocumentLink, cancelToken?: CancellationToken): MaybePromise<DocumentLink>;
 }

--- a/packages/langium/src/lsp/inlay-hint-provider.ts
+++ b/packages/langium/src/lsp/inlay-hint-provider.ts
@@ -21,17 +21,10 @@ export interface InlayHintProvider {
     /**
      * Handle the `textDocument.inlayHint` language server request.
      *
-     * The inlay hints returned in this method don't need to contain all information about the hint.
-     * Instead, the {@link resolveInlayHint} method can be used to provide further information about the hint.
+     * @throws `OperationCancelled` if cancellation is detected during execution
+     * @throws `ResponseError` if an error is detected that should be sent as response to the client
      */
     getInlayHints(document: LangiumDocument, params: InlayHintParams, cancelToken?: CancellationToken): MaybePromise<InlayHint[] | undefined>;
-    /**
-     * Handle a resolve inlay request. Allows to provide additional information for an inlay hint.
-     *
-     * This request is performed when a user clicks on a hint provided by the {@link getInlayHints} method.
-     * Only needs to be implemented if full inlay link creation is expensive.
-     */
-    resolveInlayHint?(inlayHint: InlayHint, cancelToken?: CancellationToken): MaybePromise<InlayHint>;
 }
 
 export abstract class AbstractInlayHintProvider implements InlayHintProvider {

--- a/packages/langium/src/services.ts
+++ b/packages/langium/src/services.ts
@@ -92,6 +92,9 @@ export type LangiumLspServices = {
     SignatureHelp?: SignatureHelpProvider
     CallHierarchyProvider?: CallHierarchyProvider
     DeclarationProvider?: DeclarationProvider
+    InlayHintProvider?: InlayHintProvider
+    CodeLensProvider?: CodeLensProvider
+    DocumentLinkProvider?: DocumentLinkProvider
 }
 
 /**
@@ -153,10 +156,7 @@ export type LangiumDefaultSharedServices = {
     ServiceRegistry: ServiceRegistry
     lsp: {
         Connection?: Connection
-        CodeLensProvider?: CodeLensProvider
-        DocumentLinkProvider?: DocumentLinkProvider
         ExecuteCommandHandler?: ExecuteCommandHandler
-        InlayHintProvider?: InlayHintProvider
         WorkspaceSymbolProvider?: WorkspaceSymbolProvider
         NodeKindProvider: NodeKindProvider
         FuzzyMatcher: FuzzyMatcher


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/925

Removes the `resolve` requests, which aren't usually necessary in Langium. Note that consumers off Langium can still opt to manually edit the language server initialization return value to support these requests manually.