### PR TITLE
Fix union type assignments

### DIFF
--- a/packages/langium/src/grammar/type-system/type-collector/types.ts
+++ b/packages/langium/src/grammar/type-system/type-collector/types.ts
@@ -302,12 +302,6 @@ function isTypeAssignableInternal(from: PropertyType | undefined, to: PropertyTy
         result = from.types.every(fromType => isTypeAssignableInternal(fromType, to, visited));
     } else if (isPropertyUnion(to)) {
         result = to.types.some(toType => isTypeAssignableInternal(from, toType, visited));
-    } else if (isValueType(to) && isUnionType(to.value)) {
-        if (isValueType(from) && isUnionType(from.value) && to.value.name === from.value.name) {
-            result = true;
-        } else {
-            result = isTypeAssignableInternal(from, to.value.type, visited);
-        }
     } else if (isReferenceType(from)) {
         result = isReferenceType(to)
             && from.isMulti === to.isMulti
@@ -335,6 +329,12 @@ function isTypeAssignableInternal(from: PropertyType | undefined, to: PropertyTy
             result = isTypeAssignableInternal(from, to.value.type, visited);
         } else {
             result = isInterfaceAssignable(from.value, to.value, new Set());
+        }
+    } else if (isValueType(to) && isUnionType(to.value)) {
+        if (isValueType(from) && isUnionType(from.value) && to.value.name === from.value.name) {
+            result = true;
+        } else {
+            result = isTypeAssignableInternal(from, to.value.type, visited);
         }
     } else if (isPrimitiveType(from)) {
         result = isPrimitiveType(to) && from.primitive === to.primitive;

--- a/packages/langium/test/grammar/type-system/type-validator.test.ts
+++ b/packages/langium/test/grammar/type-system/type-validator.test.ts
@@ -319,6 +319,22 @@ describe('Validate declared types', () => {
         `);
         expectNoIssues(validationResult);
     });
+
+    test('Can assign a union type value returned by a differently named rule', async () => {
+        const validationResult = await validate(`
+            interface ColorContainer {
+                color: Color
+            }
+            type Color = 'red' | 'blue' | 'green';
+            ColorContainer returns ColorContainer:
+                'color' color=ColorValue
+            ;
+            ColorValue returns Color:
+                'red' | 'blue' | 'green'
+            ;
+        `);
+        expectNoIssues(validationResult);
+    });
 });
 
 describe('Validate declared default value properties', () => {


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/issues/2074

I've noticed we're processing the `isValueType(to)` type to early, before completely "unwrapping" the `from` type. This eventually leads to some code which tries to assert that a union type can be assigned to a single value, which will quickly result in failure.

This change adjusts the order to move the unwrapping of the `to` type *after* the unwrapping of the `from` type.