### PR TITLE
Skip release process cancellation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,5 @@ jobs:
       env:
         OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
         VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
-        GH_TOKEN: ${{ github.token }}
-        RUN_ID: ${{ github.run_id }}
       run: |
         npm run publish:updated

--- a/scripts/publish-updated-packages.ts
+++ b/scripts/publish-updated-packages.ts
@@ -40,10 +40,6 @@ async function updateAndPublish() {
     const ext = await tryPublishExtension();
     if (!ext && packagesToPublish.length === 0) {
         console.log('All packages are up to date. Nothing to publish.');
-        if (process.env.RUN_ID) {
-            console.log(`Marking GitHub Action run ${process.env.RUN_ID} as cancelled.`);
-            execSync(`gh run cancel ${process.env.RUN_ID}`);
-        }
     }
 }
 


### PR DESCRIPTION
Even though the publishing CI run was correctly *cancelled*, the "total" run now counts as *failed*:

<img width="577" height="54" alt="grafik" src="https://github.com/user-attachments/assets/050a7d87-431f-4428-8bb4-cb6547daf4e1" />

<img width="621" height="69" alt="grafik" src="https://github.com/user-attachments/assets/d74ccbde-18e9-41c8-8080-8b2848128666" />

This change simply removes the part that cancels the run to ensure that the CI is marked as successful, even if it doesn't publish anything.