### PR TITLE
Update Chevrotain to 11.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,42 +266,42 @@
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.0.tgz",
+      "integrity": "sha512-Sa/G9XD23V4StfHMeQNnXbFmj8CsYUBmf+L895/hKm0RFDhxAfHzV6e58NA8j5ninntT5yqMzBW8QEbYxLkNUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
+        "@chevrotain/gast": "11.1.0",
+        "@chevrotain/types": "11.1.0",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.0.tgz",
+      "integrity": "sha512-0fyRYDFneUhbyV6k22R6bBY02+FasLqcxXYVt8z51IWTZ10l2Z2Lc0hiPTgm8MNRbYZnDbNv78b9zY5DoIJKjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "11.0.3",
+        "@chevrotain/types": "11.1.0",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.0.tgz",
+      "integrity": "sha512-3rW046uSp36liIAc/5G6A6h3gGbDN1eONpmJQpybIb+G2kSz0BNRc9ziT4DYrCUUbgNLd6bNVROqN9r7ZaajYg==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-GXni/dwJAkClMfwCtrbGU19RXQ9O76hFxq3sgy/zufXNj3ov6J/8FOWIXxJLhnKx7gzSweATmRccjlpmr5W2nA==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-DrS2yldzFnjmBV0O/kDngcFxWuqg2FdmUpaD6KyTmgIIE6lR53dq80R/Zz+o6LpUrXsLJk192kXuaeIPic4WVg==",
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3838,16 +3838,16 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.0.tgz",
+      "integrity": "sha512-BqwSf3RDQlHQ+EyWqTLDd23IwJ3clav6QyNQM4FNj0RF2/HfXESPjrApKkEstV5jbyJtUB8U4zrUFdLd2Cx1oA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
+        "@chevrotain/cst-dts-gen": "11.1.0",
+        "@chevrotain/gast": "11.1.0",
+        "@chevrotain/regexp-to-ast": "11.1.0",
+        "@chevrotain/types": "11.1.0",
+        "@chevrotain/utils": "11.1.0",
         "lodash-es": "4.17.21"
       }
     },
@@ -11624,7 +11624,7 @@
       "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
-        "chevrotain": "~11.0.3",
+        "chevrotain": "~11.1.0",
         "chevrotain-allstar": "~0.3.0",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.11",

--- a/packages/langium/package.json
+++ b/packages/langium/package.json
@@ -65,7 +65,7 @@
     "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
-    "chevrotain": "~11.0.3",
+    "chevrotain": "~11.1.0",
     "chevrotain-allstar": "~0.3.0",
     "vscode-languageserver": "~9.0.1",
     "vscode-languageserver-textdocument": "~1.0.11",

--- a/packages/langium/src/parser/token-builder.ts
+++ b/packages/langium/src/parser/token-builder.ts
@@ -99,9 +99,6 @@ export class DefaultTokenBuilder implements TokenBuilder {
         if (regex.flags.includes('u') || regex.flags.includes('s')) {
             // Unicode and dotall regexes are not supported by Chevrotain.
             return true;
-        } else if (regex.source.includes('?<=') || regex.source.includes('?<!')) {
-            // Negative and positive lookbehind are not supported by Chevrotain yet.
-            return true;
         } else {
             return false;
         }


### PR DESCRIPTION
Updates Chevrotain to the latest version. The 11.1.0 contains updates to the lexer which reduces the need for some of the workarounds that we've added to our token builder.

Note that the new feature https://github.com/Chevrotain/chevrotain/pull/2138 isn't in there yet.