### PR TITLE
Fix edge case behavior in parser value assignment

### DIFF
--- a/packages/langium/src/parser/cst-node-builder.ts
+++ b/packages/langium/src/parser/cst-node-builder.ts
@@ -225,7 +225,7 @@ export class CompositeCstNodeImpl extends AbstractCstNode implements CompositeCs
 
     private get firstNonHiddenNode(): CstNode | undefined {
         for (const child of this.content) {
-            if (!child.hidden) {
+            if (!child.hidden && !isNaN(child.offset)) {
                 return child;
             }
         }
@@ -235,7 +235,7 @@ export class CompositeCstNodeImpl extends AbstractCstNode implements CompositeCs
     private get lastNonHiddenNode(): CstNode | undefined {
         for (let i = this.content.length - 1; i >= 0; i--) {
             const child = this.content[i];
-            if (!child.hidden) {
+            if (!child.hidden && !isNaN(child.end)) {
                 return child;
             }
         }

--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -213,7 +213,7 @@ export class LangiumParser extends AbstractLangiumParser {
             cstNode = this.nodeBuilder.buildCompositeNode(feature);
         }
         const subruleResult = this.wrapper.wrapSubrule(idx, rule, args) as any;
-        if (!this.isRecording() && cstNode && cstNode.length > 0) {
+        if (!this.isRecording() && cstNode && cstNode.content.length > 0) {
             this.performSubruleAssignment(subruleResult, feature, cstNode);
         }
     }


### PR DESCRIPTION
The author over at https://github.com/mermaid-js/mermaid/pull/4450 has hit some interesting edge case behavior when the lexer output contains `NaN`. In that case, the `cstNode.length` property becomes `NaN` and the assignment isn't performed. While this lexer behavior is generally not recommended, Langium should deal with it gracefully. The current behavior is straight up just confusing.