### PR TITLE
fix: update `railroad-diagrams` default import

### DIFF
--- a/packages/langium-railroad/src/grammar-railroad.ts
+++ b/packages/langium-railroad/src/grammar-railroad.ts
@@ -6,7 +6,7 @@
 
 import { GrammarAST, findNameAssignment } from 'langium';
 import type { FakeSVG } from 'railroad-diagrams';
-import * as rr from 'railroad-diagrams';
+import { default as rr } from 'railroad-diagrams';
 
 export const defaultCss = `
 svg.railroad-diagram {


### PR DESCRIPTION
Railroad diagram import isn't correct here:

<https://github.com/langium/langium/blob/13f482bf33169092f17cf92e327b799c21f5b4dc/packages/langium-railroad/src/grammar-railroad.ts#L9>

Because the default import object is this:

```ts
[Module: null prototype] {
  default: {
    Diagram: [Function: Diagram] {
      VERTICAL_SEPARATION: 8,
      ARC_RADIUS: 10,
      DIAGRAM_CLASS: 'railroad-diagram',
      STROKE_ODD_PIXEL_LENGTH: true,
      INTERNAL_ALIGNMENT: 'center'
    },
    ComplexDiagram: [Function: ComplexDiagram],
    Sequence: [Function: Sequence],
    Choice: [Function: Choice],
    Optional: [Function: Optional],
    OneOrMore: [Function: OneOrMore],
    ZeroOrMore: [Function: ZeroOrMore],
    Terminal: [Function: Terminal],
    NonTerminal: [Function: NonTerminal],
    Comment: [Function: Comment],
    Skip: [Function: Skip]
  }
}
```

Before changes:

```
[23:07:01] Reading config from langium-config.json
[23:07:02] Writing generated files to mermaid/packages/parser/src/language/generated
TypeError: rr.NonTerminal is not a constructor
    at toRailroad (file://mermaid/node_modules/.pnpm/langium-railroad@2.0.0-next.a57102f/node_modules/langium-railroad/lib/grammar-railroad.js:87:54)
    at file://mermaid/node_modules/.pnpm/langium-railroad@2.0.0-next.a57102f/node_modules/langium-railroad/lib/grammar-railroad.js:81:100
    at Array.flatMap (<anonymous>)
    at toRailroad (file://mermaid/node_modules/.pnpm/langium-railroad@2.0.0-next.a57102f/node_modules/langium-railroad/lib/grammar-railroad.js:81:87)
    at createRuleDiagram (file://mermaid/node_modules/.pnpm/langium-railroad@2.0.0-next.a57102f/node_modules/langium-railroad/lib/grammar-railroad.js:65:36)
    at createGrammarDiagram (file://mermaid/node_modules/.pnpm/langium-railroad@2.0.0-next.a57102f/node_modules/langium-railroad/lib/grammar-railroad.js:60:17)
    at createGrammarDiagramHtml (file://mermaid/node_modules/.pnpm/langium-railroad@2.0.0-next.a57102f/node_modules/langium-railroad/lib/grammar-railroad.js:50:13)
    at generate (file://mermaid/node_modules/.pnpm/langium-cli@2.0.0-next.a57102f/node_modules/langium-cli/lib/generate.js:247:29)
    at async runGenerator (file://mermaid/node_modules/.pnpm/langium-cli@2.0.0-next.a57102f/node_modules/langium-cli/lib/langium.js:47:20)
mermaid/packages/parser:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  mermaid-parser@0.2.0 langium:watch: `langium generate --watch`
Exit status 1
```

After changes:

```
[23:02:41] Reading config from langium-config.json
[23:02:42] Writing generated files to mermaid/packages/parser/src/language/generated
[23:02:42] Writing railroad syntax diagram to mermaid/packages/parser/src/docs.html
[23:02:42] Langium generator finished successfully in 309ms
[23:02:42] Langium generator will continue running in watch mode.
```