### PR TITLE
Renamed some properties in the CST

### DIFF
--- a/packages/langium/src/generator/generator-tracing.ts
+++ b/packages/langium/src/generator/generator-tracing.ts
@@ -72,7 +72,7 @@ export function getSourceRegion(sourceSpec: TraceSourceSpec | undefined | Source
         const sourceRegion: SourceRegionPartial = sourceSpec;
 
         const sourceFileURIviaCstNode = isCstNode(sourceRegion)
-            ? getDocumentURIOrUndefined(sourceRegion?.root?.element ?? sourceRegion?.element) : undefined;
+            ? getDocumentURIOrUndefined(sourceRegion?.root?.astNode ?? sourceRegion?.astNode) : undefined;
 
         return copyDocumentSegment(sourceRegion, sourceFileURIviaCstNode);
     }

--- a/packages/langium/src/grammar/lsp/grammar-call-hierarchy.ts
+++ b/packages/langium/src/grammar/lsp/grammar-call-hierarchy.ts
@@ -31,7 +31,7 @@ export class LangiumGrammarCallHierarchyProvider extends AbstractCallHierarchyPr
             if (!targetNode) {
                 return;
             }
-            const parserRule = getContainerOfType(targetNode.element, isParserRule);
+            const parserRule = getContainerOfType(targetNode.astNode, isParserRule);
             if (!parserRule || !parserRule.$cstNode) {
                 return;
             }
@@ -77,11 +77,11 @@ export class LangiumGrammarCallHierarchyProvider extends AbstractCallHierarchyPr
             if (!refCstNode) {
                 return;
             }
-            const refNameNode = this.nameProvider.getNameNode(refCstNode.element);
+            const refNameNode = this.nameProvider.getNameNode(refCstNode.astNode);
             if (!refNameNode) {
                 return;
             }
-            const refDocUri = getDocument(refCstNode.element).uri.toString();
+            const refDocUri = getDocument(refCstNode.astNode).uri.toString();
             const ruleId = refDocUri + '@' + refNameNode.text;
 
             uniqueRules.has(ruleId) ?

