### PR TITLE
Improve source range display on definition request

### DIFF
--- a/packages/langium/src/lsp/definition-provider.ts
+++ b/packages/langium/src/lsp/definition-provider.ts
@@ -15,7 +15,7 @@ import type { MaybePromise } from '../utils/promise-utils.js';
 import type { LangiumDocument } from '../workspace/documents.js';
 import { LocationLink } from 'vscode-languageserver';
 import { getDocument } from '../utils/ast-utils.js';
-import { findDeclarationNodeAtOffset } from '../utils/cst-utils.js';
+import { findDeclarationNodeAtOffset, getDatatypeNode } from '../utils/cst-utils.js';
 
 /**
  * Language-specific service for handling go to definition requests.
@@ -79,12 +79,17 @@ export class DefaultDefinitionProvider implements DefinitionProvider {
     }
 
     protected findLinks(source: CstNode): GoToLink[] {
+        const datatypeSourceNode = getDatatypeNode(source) ?? source;
         const targets = this.references.findDeclarationNodes(source);
         const links: GoToLink[] = [];
         for (const target of targets) {
             const targetDocument = getDocument(target.astNode);
             if (targets && targetDocument) {
-                links.push({ source, target, targetDocument });
+                links.push({
+                    source: datatypeSourceNode,
+                    target,
+                    targetDocument
+                });
             }
         }
         return links;


### PR DESCRIPTION
I noticed that we use the `source` field of the definition request result incorrectly in case the source node is part of a data type rule. This change will actually highlight the full range of the data type rule that contains the clicked element.

Can also be tested with the domain model example in our repo:

<img width="304" height="204" alt="image" src="https://github.com/user-attachments/assets/1a714c69-8d34-4669-a253-95fae7207cdf" />
