### PR TITLE
fix: resolves keyword pattern matching defect in TextMate grammar for .langium files

### DIFF
--- a/packages/langium-vscode/data/langium.tmLanguage.json
+++ b/packages/langium-vscode/data/langium.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.langium",
-            "match": "\\b(left|right|assoc|current|entry|extends|fragment|grammar|hidden|import|infer|infers|infix|interface|returns|terminal|type|with|on)\\b"
+            "match": "(?<![a-zA-Z_$])(left|right|assoc|current|entry|extends|fragment|grammar|hidden|import|infer|infers|infix|interface|returns|terminal|type|with|on)(?![a-zA-Z_$])"
         },
         {
             "name": "constant.language.langium",


### PR DESCRIPTION
Improves keyword matching for Langium control keywords to prevent false positives.

Replaces word boundaries (\b) with negative lookbehind and lookahead assertions to more precisely match Langium keywords, ensuring they're not part of longer identifiers containing letters, underscores, or dollar signs.