### PR TITLE
Improve regular expression generator

### DIFF
--- a/examples/arithmetics/syntaxes/arithmetics.monarch.ts
+++ b/examples/arithmetics/syntaxes/arithmetics.monarch.ts
@@ -6,7 +6,7 @@ export default {
     operators: [
         '%','*','+',',','-','/',':',';','^'
     ],
-    symbols:  /%|\(|\)|\*|\+|,|-|\/|:|;|\^/,
+    symbols: /%|\(|\)|\*|\+|,|-|\/|:|;|\^/,
 
     tokenizer: {
         initial: [
@@ -21,9 +21,9 @@ export default {
             { regex: /\/\/[^\n\r]*/, action: {"token":"comment"} },
         ],
         comment: [
-            { regex: /[^\/\*]+/, action: {"token":"comment"} },
+            { regex: /[^/\*]+/, action: {"token":"comment"} },
             { regex: /\*\//, action: {"token":"comment","next":"@pop"} },
-            { regex: /[\/\*]/, action: {"token":"comment"} },
+            { regex: /[/\*]/, action: {"token":"comment"} },
         ],
     }
 };

--- a/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
+++ b/examples/arithmetics/syntaxes/arithmetics.tmLanguage.json
@@ -18,13 +18,13 @@
       "patterns": [
         {
           "name": "comment.block.arithmetics",
-          "begin": "\\/\\*",
+          "begin": "/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.arithmetics"
             }
           },
-          "end": "\\*\\/",
+          "end": "\\*/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.arithmetics"
@@ -32,7 +32,7 @@
           }
         },
         {
-          "begin": "\\/\\/",
+          "begin": "//",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.arithmetics"

--- a/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
+++ b/examples/domainmodel/syntaxes/domain-model.tmLanguage.json
@@ -18,13 +18,13 @@
       "patterns": [
         {
           "name": "comment.block.domain-model",
-          "begin": "\\/\\*",
+          "begin": "/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.domain-model"
             }
           },
-          "end": "\\*\\/",
+          "end": "\\*/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.domain-model"
@@ -32,7 +32,7 @@
           }
         },
         {
-          "begin": "\\/\\/",
+          "begin": "//",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.domain-model"

--- a/examples/domainmodel/syntaxes/domainmodel.monarch.ts
+++ b/examples/domainmodel/syntaxes/domainmodel.monarch.ts
@@ -6,7 +6,7 @@ export default {
     operators: [
         '.',':'
     ],
-    symbols:  /\.|:|\{|\}/,
+    symbols: /\.|:|\{|\}/,
 
     tokenizer: {
         initial: [
@@ -20,9 +20,9 @@ export default {
             { regex: /\/\/[^\n\r]*/, action: {"token":"comment"} },
         ],
         comment: [
-            { regex: /[^\/\*]+/, action: {"token":"comment"} },
+            { regex: /[^/\*]+/, action: {"token":"comment"} },
             { regex: /\*\//, action: {"token":"comment","next":"@pop"} },
-            { regex: /[\/\*]/, action: {"token":"comment"} },
+            { regex: /[/\*]/, action: {"token":"comment"} },
         ],
     }
 };

--- a/examples/requirements/syntaxes/requirements.tmLanguage.json
+++ b/examples/requirements/syntaxes/requirements.tmLanguage.json
@@ -38,13 +38,13 @@
       "patterns": [
         {
           "name": "comment.block.requirements-lang",
-          "begin": "\\/\\*",
+          "begin": "/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.requirements-lang"
             }
           },
-          "end": "\\*\\/",
+          "end": "\\*/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.requirements-lang"
@@ -52,7 +52,7 @@
           }
         },
         {
-          "begin": "\\/\\/",
+          "begin": "//",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.requirements-lang"

--- a/examples/requirements/syntaxes/tests.tmLanguage.json
+++ b/examples/requirements/syntaxes/tests.tmLanguage.json
@@ -38,13 +38,13 @@
       "patterns": [
         {
           "name": "comment.block.tests-lang",
-          "begin": "\\/\\*",
+          "begin": "/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.tests-lang"
             }
           },
-          "end": "\\*\\/",
+          "end": "\\*/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.tests-lang"
@@ -52,7 +52,7 @@
           }
         },
         {
-          "begin": "\\/\\/",
+          "begin": "//",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.tests-lang"

--- a/examples/statemachine/syntaxes/statemachine.monarch.ts
+++ b/examples/statemachine/syntaxes/statemachine.monarch.ts
@@ -6,7 +6,7 @@ export default {
     operators: [
         '=>'
     ],
-    symbols:  /=>|\{|\}/,
+    symbols: /=>|\{|\}/,
 
     tokenizer: {
         initial: [
@@ -20,9 +20,9 @@ export default {
             { regex: /\/\/[^\n\r]*/, action: {"token":"comment"} },
         ],
         comment: [
-            { regex: /[^\/\*]+/, action: {"token":"comment"} },
+            { regex: /[^/\*]+/, action: {"token":"comment"} },
             { regex: /\*\//, action: {"token":"comment","next":"@pop"} },
-            { regex: /[\/\*]/, action: {"token":"comment"} },
+            { regex: /[/\*]/, action: {"token":"comment"} },
         ],
     }
 };

--- a/examples/statemachine/syntaxes/statemachine.tmLanguage.json
+++ b/examples/statemachine/syntaxes/statemachine.tmLanguage.json
@@ -18,13 +18,13 @@
       "patterns": [
         {
           "name": "comment.block.statemachine",
-          "begin": "\\/\\*",
+          "begin": "/\\*",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.comment.statemachine"
             }
           },
-          "end": "\\*\\/",
+          "end": "\\*/",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.comment.statemachine"
@@ -32,7 +32,7 @@
           }
         },
         {
-          "begin": "\\/\\/",
+          "begin": "//",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.comment.leading.statemachine"

--- a/packages/langium-cli/src/generator/highlighting/monarch-generator.ts
+++ b/packages/langium-cli/src/generator/highlighting/monarch-generator.ts
@@ -235,7 +235,7 @@ function prettyPrintLangDef(languageDef: LanguageDefinition, node: CompositeGene
         genLanguageDefEntry('keywords', languageDef.keywords), NL,
         genLanguageDefEntry('operators', languageDef.operators), NL,
         // special case, identify symbols via singular regex
-        'symbols:  /' + languageDef.symbols.map(escapeRegExp).join('|') + '/,'
+        `symbols: ${new RegExp(languageDef.symbols.map(escapeRegExp).join('|')).toString()},`
     );
 }
 
@@ -279,8 +279,8 @@ function prettyPrintState(state: State, node: CompositeGeneratorNode): void {
 function prettyPrintRule(ruleOrState: Rule | State): CompositeGeneratorNode {
     if (isRule(ruleOrState)) {
         // extract rule pattern, either just a string or a regex w/ parts
-        const rulePatt = ruleOrState.regex instanceof RegExp ? ruleOrState.regex.toString() : `/${ruleOrState.regex}/`;
-        return new CompositeGeneratorNode('{ regex: ' + rulePatt + ', action: ' + prettyPrintAction(ruleOrState.action) + ' },');
+        const rulePatt = ruleOrState.regex instanceof RegExp ? ruleOrState.regex : new RegExp(ruleOrState.regex);
+        return new CompositeGeneratorNode('{ regex: ' + rulePatt.toString() + ', action: ' + prettyPrintAction(ruleOrState.action) + ' },');
     } else {
         // include another state by name, implicitly includes all of its contents
         return new CompositeGeneratorNode(`{ include: '@${ruleOrState.name}' },`);

--- a/packages/langium/src/utils/regex-util.ts
+++ b/packages/langium/src/utils/regex-util.ts
@@ -123,10 +123,10 @@ export function getTerminalParts(regex: RegExp | string): Array<{ start: string,
 
 export function isMultilineComment(regex: RegExp | string): boolean {
     try {
-        if (typeof regex !== 'string') {
-            regex = regex.source;
+        if (typeof regex === 'string') {
+            regex = new RegExp(regex);
         }
-        regex = `/${regex}/`;
+        regex = regex.toString();
         visitor.reset(regex);
         // Parsing the pattern might fail (since it's user code)
         visitor.visit(regexParser.pattern(regex));
@@ -142,7 +142,7 @@ export function isWhitespaceRegExp(value: RegExp | string): boolean {
 }
 
 export function escapeRegExp(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export function getCaseInsensitivePattern(keyword: string): string {

--- a/packages/langium/test/utils/regex-util.test.ts
+++ b/packages/langium/test/utils/regex-util.test.ts
@@ -99,24 +99,24 @@ describe('comment start/end parts', () => {
 
     test('JS style singleline comment should start with //', () => {
         expect(getTerminalParts(/\/\/[^\n\r]*/)).toEqual([{
-            start: '\\/\\/',
+            start: '//',
             end: ''
         }]);
     });
 
     test('JS style multiline comment should start with /* and end with */', () => {
         expect(getTerminalParts(/\/\*[\s\S]*?\*\//)).toEqual([{
-            start: '\\/\\*',
-            end: '\\*\\/'
+            start: '/\\*',
+            end: '\\*/'
         }]);
     });
 
     test('JS style combined comment should contain both /* */ and // parts', () => {
         expect(getTerminalParts(/\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/)).toEqual([{
-            start: '\\/\\*',
-            end: '\\*\\/'
+            start: '/\\*',
+            end: '\\*/'
         }, {
-            start: '\\/\\/',
+            start: '//',
             end: ''
         }]);
     });


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/740

This was initially fixed back in https://github.com/langium/langium/pull/1070. However, the fix to escape `/` was just a workaround. While escaping `/` works as expected, it does not need to be escaped. The only reason it has to be escaped in JS is that `/` is the regex literal delimiter.

Using `new RegExp().toString()` automatically escapes `/` as needed. 