### PR TITLE
Refactor follow element computation

### DIFF
--- a/packages/langium/src/lsp/completion/follow-element-computation.ts
+++ b/packages/langium/src/lsp/completion/follow-element-computation.ts
@@ -6,10 +6,8 @@
 
 import type { IToken } from 'chevrotain';
 import * as ast from '../../languages/generated/ast.js';
-import { isAstNode } from '../../syntax-tree.js';
-import { getContainerOfType } from '../../utils/ast-utils.js';
-import type { Cardinality } from '../../utils/grammar-utils.js';
 import { getCrossReferenceTerminal, getExplicitRuleType, getTypeName, isArrayCardinality, isOptionalCardinality, terminalRegex } from '../../utils/grammar-utils.js';
+import { getContainerOfType } from '../../utils/ast-utils.js';
 
 export interface NextFeature<T extends ast.AbstractElement = ast.AbstractElement> {
     /**
@@ -30,7 +28,7 @@ export interface NextFeature<T extends ast.AbstractElement = ast.AbstractElement
  * Calculates any features that can follow the given feature stack.
  * This also includes features following optional features and features from previously called rules that could follow the last feature.
  * @param featureStack A stack of features starting at the entry rule and ending at the feature of the current cursor position.
- * @param unparsedTokens All tokens which haven't been parsed successfully yet. This is the case when we call this function inside an alternative.
+ * @param unparsedTokens All tokens which haven't been parsed successfully yet. This is the case when we call this function inside an alternative or before parsing any tokens.
  * @returns Any `AbstractElement` that could be following the given feature stack.
  */
 export function findNextFeatures(featureStack: NextFeature[][], unparsedTokens: IToken[]): NextFeature[] {
@@ -46,68 +44,74 @@ export function findNextFeatures(featureStack: NextFeature[][], unparsedTokens: 
     return nextStacks.map(e => e[e.length - 1]);
 }
 
-function findNextFeaturesInternal(options: { next: NextFeature, cardinalities: Map<ast.AbstractElement, Cardinality>, visited: Set<ast.AbstractElement>, plus: Set<ast.AbstractElement> }): NextFeature[] {
-    const { next, cardinalities, visited, plus } = options;
-    const features: NextFeature[] = [];
-    const feature = next.feature;
-    if (visited.has(feature)) {
-        return [];
-    } else if (!ast.isGroup(feature)) {
-        // Do not add the feature to the list if it is a group
-        // `findFirstFeaturesInternal` will take care of this
-        visited.add(feature);
+function findNextFeaturesInternal(stack: NextFeature[]): NextFeature[][] {
+    const features: NextFeature[][] = [];
+    if (stack.length === 0) {
+        return features;
     }
-    let parent: ast.Group | undefined;
-    let item = feature;
-    while (item.$container) {
-        if (ast.isGroup(item.$container)) {
-            parent = item.$container;
-            break;
-        } else if (ast.isAbstractElement(item.$container)) {
-            item = item.$container;
-        } else {
-            break;
-        }
-    }
-    // First try to iterate the same element again
-    if (isArrayCardinality(item.cardinality)) {
+    const top = stack[stack.length - 1];
+    const { group, child } = findGroupAndChild(top.feature);
+
+    if (isArrayCardinality(child.cardinality)) {
+        // The feature can appear again, so we try to find its first features again
         const repeatingFeatures = findFirstFeaturesInternal({
-            next: {
-                feature: item,
-                type: next.type
-            },
-            cardinalities,
-            visited,
-            plus
+            feature: child,
+            type: top.type,
+            property: top.property
         });
-        for (const repeatingFeature of repeatingFeatures) {
-            plus.add(repeatingFeature.feature);
-        }
         features.push(...repeatingFeatures);
     }
-    if (parent) {
-        const ownIndex = parent.elements.indexOf(item);
-        // Find next elements of the same group
-        if (ownIndex !== undefined && ownIndex < parent.elements.length - 1) {
-            features.push(...findNextFeaturesInGroup({
-                feature: parent,
-                type: next.type
-            }, ownIndex + 1, cardinalities, visited, plus));
-        }
-        // Try to find the next elements of the parent
-        // Only do this if every following element is either optional or has been parsed as +
-        if (features.every(e => isOptionalCardinality(e.feature.cardinality, e.feature) || isOptionalCardinality(cardinalities.get(e.feature)) || plus.has(e.feature))) {
-            features.push(...findNextFeaturesInternal({
-                next: {
+
+    let groupIndex = -1;
+    if (group) {
+        groupIndex = group.elements.indexOf(child);
+    }
+
+    const parentStack = stack.slice(0, -1);
+    if (!group) {
+        const parent = getAbstractElementParent(child);
+        if (parent) {
+            // The feature is not part of a group
+            // But the parent might be
+            features.push(...findNextFeaturesInternal([
+                ...parentStack,
+                {
                     feature: parent,
-                    type: next.type
-                },
-                cardinalities,
-                visited,
-                plus
-            }));
+                }
+            ]));
+        } else {
+            // The feature is "standalone", meaning it is the top-level feature of a rule
+            // The next elements are defined by the previous stack elements
+            features.push(...findNextFeaturesInternal(parentStack));
+        }
+    } else {
+        // The feature is somewhere within the group
+        const nextIndex = groupIndex + 1;
+        const { stacks, end } = findNextFeaturesInGroup({
+            feature: group,
+            type: top.type
+        }, nextIndex);
+        for (const newStack of stacks) {
+            features.push([...parentStack, ...newStack]);
+        }
+        // If we reached the end of the group, continue searching for following features
+        if (end) {
+            // Set groupIndex to the last element index to indicate that we are at the end of the group
+            // This will trigger the parent search below
+            groupIndex = group.elements.length - 1;
         }
     }
+    if (group && groupIndex === group.elements.length - 1) {
+        // The feature is the last element of a group
+        // The next elements are defined by the parent group
+        features.push(...findNextFeaturesInternal([
+            ...parentStack,
+            {
+                feature: group,
+            }
+        ]));
+    }
+
     return features;
 }
 
@@ -115,67 +119,43 @@ function findNextFeaturesInternal(options: { next: NextFeature, cardinalities: M
  * Calculates the first child feature of any `AbstractElement`.
  * @param next The `AbstractElement` whose first child features should be calculated.
  */
-export function findFirstFeatures(next: ast.AbstractElement | NextFeature): NextFeature[] {
-    if (isAstNode(next)) {
-        next = { feature: next };
-    }
-    return findFirstFeaturesInternal({ next, cardinalities: new Map(), visited: new Set(), plus: new Set() });
+export function findFirstFeatures(next: ast.AbstractElement): NextFeature[][] {
+    return findFirstFeaturesInternal({ feature: next });
 }
 
-function findFirstFeaturesInternal(options: { next: NextFeature, cardinalities: Map<ast.AbstractElement, Cardinality>, visited: Set<ast.AbstractElement>, plus: Set<ast.AbstractElement> }): NextFeature[] {
-    const { next, cardinalities, visited, plus } = options;
-    if (next === undefined) {
-        return [];
-    }
+function findFirstFeaturesInternal(next: NextFeature): NextFeature[][] {
     const { feature, type } = next;
     if (ast.isGroup(feature)) {
-        if (visited.has(feature)) {
-            return [];
-        } else {
-            visited.add(feature);
-        }
-        return findNextFeaturesInGroup(next as NextFeature<ast.Group>, 0, cardinalities, visited, plus)
-            .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
+        return findNextFeaturesInGroup(next as NextFeature<ast.Group>, 0).stacks;
     } else if (ast.isAlternatives(feature) || ast.isUnorderedGroup(feature)) {
         return feature.elements.flatMap(e => findFirstFeaturesInternal({
-            next: {
-                feature: e,
-                type,
-                property: next.property
-            },
-            cardinalities,
-            visited,
-            plus
-        }))
-            .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
+            feature: e,
+            type,
+            property: next.property
+        }));
     } else if (ast.isAssignment(feature)) {
-        const assignmentNext = {
+        return findFirstFeaturesInternal({
             feature: feature.terminal,
             type,
             property: next.property ?? feature.feature
-        };
-        return findFirstFeaturesInternal({ next: assignmentNext, cardinalities, visited, plus })
-            .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
-    } else if (ast.isAction(feature)) {
-        return findNextFeaturesInternal({
-            next: {
-                feature,
-                type: getTypeName(feature),
-                property: next.property ?? feature.feature
-            },
-            cardinalities,
-            visited,
-            plus
         });
+    } else if (ast.isAction(feature)) {
+        return findNextFeaturesInternal([{
+            feature,
+            type: getTypeName(feature),
+            property: next.property ?? feature.feature
+        }]);
     } else if (ast.isRuleCall(feature) && ast.isParserRule(feature.rule.ref)) {
         const rule = feature.rule.ref;
-        const ruleCallNext = {
+        const stacks = findFirstFeaturesInternal({
             feature: rule.definition,
             type: rule.fragment || rule.dataType ? undefined : (getExplicitRuleType(rule) ?? rule.name),
             property: next.property
-        };
-        return findFirstFeaturesInternal({ next: ruleCallNext, cardinalities, visited, plus })
-            .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
+        });
+        for (const stack of stacks) {
+            stack.unshift(next);
+        }
+        return stacks;
     } else if (ast.isRuleCall(feature) && ast.isInfixRule(feature.rule.ref)) {
         const rule = feature.rule.ref;
         const call = rule.call.rule.ref;
@@ -183,50 +163,92 @@ function findFirstFeaturesInternal(options: { next: NextFeature, cardinalities: 
             console.error('Failed to resolve reference to ' + rule.call.rule.$refText);
             return [];
         }
-        const ruleCallNext = {
+        const stacks = findFirstFeaturesInternal({
             feature: call.definition,
             type: getExplicitRuleType(call) ?? call.name,
             property: 'parts'
-        };
-        return findFirstFeaturesInternal({ next: ruleCallNext, cardinalities, visited, plus })
-            .map(e => modifyCardinality(e, feature.cardinality, cardinalities));
+        });
+        for (const stack of stacks) {
+            stack.unshift(next);
+        }
+        return stacks;
     } else {
-        return [next];
+        return [[next]];
     }
 }
 
-/**
- * Modifying the cardinality is necessary to identify which features are coming from an optional feature.
- * Those features should be optional as well.
- * @param next The next feature that could be made optionally.
- * @param cardinality The cardinality of the calling (parent) object.
- * @returns A new feature that could be now optional (`?` or `*`).
- */
-function modifyCardinality(next: NextFeature, cardinality: Cardinality, cardinalities: Map<ast.AbstractElement, Cardinality>): NextFeature {
-    cardinalities.set(next.feature, cardinality);
-    return next;
+interface FirstGroupFeatures {
+    stacks: NextFeature[][]
+    /**
+     * Indicates whether the end of the group has been reached.
+     * If true, the caller should continue searching for following features.
+     */
+    end: boolean
 }
 
-function findNextFeaturesInGroup(next: NextFeature<ast.Group>, index: number, cardinalities: Map<ast.AbstractElement, Cardinality>, visited: Set<ast.AbstractElement>, plus: Set<ast.AbstractElement>): NextFeature[] {
-    const features: NextFeature[] = [];
+function findNextFeaturesInGroup(next: NextFeature<ast.Group>, index: number): FirstGroupFeatures {
+    const features: NextFeature[][] = [];
     let firstFeature: NextFeature;
     while (index < next.feature.elements.length) {
-        const feature = next.feature.elements[index++];
+        const feature = next.feature.elements[index];
         firstFeature = {
             feature,
             type: next.type
         };
-        features.push(...findFirstFeaturesInternal({
-            next: firstFeature,
-            cardinalities,
-            visited,
-            plus
-        }));
-        if (!isOptionalCardinality(firstFeature.feature.cardinality ?? cardinalities.get(firstFeature.feature), firstFeature.feature)) {
+        const stacks = findFirstFeaturesInternal(firstFeature);
+        features.push(...stacks);
+        if (isElementOptional(feature, new Map())) {
+            // Continue with the next element
+            index++;
+        } else {
             break;
         }
     }
-    return features;
+    return {
+        stacks: features,
+        end: index >= next.feature.elements.length
+    };
+}
+
+/**
+ * Determines recursively whether an element is optional. It is not sufficient to check only the cardinality of the element itself,
+ * because it could a group or alternative that contains only optional elements.
+ */
+function isElementOptional(feature: ast.AbstractElement, visited: Map<ast.AbstractElement, boolean>): boolean {
+    const visitedResult = visited.get(feature);
+    if (visitedResult !== undefined) {
+        return visitedResult;
+    }
+    visited.set(feature, false);
+    if (isOptionalCardinality(feature.cardinality, feature)) {
+        visited.set(feature, true);
+        return true;
+    }
+    if (ast.isGroup(feature)) {
+        for (const element of feature.elements) {
+            if (!isElementOptional(element, visited)) {
+                visited.set(feature, false);
+                return false;
+            }
+        }
+        visited.set(feature, true);
+        return true;
+    } else if (ast.isAlternatives(feature) || ast.isUnorderedGroup(feature)) {
+        for (const element of feature.elements) {
+            if (isElementOptional(element, visited)) {
+                visited.set(feature, true);
+                return true;
+            }
+        }
+        visited.set(feature, false);
+        return false;
+    } else if (ast.isRuleCall(feature) && ast.isParserRule(feature.rule.ref)) {
+        const rule = feature.rule.ref;
+        const result = isElementOptional(rule.definition, visited);
+        visited.set(feature, result);
+        return result;
+    }
+    return false;
 }
 
 interface InterpretationContext {
@@ -250,36 +272,46 @@ function findNextFeatureStacks(stacks: NextFeature[][], token?: IToken): NextFea
 }
 
 function interpretStackToken(stack: NextFeature[], token?: IToken): NextFeature[][] {
-    const cardinalities = new Map<ast.AbstractElement, Cardinality>();
-    const plus = new Set<ast.AbstractElement>(stack.map(e => e.feature).filter(isPlusFeature));
-    const newStacks: NextFeature[][] = [];
-    while (stack.length > 0) {
-        const top = stack.pop()!;
-        const allNextFeatures = findNextFeaturesInternal({
-            next: top,
-            cardinalities,
-            plus,
-            visited: new Set()
-        }).filter(next => token ? featureMatches(next.feature, token) : true);
-        for (const nextFeature of allNextFeatures) {
-            newStacks.push([...stack, nextFeature]);
-        }
-        if (!allNextFeatures.every(e => isOptionalCardinality(e.feature.cardinality, e.feature) || isOptionalCardinality(cardinalities.get(e.feature)))) {
+    const allNextFeatures = findNextFeaturesInternal(stack);
+    const matchingNextFeatures = allNextFeatures.filter(next => token ? featureMatches(next[next.length - 1].feature, token) : true);
+    return matchingNextFeatures;
+}
+
+export function findGroupAndChild(feature: ast.AbstractElement): { group: ast.Group | undefined, child: ast.AbstractElement } {
+    let parent: ast.Group | undefined;
+    let item = feature;
+    while (item.$container) {
+        if (ast.isGroup(item.$container)) {
+            parent = item.$container;
+            break;
+        } else if (ast.isAbstractElement(item.$container)) {
+            item = item.$container;
+        } else {
             break;
         }
     }
-    return newStacks;
+    if (parent) {
+        return { group: parent, child: item };
+    }
+    return {
+        group: undefined,
+        // Even if there is no group, return the feature parent if it is an assignment
+        // We need this later to handle the cardinality of the feature correctly
+        child: getContainerOfType(feature, ast.isAssignment) ?? feature
+    };
 }
 
-function isPlusFeature(feature: ast.AbstractElement): boolean {
-    if (feature.cardinality === '+') {
-        return true;
+function getAbstractElementParent(element: ast.AbstractElement): ast.AbstractElement | undefined {
+    const parent = element.$container;
+    const assignment = getContainerOfType(parent, ast.isAssignment);
+    if (assignment) {
+        return getAbstractElementParent(assignment);
+    } else {
+        if (parent && ast.isAbstractElement(parent)) {
+            return parent;
+        }
     }
-    const assignment = getContainerOfType(feature, ast.isAssignment);
-    if (assignment && assignment.cardinality === '+') {
-        return true;
-    }
-    return false;
+    return undefined;
 }
 
 function featureMatches(feature: ast.AbstractElement, token: IToken): boolean {
@@ -300,11 +332,8 @@ function featureMatches(feature: ast.AbstractElement, token: IToken): boolean {
 function ruleMatches(rule: ast.AbstractRule | undefined, token: IToken): boolean {
     if (ast.isParserRule(rule)) {
         const ruleFeatures = findFirstFeatures(rule.definition);
-        return ruleFeatures.some(e => featureMatches(e.feature, token));
+        return ruleFeatures.some(e => featureMatches(e[e.length - 1].feature, token));
     } else if (ast.isTerminalRule(rule)) {
-        // We have to take keywords into account
-        // e.g. most keywords are valid IDs as well
-        // Only return 'true' if this terminal does not match a keyword. TODO
         return terminalRegex(rule).test(token.image);
     } else {
         return false;


### PR DESCRIPTION
Closes https://github.com/eclipse-langium/langium/pull/2086
Fixes https://github.com/eclipse-langium/langium/issues/1798
Fixes https://github.com/eclipse-langium/langium/issues/1955

It took me a bit to make sense of what I wrote >4 years ago - turns out, our original completion logic was pretty over-complicated and didn't make a lot of sense (explains the difficulty of understanding it in the first place).

This PR refactors the follow element computation pretty thouroughly, which should improve the completion quite massively in a lot of cases. It takes inspiration from the lookahead algorithm for LL(1) grammars. It essentially performs something that is analogous to the NFA->DFA transformation but for LL grammars.

The PR also adds a bunch of tests to ensure that we don't regress for these improvements.