--- a/packages/langium/src/grammar/lsp/grammar-code-actions.ts
+++ b/packages/langium/src/grammar/lsp/grammar-code-actions.ts
@@ -249,7 +249,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         const rootCst = document.parseResult.value.$cstNode;
         if (rootCst) {
             const cstNode = findLeafNodeAtOffset(rootCst, offset);
-            const container = getContainerOfType(cstNode?.element, ast.isCharacterRange);
+            const container = getContainerOfType(cstNode?.astNode, ast.isCharacterRange);
             if (container && container.right && container.$cstNode) {
                 const left = container.left.value;
                 const right = container.right.value;
@@ -337,7 +337,7 @@ export class LangiumGrammarCodeActionProvider implements CodeActionProvider {
         const rootCst = document.parseResult.value.$cstNode;
         if (rootCst) {
             const cstNode = findLeafNodeAtOffset(rootCst, offset);
-            const container = getContainerOfType(cstNode?.element, ast.isParserRule);
+            const container = getContainerOfType(cstNode?.astNode, ast.isParserRule);
             if (container && container.$cstNode) {
                 return {
                     title: `Add new rule '${data.refText}'`,

--- a/packages/langium/src/grammar/lsp/grammar-definition.ts
+++ b/packages/langium/src/grammar/lsp/grammar-definition.ts
@@ -28,8 +28,8 @@ export class LangiumGrammarDefinitionProvider extends DefaultDefinitionProvider 
 
     protected override collectLocationLinks(sourceCstNode: LeafCstNode, _params: DefinitionParams): MaybePromise<LocationLink[] | undefined> {
         const pathFeature: Properties<GrammarImport> = 'path';
-        if (isGrammarImport(sourceCstNode.element) && findAssignment(sourceCstNode)?.feature === pathFeature) {
-            const importedGrammar = resolveImport(this.documents, sourceCstNode.element);
+        if (isGrammarImport(sourceCstNode.astNode) && findAssignment(sourceCstNode)?.feature === pathFeature) {
+            const importedGrammar = resolveImport(this.documents, sourceCstNode.astNode);
             if (importedGrammar?.$document) {
                 const targetObject = this.findTargetObject(importedGrammar) ?? importedGrammar;
                 const selectionRange = this.nameProvider.getNameNode(targetObject)?.range ?? Range.create(0, 0, 0, 0);

--- a/packages/langium/src/grammar/references/grammar-references.ts
+++ b/packages/langium/src/grammar/references/grammar-references.ts
@@ -30,7 +30,7 @@ export class LangiumGrammarReferences extends DefaultReferences {
     }
 
     override findDeclaration(sourceCstNode: CstNode): AstNode | undefined {
-        const nodeElem = sourceCstNode.element;
+        const nodeElem = sourceCstNode.astNode;
         const assignment = findAssignment(sourceCstNode);
         if (assignment && assignment.feature === 'feature') {
             // Only search for a special declaration if the cst node is the feature property of the action/assignment

--- a/packages/langium/src/lsp/call-hierarchy-provider.ts
+++ b/packages/langium/src/lsp/call-hierarchy-provider.ts
@@ -57,7 +57,7 @@ export abstract class AbstractCallHierarchyProvider implements CallHierarchyProv
             return undefined;
         }
 
-        return this.getCallHierarchyItems(declarationNode.element, document);
+        return this.getCallHierarchyItems(declarationNode.astNode, document);
     }
 
     protected getCallHierarchyItems(targetNode: AstNode, document: LangiumDocument<AstNode>): CallHierarchyItem[] | undefined {
@@ -94,12 +94,12 @@ export abstract class AbstractCallHierarchyProvider implements CallHierarchyProv
         }
 
         const references = this.references.findReferences(
-            targetNode.element,
+            targetNode.astNode,
             {
                 includeDeclaration: false
             }
         );
-        return this.getIncomingCalls(targetNode.element, references);
+        return this.getIncomingCalls(targetNode.astNode, references);
     }
 
     /**
@@ -118,7 +118,7 @@ export abstract class AbstractCallHierarchyProvider implements CallHierarchyProv
         if (!targetNode) {
             return undefined;
         }
-        return this.getOutgoingCalls(targetNode.element);
+        return this.getOutgoingCalls(targetNode.astNode);
     }
 
     /**

--- a/packages/langium/src/lsp/completion/completion-provider.ts
+++ b/packages/langium/src/lsp/completion/completion-provider.ts
@@ -231,7 +231,7 @@ export class DefaultCompletionProvider implements CompletionProvider {
         };
         let astNode: AstNode | undefined;
         if (previousTokenStart !== undefined && previousTokenEnd !== undefined && previousTokenEnd === offset) {
-            astNode = findLeafNodeAtOffset(cst, previousTokenStart)?.element;
+            astNode = findLeafNodeAtOffset(cst, previousTokenStart)?.astNode;
             const previousTokenFeatures = this.findFeaturesAt(textDocument, previousTokenStart);
             yield {
                 ...partialContext,
@@ -241,8 +241,8 @@ export class DefaultCompletionProvider implements CompletionProvider {
                 features: previousTokenFeatures,
             };
         }
-        astNode = findLeafNodeAtOffset(cst, nextTokenStart)?.element
-            ?? (previousTokenStart === undefined ? undefined : findLeafNodeAtOffset(cst, previousTokenStart)?.element);
+        astNode = findLeafNodeAtOffset(cst, nextTokenStart)?.astNode
+            ?? (previousTokenStart === undefined ? undefined : findLeafNodeAtOffset(cst, previousTokenStart)?.astNode);
 
         if (!astNode) {
             const parserRule = getEntryRule(this.grammar)!;

--- a/packages/langium/src/lsp/definition-provider.ts
+++ b/packages/langium/src/lsp/definition-provider.ts
@@ -64,7 +64,7 @@ export class DefaultDefinitionProvider implements DefinitionProvider {
         if (goToLink) {
             return [LocationLink.create(
                 goToLink.targetDocument.textDocument.uri,
-                (goToLink.target.element.$cstNode ?? goToLink.target).range,
+                (goToLink.target.astNode.$cstNode ?? goToLink.target).range,
                 goToLink.target.range,
                 goToLink.source.range
             )];
@@ -74,8 +74,8 @@ export class DefaultDefinitionProvider implements DefinitionProvider {
 
     protected findLink(source: CstNode): GoToLink | undefined {
         const target = this.references.findDeclarationNode(source);
-        if (target?.element) {
-            const targetDocument = getDocument(target.element);
+        if (target?.astNode) {
+            const targetDocument = getDocument(target.astNode);
             if (target && targetDocument) {
                 return { source, target, targetDocument };
             }

--- a/packages/langium/src/lsp/formatter.ts
+++ b/packages/langium/src/lsp/formatter.ts
@@ -470,8 +470,8 @@ export abstract class AbstractFormatter implements Formatter {
         return new StreamImpl<{ index: number }, CstNode>(
             () => ({ index: 0 }),
             (state) => {
-                if (state.index < node.children.length) {
-                    return { done: false, value: node.children[state.index++] };
+                if (state.index < node.content.length) {
+                    return { done: false, value: node.content[state.index++] };
                 } else {
                     // Reset the indentation to the level when we entered the node
                     context.indentation = initial;

--- a/packages/langium/src/lsp/rename-provider.ts
+++ b/packages/langium/src/lsp/rename-provider.ts
@@ -94,6 +94,6 @@ export class DefaultRenameProvider implements RenameProvider {
     }
 
     protected isNameNode(leafNode: CstNode | undefined): boolean | undefined {
-        return leafNode?.element && isNamed(leafNode.element) && leafNode === this.nameProvider.getNameNode(leafNode.element);
+        return leafNode?.astNode && isNamed(leafNode.astNode) && leafNode === this.nameProvider.getNameNode(leafNode.astNode);
     }
 }

--- a/packages/langium/src/lsp/signature-help-provider.ts
+++ b/packages/langium/src/lsp/signature-help-provider.ts
@@ -32,7 +32,7 @@ export abstract class AbstractSignatureHelpProvider implements SignatureHelpProv
         if (cst) {
             const sourceCstNode = findLeafNodeAtOffset(cst, document.textDocument.offsetAt(params.position));
             if (sourceCstNode) {
-                return this.getSignatureFromElement(sourceCstNode.element, cancelToken);
+                return this.getSignatureFromElement(sourceCstNode.astNode, cancelToken);
             }
         }
         return undefined;

--- a/packages/langium/src/parser/value-converter.ts
+++ b/packages/langium/src/parser/value-converter.ts
@@ -25,7 +25,7 @@ export type ValueType = string | number | boolean | bigint | Date;
 export class DefaultValueConverter implements ValueConverter {
 
     convert(input: string, cstNode: CstNode): ValueType {
-        let feature: AbstractElement | undefined = cstNode.feature;
+        let feature: AbstractElement | undefined = cstNode.grammarSource;
         if (isCrossReference(feature)) {
             feature = getCrossReferenceTerminal(feature);
         }

--- a/packages/langium/src/references/references.ts
+++ b/packages/langium/src/references/references.ts
@@ -77,7 +77,7 @@ export class DefaultReferences implements References {
     findDeclaration(sourceCstNode: CstNode): AstNode | undefined {
         if (sourceCstNode) {
             const assignment = findAssignment(sourceCstNode);
-            const nodeElem = sourceCstNode.element;
+            const nodeElem = sourceCstNode.astNode;
             if (assignment && nodeElem) {
                 const reference = (nodeElem as GenericAstNode)[assignment.feature];
 

--- a/packages/langium/src/syntax-tree.ts
+++ b/packages/langium/src/syntax-tree.ts
@@ -215,28 +215,36 @@ export interface TypeMandatoryProperty {
  */
 export interface CstNode extends DocumentSegment {
     /** The container node in the CST */
+    readonly container?: CompositeCstNode;
+    /** @deprecated use `container` instead. */
     readonly parent?: CompositeCstNode;
     /** The actual text */
     readonly text: string;
     /** The root CST node */
     readonly root: RootCstNode;
     /** The grammar element from which this node was parsed */
+    readonly grammarSource: AbstractElement;
+    /** @deprecated use `grammarSource` instead. */
     readonly feature: AbstractElement;
     /** The AST node created from this CST node */
+    readonly astNode: AstNode;
+    /** @deprecated use `astNode` instead. */
     readonly element: AstNode;
     /** Whether the token is hidden, i.e. not explicitly part of the containing grammar rule */
     readonly hidden: boolean;
 }
 
 /**
- * A composite CST node has children, but no directly associated token.
+ * A composite CST node contains other nodes, but no directly associated token.
  */
 export interface CompositeCstNode extends CstNode {
+    readonly content: CstNode[];
+    /** @deprecated use `content` instead. */
     readonly children: CstNode[];
 }
 
 export function isCompositeCstNode(node: unknown): node is CompositeCstNode {
-    return typeof node === 'object' && node !== null && 'children' in node;
+    return typeof node === 'object' && node !== null && Array.isArray((node as CompositeCstNode).content);
 }
 
 /**
@@ -247,7 +255,7 @@ export interface LeafCstNode extends CstNode {
 }
 
 export function isLeafCstNode(node: unknown): node is LeafCstNode {
-    return typeof node === 'object' && node !== null && 'tokenType' in node;
+    return typeof node === 'object' && node !== null && typeof (node as LeafCstNode).tokenType === 'object';
 }
 
 export interface RootCstNode extends CompositeCstNode {
@@ -255,7 +263,7 @@ export interface RootCstNode extends CompositeCstNode {
 }
 
 export function isRootCstNode(node: unknown): node is RootCstNode {
-    return isCompositeCstNode(node) && 'fullText' in node;
+    return isCompositeCstNode(node) && typeof (node as RootCstNode).fullText === 'string';
 }
 
 /**


### PR DESCRIPTION
I noticed that our CST has properties named after the "node model" of Xtext. I propose to rename some to improve clarity:
 - `parent`  → `container`
 - `children` → `content`
 - `feature` → `grammarSource`
 - `element` → `astNode`