### PR TITLE
Fix the CST after performing assigned actions

### DIFF
--- a/packages/langium/src/parser/langium-parser.ts
+++ b/packages/langium/src/parser/langium-parser.ts
@@ -340,6 +340,7 @@ export class LangiumParser extends AbstractLangiumParser {
             let last = this.current;
             if (action.feature && action.operator) {
                 last = this.construct();
+                this.nodeBuilder.removeNode(last.$cstNode);
                 const node = this.nodeBuilder.buildCompositeNode(action);
                 node.content.push(last.$cstNode);
                 const newItem = { $type };


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/1645

We accidentally never actually removed the CST node that was added before executing the action. This led to CST nodes being available in the CST multiple times and accidentally shadowing some other nodes. In the case of the linked issue, the erroneous CST node shadowed a comment node.