### PR TITLE
DefaultWorkspaceManager: improve error handling in traverseFolder

### DIFF
--- a/packages/langium/src/workspace/workspace-manager.ts
+++ b/packages/langium/src/workspace/workspace-manager.ts
@@ -206,9 +206,8 @@ export class DefaultWorkspaceManager implements WorkspaceManager {
                     }
                 }
             }));
-        } catch(e) {
-            console.error('Failure while reading directory content', e);
-            return Promise.resolve();
+        } catch (e) {
+            console.error('Failure to read directory content of ' + folderPath.toString(true), e);
         }
     }
 


### PR DESCRIPTION
fixes #2044 

- check if directory exists eg in workspaces a directory could have been delete since the last start
- catch all errors while reading the directory content