### PR TITLE
langium/generate: fixed incorrect indentation replication for indented multiline substitutions

### DIFF
--- a/packages/langium/src/generate/template-node.ts
+++ b/packages/langium/src/generate/template-node.ts
@@ -526,7 +526,7 @@ function composeFinalGeneratorNode(splitAndMerged: GeneratedOrMarker[]): Composi
                     //   }
                     // assuming that ${foo(bar)} yields a multiline result;
                     // the whitespace between 'return' and '${foo(bar)}' shall not add to the indentation of '${foo(bar)}'s result!
-                    const indent: string = (i === 0 || isNewLineMarker(splitAndMerged[i - 1])) && typeof segment === 'string' && segment.length !== 0 ? ''.padStart(segment.length - segment.trimStart().length) : '';
+                    const indent: string = (i === 0 || isNewLineMarker(splitAndMerged[i - 1])) && typeof segment === 'string' && segment.length !== 0 ? segment.substring(0, segment.length - segment.trimStart().length) : '';
                     const content = isSubstitutionWrapper(segment)? segment.content : segment;
                     let indented: IndentNode | undefined;
                     return {

--- a/packages/langium/test/generate/template-node.test.ts
+++ b/packages/langium/test/generate/template-node.test.ts
@@ -741,6 +741,20 @@ describe('Single multiline substitution templates', () => {
         const text = toString(node);
         expect(text).toBe('  ' + ML_TEXT_TEMPLATE + EOL);
     });
+    test('With tab indentation', () => {
+        const node = n`
+        	header (
+        		${new CompositeGeneratorNode('More', NL, 'generated text!')}
+        	) footer
+        `;
+        const text = toString(node);
+        expect(text).toBe(
+            `header (${EOL
+            }	More${EOL
+            }	generated text!${EOL
+            }) footer`
+        );
+    });
 });
 
 describe('Nested multiline substitution templates', () => {


### PR DESCRIPTION
Fixes #2081