### PR TITLE
Improve range calculation for linking errors

### DIFF
--- a/packages/langium/src/validation/document-validator.ts
+++ b/packages/langium/src/validation/document-validator.ts
@@ -164,6 +164,7 @@ export class DefaultDocumentValidator implements DocumentValidator {
             if (linkingError) {
                 const info: DiagnosticInfo<AstNode, string> = {
                     node: linkingError.container,
+                    range: reference.$refNode?.range,
                     property: linkingError.property,
                     index: linkingError.index,
                     data: {


### PR DESCRIPTION
In some rare cases (grammar specific), the error would appear on the incorrect range. Instead of searching through the CST for the range of the reference, we should simply use `$refNode.range`, which is already available at this point and can be accessed without expensive search.