### PR TITLE
Use exact project name for code generation

### DIFF
--- a/examples/requirements/langium-config.json
+++ b/examples/requirements/langium-config.json
@@ -1,5 +1,5 @@
 {
-    "projectName": "Requirements and Tests",
+    "projectName": "RequirementsAndTests",
     "languages": [{
         "id": "requirements-lang",
         "grammar": "src/language-server/requirements.langium",

--- a/packages/langium-cli/langium-config-schema.json
+++ b/packages/langium-cli/langium-config-schema.json
@@ -129,7 +129,8 @@
     "properties": {
         "projectName": {
             "description": "The name of your Langium project",
-            "type": "string"
+            "type": "string",
+            "pattern": "^[a-zA-Z_$][0-9a-zA-Z_$]*$"
         },
         "languages": {
             "description": "Your language configurations",

--- a/packages/langium-cli/src/package.ts
+++ b/packages/langium-cli/src/package.ts
@@ -10,7 +10,6 @@ import path from 'path';
 import type { GenerateOptions } from './generate';
 import { log } from './generator/util';
 import chalk from 'chalk';
-import _ from 'lodash';
 
 export interface Package {
     name: string
@@ -93,8 +92,6 @@ export async function loadConfig(options: GenerateOptions): Promise<LangiumConfi
     try {
         const obj = await fs.readJson(filePath, { encoding: 'utf-8' });
         const config: LangiumConfig = path.basename(filePath) === 'package.json' ? obj.langium : obj;
-        config.projectName = _.camelCase(config.projectName);
-        config.projectName = config.projectName.charAt(0).toUpperCase() + config.projectName.slice(1);
         config[RelativePath] = relativePath;
         return config;
     } catch (err) {


### PR DESCRIPTION
The default case type conversion rule don't always make sense for abbreviated project names. For example:

```json
{
  "projectName": "FormML",
  "languages": [
    ...
  ],
}
```

Then generated codes will be like `FormMlAstType`. But the expectation may be `FormMLAstType` to keep abbreviations in uppercase.

So I add an option `exact` to indicate that don't do any change on project name in generation.