### PR TITLE
Add sbom generation and upload workflow

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,71 @@
+name: Generate SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version"
+        default: "main"
+        required: true
+
+env:
+  REGISTRY_URL: "https://registry.npmjs.org"
+  CDXGEN_VERSION: "11.7.0"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    permissions:
+      packages: read
+
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version: $VERSION"
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.version.outputs.PROJECT_VERSION }}
+
+      - name: Setup Node SDK
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: ${{ env.REGISTRY_URL }}
+
+      - name: Install cdxgen
+        run: |
+          npm install -g @cyclonedx/cdxgen@${{ env.CDXGEN_VERSION }}
+
+      - name: Generate SBOM
+        run: |
+          cdxgen -r -o bom.json --filter=examples
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: sbom
+          path: bom.json
+
+  store-sbom-data: # stores sbom and metadata in a predefined format for otterdog to pick up
+    needs: ["generate-sbom"]
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: "langium-workspaces"
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: "sbom"
+      bomFilename: "bom.json"
+      parentProject: "9f4d61ec-852d-4270-b6f5-31c7ad58c1a4"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ More complex examples are available as separate repositories in [our GitHub orga
 * **[lox](https://github.com/langium/langium-lox)**: Implementation of the Lox language from the popular book [Crafting Interpreters](https://craftinginterpreters.com/the-lox-language.html).
 * **[minilogo](https://github.com/langium/langium-minilogo)**: Implementation of a [logo](https://el.media.mit.edu/logo-foundation/what_is_logo/logo_programming.html) language dialect. Shows how to integrate Langium in the browser.
 
+## SBOM
+
+To enhance supply chain security and offer users clear insight into project  components, Eclipse Langium now generates a Software Bill of Materials (SBOM) for every release. These are published to the Eclipse Foundation SBOM registry, with access instructions and usage details available in this [documentation](https://eclipse-csi.github.io/security-handbook/sbom/registry.html).
+
 ## Contributing
 
 If you want to contribute to Langium, please take a look at [our contributing guide](https://github.com/eclipse-langium/langium/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
### What it does
This PR aims to bootstrap the EF Security Team initiative of supporting projects in implementing automated SBOM generation and upload workflows, with the goal of enhancing software supply chain security.

We wanted this to seamlessly integrate with your existing release processes, so we implemented 1 workflow meant to generate an SBOM for all products comprised in this repository.

Currently the workflow is triggered by new releases being published. A polyglot tool (`cdxgen`) is used to generate the SBOM, which is then uploaded as an artifact. The `store-sbom-data` reusable workflow stores additional metadata about the project and upon completion, the self service system downloads the SBOM from artifacts and uploads it to our DependencyTrack [instance](https://sbom.eclipse.org/), under the `Eclipse Langium/langium-workspaces` entry. After a successful workflow run, to view the uploaded results, you can log into the instance by using your EF account credentials.

For any inconsistencies or potential integration issues with existing release processes that we might have missed, please feel free to update the workflow as needed, edits by maintainers are enabled.

More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html), alongside documentation on what is an SBOM, what are they used for, tooling ecosystem and our upload integration. Previous successful early adopters workflow examples are listed in the table at [SBOM Early Adopters](https://eclipse-csi.github.io/security-handbook/sbom/earlyadopters.html). Additionally, more information about our DependencyTrack instance can be found at [SBOM Registry](https://eclipse-csi.github.io/security-handbook/sbom/registry.html).

Please let us know if you have any questions we can help with.

### How to test

SBOMs will be generated when a new Github Release is created. In order to test, there's the option to do a manual run of the workflow. We have tested the SBOM generation separately and everything worked successfully. However, due to limited permissions, inability to simulate the trigger event and possibly incomplete knowledge of your release processes, if the changes get merged, we'd ask if you could manually run it once so we can confirm the upload to our instance works as expected. 

For the "Version" input, the value of the latest **release tag** can be used, together with the default branch. Allow a couple of minutes after completion for otterdog to pick up the SBOM. Afterwards, it should appear on our DependencyTrack instance. Instructions on how to log into it can be found in our [Security Handbook/SBOM Registry](https://eclipse-csi.github.io/security-handbook/sbom/registry.html).

### Notes
- `langium-workspaces` is a mono-repo that holds multiple components (packages) listed under `workspaces`. The workflow generates 1 "aggregate" SBOM for all these components. Therefore, if they  are to be used independently, to assess risk/mitigate vulnerabilities, extra search steps will be required. As available tooling improves, generating multiple SBOMs - one per product - might be a good idea to look into in the future.
- `devDependencies` are captured in the SBOM; `cdxgen` has a `required-only` option that should differentiate between dev/prod dependencies, however in this case using the option seems to makes the components (packages) not show in the SBOM.
- Looking through: https://www.npmjs.com/package/langium?activeTab=versions it seems there are more versions available that the ones with a Github Release associated. It's important to note that unless one is created or the workflow is manually run (for example on a tag) - those versions will not have an SBOM generated
