### PR TITLE
Infer optional properties for guarded groups

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/inferred-types.ts
@@ -329,7 +329,9 @@ function newTypePart(element?: ParserRule | Action | string): TypePart {
  * @param element The given AST element, from which it's necessary to extract the type.
  */
 function collectElement(graph: TypeGraph, current: TypePart, element: AbstractElement): TypePart {
-    const optional = isOptionalCardinality(element.cardinality);
+    const optional = isOptionalCardinality(element.cardinality)
+        // Groups with guard conditions become optional as well
+        || (isGroup(element) && element.guardCondition);
     if (isAlternatives(element)) {
         const children: TypePart[] = [];
         if (optional) {

--- a/packages/langium/test/grammar/type-system/inferred-types.test.ts
+++ b/packages/langium/test/grammar/type-system/inferred-types.test.ts
@@ -74,6 +74,19 @@ describe('Inferred types', () => {
         `);
     });
 
+    test('Should infer optional property for guarded group', async () => {
+        await expectTypes(`
+            A<G>: a=ID (<G> b=ID);
+            terminal ID returns string: /string/;
+        `, expandToString`
+            export interface A extends AstNode {
+                readonly $type: 'A';
+                a: string
+                b?: string
+            }
+        `);
+    });
+
     test('Should correctly infer types using chained actions', async () => {
         await expectTypes(`
             A: a=ID ({infer B} b=ID ({infer C} c=ID)?)? d=ID;


### PR DESCRIPTION
Closes https://github.com/langium/langium/issues/1047

While collecting the AST types, this chanages how optionality is computed for guarded groups. If a group is guarded, all properties within are potentially optional.