### PR TITLE
Use source maps for all debug configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,10 @@
             "args": [
                 "${workspaceFolder}/examples",
                 "--extensionDevelopmentPath=${workspaceFolder}/packages/langium-vscode"
+            ],
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/{packages,examples}/*/{lib,out}/**/*.js"
             ]
         },
         {
@@ -22,6 +26,10 @@
             "args": [
                 "${workspaceFolder}/examples/arithmetics/example",
                 "--extensionDevelopmentPath=${workspaceFolder}/examples/arithmetics"
+            ],
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/{packages,examples}/*/{lib,out}/**/*.js"
             ]
         },
         {
@@ -32,6 +40,10 @@
             "args": [
                 "${workspaceFolder}/examples/domainmodel/example",
                 "--extensionDevelopmentPath=${workspaceFolder}/examples/domainmodel"
+            ],
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/{packages,examples}/*/{lib,out}/**/*.js"
             ]
         },
         {
@@ -42,6 +54,10 @@
             "args": [
                 "${workspaceFolder}/examples/requirements/example",
                 "--extensionDevelopmentPath=${workspaceFolder}/examples/requirements"
+            ],
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/{packages,examples}/*/{lib,out}/**/*.js"
             ]
         },
         {
@@ -52,6 +68,10 @@
             "args": [
                 "${workspaceFolder}/examples/statemachine/example",
                 "--extensionDevelopmentPath=${workspaceFolder}/examples/statemachine"
+            ],
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/{packages,examples}/*/{lib,out}/**/*.js"
             ]
         },
         {
@@ -64,11 +84,7 @@
             ],
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceFolder}/packages/langium/lib/**/*.js",
-                "${workspaceFolder}/examples/arithmetics/out/**/*.js",
-                "${workspaceFolder}/examples/domainmodel/out/**/*.js",
-                "${workspaceFolder}/examples/statemachine/out/**/*.js",
-                "${workspaceFolder}/packages/langium-vscode/out/**/*.js"
+                "${workspaceFolder}/{packages,examples}/*/{lib,out}/**/*.js"
             ]
         },
         {

--- a/packages/generator-langium/templates/vscode/.vscode/launch.json
+++ b/packages/generator-langium/templates/vscode/.vscode/launch.json
@@ -11,6 +11,10 @@
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
             ]
         },
         {


### PR DESCRIPTION
I'm not sure when this has happened, but `extensionHost` type launch requests now require `sourceMaps` and `outFiles` arguments to debug the TypeScript sources.

This change adds these properties to our debug configs and the generated yeoman config.